### PR TITLE
Fix avatar cache issue

### DIFF
--- a/frontend/src/app/components/user_management/User_Modal.tsx
+++ b/frontend/src/app/components/user_management/User_Modal.tsx
@@ -10,8 +10,14 @@ import { M3FloatingInput } from "../template/M3FloatingInput";
 import Image from "next/image";
 async function uploadAvatar(file, userId) {
   const customFileName = userId.toString();
-  const imageUrl = await uploadImage(file, "avatars", userId.toString(), customFileName);
-  return imageUrl;
+  const imageUrl = await uploadImage(
+    file,
+    "avatars",
+    userId.toString(),
+    customFileName
+  );
+  // Append a cache buster so the browser doesn't show a cached avatar
+  return `${imageUrl}?v=${Date.now()}`;
 }
 
 export default function UserModal({


### PR DESCRIPTION
## Summary
- prevent browser caching on avatar upload by appending a cachebuster query

## Testing
- `pytest -q` *(fails: ValidationError: database_url field required)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68404cd1407c8322ad651f9d3f03be58