### PR TITLE
Fix API URL mixed content issue

### DIFF
--- a/frontend/src/app/lib/config.ts
+++ b/frontend/src/app/lib/config.ts
@@ -8,6 +8,13 @@
  * that fetch calls use relative URLs and automatically match the current
  * protocol and host.
  */
-export const API_URL = process.env.NEXT_PUBLIC_API_URL
-  ? process.env.NEXT_PUBLIC_API_URL.replace(/^http:/, "https:")
-  : "";
+const envUrl = process.env.NEXT_PUBLIC_API_URL ?? "";
+let url = envUrl;
+
+// When running in the browser over HTTPS and the API URL uses HTTP,
+// upgrade it to HTTPS to avoid mixed content errors.
+if (typeof window !== "undefined" && url.startsWith("http://") && window.location.protocol === "https:") {
+  url = url.replace(/^http:/, "https:");
+}
+
+export const API_URL = url;


### PR DESCRIPTION
## Summary
- avoid mixed content by upgrading API URL to HTTPS when the site is served securely

## Testing
- `pytest -q` *(fails: ValidationError: database_url field required)*

------
https://chatgpt.com/codex/tasks/task_e_6842173eaf6483229959f221428a8d71