### PR TITLE
Handle new user login redirection

### DIFF
--- a/frontend/src/app/lib/usersApi.ts
+++ b/frontend/src/app/lib/usersApi.ts
@@ -18,6 +18,13 @@ export async function registerUser({ nickname, email, password, role, image_url 
   return await res.json();
 }
 
+export async function userExists(email: string): Promise<boolean> {
+  const res = await fetch(`${API_URL}/users/users`);
+  if (!res.ok) throw new Error("Could not fetch user list");
+  const users = await res.json();
+  return users.some((u: { email: string }) => u.email.toLowerCase() === email.toLowerCase());
+}
+
   export async function loginUser({ email, password }: unknown) {
     const params = new URLSearchParams();
     params.append("username", email);


### PR DESCRIPTION
## Summary
- check if a user exists when login fails
- show welcome message and switch to registration if the email isn't found
- provide helper `userExists` API call

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d9710cec8322bcbf21e4554a452f