### PR TITLE
Refactor frontend fetching with SWR

### DIFF
--- a/frontend/src/app/lib/useCharacteristicsForConcept.ts
+++ b/frontend/src/app/lib/useCharacteristicsForConcept.ts
@@ -1,0 +1,13 @@
+import useSWR from "swr";
+import { getCharacteristicsForConcept } from "./characteristicsAPI";
+import { useAuth } from "../components/auth/AuthProvider";
+
+export function useCharacteristicsForConcept(conceptId?: number) {
+  const { token } = useAuth();
+  const fetcher = () => getCharacteristicsForConcept(conceptId!, token);
+  const { data, error, mutate, isLoading } = useSWR(
+    conceptId && token ? ["characteristicsForConcept", conceptId, token] : null,
+    fetcher
+  );
+  return { characteristics: data || [], error, mutate, isLoading };
+}

--- a/frontend/src/app/lib/useConceptById.ts
+++ b/frontend/src/app/lib/useConceptById.ts
@@ -1,0 +1,13 @@
+import useSWR from "swr";
+import { getConcept } from "./conceptsAPI";
+import { useAuth } from "../components/auth/AuthProvider";
+
+export function useConceptById(conceptId?: number) {
+  const { token } = useAuth();
+  const fetcher = () => getConcept(conceptId!, token);
+  const { data, error, mutate, isLoading } = useSWR(
+    conceptId && token ? ["concept", conceptId, token] : null,
+    fetcher
+  );
+  return { concept: data || null, error, mutate, isLoading };
+}

--- a/frontend/src/app/lib/usePageById.ts
+++ b/frontend/src/app/lib/usePageById.ts
@@ -1,0 +1,13 @@
+import useSWR from "swr";
+import { getPage } from "./pagesAPI";
+import { useAuth } from "../components/auth/AuthProvider";
+
+export function usePageById(pageId?: number) {
+  const { token } = useAuth();
+  const fetcher = () => getPage(pageId!, token);
+  const { data, error, mutate, isLoading } = useSWR(
+    pageId && token ? ["page", pageId, token] : null,
+    fetcher
+  );
+  return { page: data || null, error, mutate, isLoading };
+}

--- a/frontend/src/app/lib/usePagesForConcept.ts
+++ b/frontend/src/app/lib/usePagesForConcept.ts
@@ -1,0 +1,13 @@
+import useSWR from "swr";
+import { getPagesForConcept } from "./pagesAPI";
+import { useAuth } from "../components/auth/AuthProvider";
+
+export function usePagesForConcept(conceptId?: number) {
+  const { token } = useAuth();
+  const fetcher = () => getPagesForConcept(conceptId!, token);
+  const { data, error, mutate, isLoading } = useSWR(
+    conceptId && token ? ["pagesForConcept", conceptId, token] : null,
+    fetcher
+  );
+  return { pages: data || [], error, mutate, isLoading };
+}

--- a/frontend/src/app/lib/useWorld.ts
+++ b/frontend/src/app/lib/useWorld.ts
@@ -1,0 +1,13 @@
+import useSWR from "swr";
+import { getGameWorld } from "./gameworldsAPI";
+import { useAuth } from "../components/auth/AuthProvider";
+
+export function useWorld(worldId?: number) {
+  const { token } = useAuth();
+  const fetcher = () => getGameWorld(worldId!, token);
+  const { data, error, mutate, isLoading } = useSWR(
+    worldId && token ? ["gameworld", worldId, token] : null,
+    fetcher
+  );
+  return { world: data || null, error, mutate, isLoading };
+}

--- a/frontend/src/app/worlds/[worldID]/concept/[conceptID]/page.tsx
+++ b/frontend/src/app/worlds/[worldID]/concept/[conceptID]/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 import { use } from "react";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { useAuth } from "@/app/components/auth/AuthProvider";
-import { getGameWorld, getGameWorlds } from "@/app/lib/gameworldsAPI";
-import { getConcept } from "@/app/lib/conceptsAPI";
-import { getPagesForConcept } from "@/app/lib/pagesAPI";
+import { useWorld } from "@/app/lib/useWorld";
+import { useWorlds } from "@/app/lib/userWorlds";
+import { useConceptById } from "@/app/lib/useConceptById";
+import { usePagesForConcept } from "@/app/lib/usePagesForConcept";
 import DashboardLayout from "@/app/components/DashboardLayout";
 import AuthGuard from "@/app/components/auth/AuthGuard";
 import WorldBreadcrumb from "@/app/components/worlds/WorldBreadCrump";
