### PR TITLE
Fix /public persistence in container

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # Shrecknet
+
+This project contains a Next.js frontend and a FastAPI backend.
+
+## Persisting uploaded files
+
+When running the system with Docker Compose, make sure the `public` directory from the frontend is mounted so uploaded images and documents are kept between container restarts.
+
+```
+docker compose up --build
+```
+
+Docker Compose now maps `./frontend/public` on your host to `/app/public` inside the frontend container. Any files uploaded through the API will appear in that directory on the host and will be preserved.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ services:
     depends_on:
       - backend
 
-    # volumes:
-    #   - ./frontend/public:/app/public   
+    volumes:
+      - ./frontend/public:/app/public
 
   backend:
     build:


### PR DESCRIPTION
## Summary
- persist frontend `public` directory via volume
- add docs on mounting the volume

## Testing
- `pytest -q` *(fails: RuntimeError: Event loop is closed, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6840095b89008322ac7030cd91927f2f