### PR TITLE
Fix create page runtime error

### DIFF
--- a/frontend/src/app/worlds/[worldID]/concept/[conceptID]/page/[pageID]/page.tsx
+++ b/frontend/src/app/worlds/[worldID]/concept/[conceptID]/page/[pageID]/page.tsx
@@ -127,12 +127,14 @@ export default function PageView() {
 
   async function handleSaveContent(newContent) {
     if (!pageId || !token) return;
-    
+
     try {
       await updatePage(Number(pageId), { content: newContent }, token);
       const freshPage = await getPage(pageId, token);
       setPage(freshPage);
-    } 
+    } catch (err) {
+      console.error("Failed to save page content", err);
+    }
   }
 
   // --- DELETE PAGE HANDLER ---


### PR DESCRIPTION
## Summary
- add a missing `catch` block to the page editor's `handleSaveContent`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684057eb11c48322893ab783556d378c