### PR TITLE
Fix ImportWorldModal pipeline

### DIFF
--- a/frontend/src/app/components/importexport/ImportWorldModal.tsx
+++ b/frontend/src/app/components/importexport/ImportWorldModal.tsx
@@ -17,7 +17,6 @@ export default function ImportWorldModal({ open, onClose, onImported }) {
   const [progress, setProgress] = useState(""); // progress for ZIP handling
 
   function reset() {
-    setFile(null);
     setImportData(null);
     setEditedWorld(null);
     setError("");
@@ -31,7 +30,6 @@ export default function ImportWorldModal({ open, onClose, onImported }) {
     reset();
     const f = e.target.files?.[0];
     if (!f) return;
-    setFile(f);
     try {
       if (f.name.endsWith(".zip")) {
         setProgress("Reading ZIP file...");


### PR DESCRIPTION
## Summary
- remove unused `setFile` calls in `ImportWorldModal`

## Testing
- `npm run lint` *(fails: `@typescript-eslint/no-unused-vars` and other lint errors)*
- `pytest -q` *(fails: missing Settings env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68400b5a56008322979d977083fd590c