### PR TITLE
Fix Mixed Content by forcing HTTPS for API URL

### DIFF
--- a/frontend/src/app/lib/config.ts
+++ b/frontend/src/app/lib/config.ts
@@ -9,7 +9,15 @@
  * protocol and host.
  */
 const envUrl = process.env.NEXT_PUBLIC_API_URL ?? "";
+const isProd = process.env.NODE_ENV === "production";
+
 let url = envUrl;
+
+// When building for production, assume the site will run over HTTPS and
+// upgrade the API URL if it explicitly uses HTTP.
+if (isProd && url.startsWith("http://")) {
+  url = url.replace(/^http:/, "https:");
+}
 
 // When running in the browser over HTTPS and the API URL uses HTTP,
 // upgrade it to HTTPS to avoid mixed content errors.


### PR DESCRIPTION
## Summary
- ensure API URL is rewritten to HTTPS when building for production

## Testing
- `npm run lint` *(fails: unused vars and lint errors)*
- `pytest -q` *(fails: Settings missing required fields)*

------
https://chatgpt.com/codex/tasks/task_e_6842190d96808322af45ecf3a4b8b918