### PR TITLE
Fix uploading world image filename

### DIFF
--- a/frontend/src/app/lib/importWorldZip.ts
+++ b/frontend/src/app/lib/importWorldZip.ts
@@ -3,7 +3,7 @@ import JSZip from "jszip";
 // Helper: upload a file to your frontend public folder
 export async function uploadImageFile(fileBlob, folder, filename) {
   const formData = new FormData();
-  formData.append("file", fileBlob);
+  formData.append("file", fileBlob, filename);
   formData.append("folder", folder);
   formData.append("filename", filename.replace(/\.[^/.]+$/, "")); // Remove extension if present, add it below
 


### PR DESCRIPTION
## Summary
- ensure uploaded image includes the original filename when importing a zip

## Testing
- `npm run lint` *(fails: `UserGrid` unused etc.)*
- `pytest -q` *(fails: pydantic ValidationError for missing env vars)*

------
https://chatgpt.com/codex/tasks/task_e_684008be40d48322bfee780371c9c56c