### PR TITLE
Fix duplicate page value insertion

### DIFF
--- a/backend/app/crud/crud_page.py
+++ b/backend/app/crud/crud_page.py
@@ -56,6 +56,15 @@ async def delete_page(session: AsyncSession, page_id: int) -> bool:
 # --- PAGE CHARACTERISTIC VALUE CRUD ---
 
 async def create_page_characteristic_value(session: AsyncSession, value_obj: PageCharacteristicValue) -> PageCharacteristicValue:
+    existing = await session.get(
+        PageCharacteristicValue,
+        (value_obj.page_id, value_obj.characteristic_id),
+    )
+    if existing:
+        existing.value = value_obj.value
+        await session.commit()
+        await session.flush()
+        return existing
     session.add(value_obj)
     await session.commit()
     await session.flush()


### PR DESCRIPTION
## Summary
- avoid UNIQUE constraint errors when creating page values by updating existing records

## Testing
- `pytest tests/test_page.py::test_page_create_update_delete_rbac -q` *(fails: ConnectionRefusedError from redis)*

------
https://chatgpt.com/codex/tasks/task_e_68421037c948832284d2ad165d236a8c