### PR TITLE
Fix volume mapping for frontend assets

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,10 +16,11 @@ services:
       context: ./backend
       network: host
     ports:
-      - "8000:8000"    
+      - "8000:8000"
     env_file:
-     - ./backend/.env      
+     - ./backend/.env
 
     volumes:
-      - ./backend/data:/app/data         # maps host ./data to /backend/data in the container      
+      - ./backend/data:/app/data         # maps host ./data to /backend/data in the container
+      - ./frontend/public:/app/public    # share uploaded assets with frontend
  


### PR DESCRIPTION
## Summary
- make backend container use the same `public` directory as frontend

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: OperationalError and 422 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68401a128ab88322b6a98e836780a115