### PR TITLE
Ensure world logos overwrite and refresh

### DIFF
--- a/frontend/src/app/components/worlds/WorldForm.tsx
+++ b/frontend/src/app/components/worlds/WorldForm.tsx
@@ -7,7 +7,8 @@ async function uploadWorldLogo(file, worldName) {
   const safeWorldName = worldName.trim().replace(/[^a-zA-Z0-9_-]/g, "_") || "new_world";
   const customFileName = "world_logo";
   const imageUrl = await uploadImage(file, "worlds", safeWorldName, customFileName);
-  return imageUrl;
+  // Append timestamp to bypass aggressive caching for the same filename
+  return `${imageUrl}?t=${Date.now()}`;
 }
 
 export default function WorldForm({

--- a/frontend/src/pages/api/uploadFile.ts
+++ b/frontend/src/pages/api/uploadFile.ts
@@ -44,7 +44,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
 
     const fileName = customFileName
       ? `${customFileName}${fileExt}`
-      : `${Date.now()}_${baseName}`;
+      : `${baseName}`;
     const dest = path.join(dir, fileName);
 
     if (fs.existsSync(dest)) fs.unlinkSync(dest);

--- a/frontend/src/pages/api/uploadImage.ts
+++ b/frontend/src/pages/api/uploadImage.ts
@@ -42,10 +42,11 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     const baseName =
       (file.originalFilename || file.name || "upload").replace(/[^a-zA-Z0-9_.-]/g, "_");
 
-    // Use customFileName if present, otherwise fallback to timestamp name
+    // Use customFileName if present, otherwise use the base name so repeated
+    // uploads replace the previous file
     const fileName = customFileName
       ? `${customFileName}${fileExt}`
-      : `${Date.now()}_${baseName}`;
+      : `${baseName}`;
     const dest = path.join(dir, fileName);
 
     // Delete unknown old file with the same name to avoid duplicates


### PR DESCRIPTION
## Summary
- overwrite images using original name in upload APIs
- append timestamp to newly uploaded world logos so cached images refresh

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: httpx)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840826e815c8322a9e6e048526b14ce