@@ -16,49 +17,20 @@ import CardScroller from "@/app/components/template/CardScroller";
 import Image from "next/image";
 export default function ConceptPage({ params }) {
   const { conceptID } = use(params);
-  const {token} = useAuth()
-  
-  const router = useRouter();  
+  const { token } = useAuth();
 
-  const [concept, setConcept] = useState(null);
-  const [pages, setPages] = useState([]);
-  const [world, setWorld] = useState(null);
-  const [worlds, setWorlds] = useState([]);
+  const router = useRouter();
+
   const [search, setSearch] = useState("");
-  const [loading, setLoading] = useState(true);
   const [zoomOpen, setZoomOpen] = useState(false);
 
- useEffect(() => {
-     async function fetchData() {
-       if (!token || !conceptID) return;
-       try {
-        console.log("Concept Number:" + Number(conceptID))
-         const conceptData = await getConcept(Number(conceptID), token);
-         console.log("Concept data:" + JSON.stringify(conceptData))
-         setConcept(conceptData);
-
-         console.log("Gameworld Number:" + conceptData.gameworld_id)
-         const worldData = await getGameWorld(conceptData.gameworld_id, token);
-         console.log("Gameworld data:" + JSON.stringify(worldData))
-         setWorld(worldData);
- 
-         const worldsList = await getGameWorlds(token);
-         console.log("World list data:" + JSON.stringify(worldsList))
-         setWorlds(worldsList);
-
-         console.log("ConceptID:" + JSON.stringify(Number(conceptID)))
-         console.log("Token:" + token)
-         const pagesData = await getPagesForConcept(Number(conceptID), token);
-         console.log("pagesData data:" + JSON.stringify(pagesData))
-         setPages(pagesData);
-       } finally {
-         setLoading(false);
-       }
-     }
-     fetchData();
-   }, [conceptID, token]);
-
+  const { concept, isLoading: conceptLoading } = useConceptById(Number(conceptID));
+  const { world, isLoading: worldLoading } = useWorld(concept?.gameworld_id);
+  const { worlds, isLoading: worldsLoading } = useWorlds();
+  const { pages, isLoading: pagesLoading } = usePagesForConcept(Number(conceptID));
   const { concepts } = useConcepts(world?.id);
+
+  const loading = conceptLoading || worldLoading || worldsLoading || pagesLoading;
 
   const filteredPages = pages
   .filter(p =>

--- a/frontend/src/app/worlds/[worldID]/group/[groupID]/page.tsx
+++ b/frontend/src/app/worlds/[worldID]/group/[groupID]/page.tsx
@@ -2,9 +2,10 @@
 
 import { use } from "react";
 
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { useAuth } from "../../../../components/auth/AuthProvider";
-import { getGameWorld, getGameWorlds } from "../../../../lib/gameworldsAPI";
+import { useWorld } from "../../../../lib/useWorld";
+import { useWorlds } from "../../../../lib/userWorlds";
 import DashboardLayout from "../../../../components/DashboardLayout";
 import AuthGuard from "../../../../components/auth/AuthGuard";
 import WorldBreadcrumb from "../../../../components/worlds/WorldBreadCrump";
@@ -13,39 +14,22 @@ import { BookOpen } from "lucide-react";
 import CardScroller from "@/app/components/template/CardScroller";
 import Link from "next/link";
 import Image from "next/image";
-import { getConcepts } from "@/app/lib/conceptsAPI";
+import { useConcepts } from "@/app/lib/useConcept";
 export default function GroupPage({ params }) {
 
 
   const { worldID, groupID } = use(params);
-  const {token} = useAuth()
-  
+  const { token } = useAuth();
+
   const router = useRouter();
 
-  const [world, setWorld] = useState(null);
-  const [worlds, setWorlds] = useState([]);
-  const [concepts, setConcepts] = useState([]);
-  const [loading, setLoading] = useState(true);
+  const { world, isLoading: worldLoading } = useWorld(Number(worldID));
+  const { worlds, isLoading: worldsLoading } = useWorlds();
+  const { concepts, isLoading: conceptsLoading } = useConcepts(Number(worldID));
+
+  const loading = worldLoading || worldsLoading || conceptsLoading;
 
 
-  useEffect(() => {
-    
-  async function fetchData() {
-      if (!token) return;
-      try {
-        const allWorlds = await getGameWorlds(token);        
-        const currentWorld = await getGameWorld(worldID, token);
-        const worldConcepts = await getConcepts(token, { gameworld_id: worldID });
-
-        setWorld(currentWorld);
-        setWorlds(allWorlds);
-        setConcepts(worldConcepts);
-      } finally {
-        setLoading(false);
-      }
-    }
-    fetchData();
-  }, [worldID, token]);
 
   const filteredConcepts = concepts
   .filter(c => c.group === groupID)


### PR DESCRIPTION
## Summary
- add reusable SWR hooks for worlds, concepts, pages and characteristics
- refactor world- and concept-related pages to use the new hooks
- remove manual fetches and rely on caching

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68421d847f4083229a874dba51d45f43