### PR TITLE
Update user API routes

### DIFF
--- a/backend/app/api/api_user.py
+++ b/backend/app/api/api_user.py
@@ -12,9 +12,9 @@ from app.crud.crud_users import get_user_by_email, get_user, create_user, list_a
 from app.models.model_user import User
 from app.dependencies import get_current_user, require_role
 
-router = APIRouter(prefix="/users", tags=["Users"])
+router = APIRouter(tags=["Users"])
 
-@router.post("/", response_model=UserRead)
+@router.post("/user/", response_model=UserRead)
 async def register(user: UserCreate, session: AsyncSession = Depends(get_session)):
     existing = await get_user_by_email(session, user.email)
     if existing:
@@ -26,7 +26,7 @@ async def register(user: UserCreate, session: AsyncSession = Depends(get_session
         raise HTTPException(status_code=400, detail="Failed to create user")
     return db_user
 
-@router.post("/login", response_model=Token)
+@router.post("/user/login", response_model=Token)
 async def login(form_data: OAuth2PasswordRequestForm = Depends(), session: AsyncSession = Depends(get_session)):
     user = await get_user_by_email(session, form_data.username)
     if not user or not verify_password(form_data.password, user.hashed_password):
@@ -34,22 +34,22 @@ async def login(form_data: OAuth2PasswordRequestForm = Depends(), session: Async
     token = create_access_token(data={"sub": user.email})
     return {"access_token": token, "token_type": "bearer"}
 
-@router.get("/me", response_model=UserRead)
+@router.get("/user/me", response_model=UserRead)
 async def read_users_me(current_user: User = Depends(get_current_user)):
     return current_user
 
-@router.get("/users", response_model=list[UserRead])
+@router.get("/users/", response_model=list[UserRead])
 async def list_users(skip: int = 0, limit: int = 100, session: AsyncSession = Depends(get_session)):
     return await list_all_users(session, skip=skip, limit=limit)
 
-@router.get("/{user_id}", response_model=UserRead)
+@router.get("/user/{user_id}", response_model=UserRead)
 async def see_user(user_id: int, session: AsyncSession = Depends(get_session)):
     user = await get_user(session, user_id)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
     return user
 
-@router.patch("/{user_id}", response_model=UserRead)
+@router.patch("/user/{user_id}", response_model=UserRead)
 async def update_user(
     user_id: int,
     user_update: UserUpdate,
@@ -60,7 +60,7 @@ async def update_user(
         raise HTTPException(status_code=404, detail="User not found")
     return updated
 
-@router.delete("/{user_id}")
+@router.delete("/user/{user_id}")
 async def delete_user(
     user_id: int,
     session: AsyncSession = Depends(get_session),    

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -81,7 +81,7 @@ async def create_user(async_client):
         }
 
         print (f"User created: {email}")
-        response = await async_client.post("/users/", json=user_data)
+        response = await async_client.post("/user/", json=user_data)
         assert response.status_code == 200, response.text
         return response.json()
     return _create_user
@@ -91,7 +91,7 @@ async def login_and_get_token(async_client, create_user):
     async def _login(email, password, role):
         # await create_user(email, password, role)
         data = {"username": email, "password": password}
-        response = await async_client.post("/users/login", data=data)
+        response = await async_client.post("/user/login", data=data)
         assert response.status_code == 200, response.text
         token = response.json()["access_token"]
         return token

--- a/backend/tests/test_characteristic.py
+++ b/backend/tests/test_characteristic.py
@@ -17,9 +17,9 @@ WRITER = {
 
 @pytest.mark.anyio
 async def register_and_login(async_client, user_data):
-    resp = await async_client.post("/users/", json=user_data)
+    resp = await async_client.post("/user/", json=user_data)
     assert resp.status_code == 200, resp.text
-    resp = await async_client.post("/users/login", data={
+    resp = await async_client.post("/user/login", data={
         "username": user_data["email"], "password": user_data["password"]
     })
     assert resp.status_code == 200, resp.text

--- a/backend/tests/test_concept.py
+++ b/backend/tests/test_concept.py
@@ -31,9 +31,9 @@ PLAYER = {
 
 @pytest.mark.anyio
 async def register_and_login(async_client, user_data):
-    resp = await async_client.post("/users/", json=user_data)
+    resp = await async_client.post("/user/", json=user_data)
     assert resp.status_code == 200, resp.text
-    resp = await async_client.post("/users/login", data={
+    resp = await async_client.post("/user/login", data={
         "username": user_data["email"], "password": user_data["password"]
     })
     assert resp.status_code == 200, resp.text

--- a/backend/tests/test_gameworld.py
+++ b/backend/tests/test_gameworld.py
@@ -27,10 +27,10 @@ WRITER = {
 @pytest.mark.anyio
 async def register_and_login(async_client, user_data):
     # Register user
-    resp = await async_client.post("/users/", json=user_data)
+    resp = await async_client.post("/user/", json=user_data)
     assert resp.status_code == 200, resp.text
     # Login
-    resp = await async_client.post("/users/login", data={
+    resp = await async_client.post("/user/login", data={
         "username": user_data["email"], "password": user_data["password"]
     })
     assert resp.status_code == 200, resp.text

--- a/backend/tests/test_page.py
+++ b/backend/tests/test_page.py
@@ -24,9 +24,9 @@ PLAYER = {
 
 @pytest.mark.anyio
 async def register_and_login(async_client, user_data):
-    resp = await async_client.post("/users/", json=user_data)
+    resp = await async_client.post("/user/", json=user_data)
     assert resp.status_code == 200, resp.text
-    resp = await async_client.post("/users/login", data={
+    resp = await async_client.post("/user/login", data={
         "username": user_data["email"], "password": user_data["password"]
     })
     assert resp.status_code == 200, resp.text

--- a/backend/tests/test_user.py
+++ b/backend/tests/test_user.py
@@ -11,13 +11,13 @@ async def test_user_registration_and_login(async_client, create_user, login_and_
     assert token
 
     # Authenticated endpoint
-    resp = await async_client.get("/users/me", headers={"Authorization": f"Bearer {token}"})
+    resp = await async_client.get("/user/me", headers={"Authorization": f"Bearer {token}"})
     assert resp.status_code == 200
     assert resp.json()["email"] == "writer@test.com"
 
 @pytest.mark.anyio
 async def test_protected_route_requires_login(async_client):
-    resp = await async_client.get("/users/me")
+    resp = await async_client.get("/user/me")
     assert resp.status_code == 401
 
 @pytest.mark.anyio

--- a/frontend/src/app/lib/usersApi.ts
+++ b/frontend/src/app/lib/usersApi.ts
@@ -2,14 +2,14 @@ import { API_URL } from "./config";
 
 console.log("Public API: "+API_URL)
 export async function getUserCount(): Promise<number> {
-  const res = await fetch(`${API_URL}/users/users`);
+  const res = await fetch(`${API_URL}/users/`);
   if (!res.ok) throw new Error("Could not fetch user list");
   const users = await res.json();
   return users.length;
 }
 
 export async function registerUser({ nickname, email, password, role, image_url }: unknown) {
-  const res = await fetch(`${API_URL}/users/`, {
+  const res = await fetch(`${API_URL}/user/`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ nickname, email, password, role, image_url }),
@@ -19,7 +19,7 @@ export async function registerUser({ nickname, email, password, role, image_url 
 }
 
 export async function userExists(email: string): Promise<boolean> {
-  const res = await fetch(`${API_URL}/users/users`);
+  const res = await fetch(`${API_URL}/users/`);
   if (!res.ok) throw new Error("Could not fetch user list");
   const users = await res.json();
   return users.some((u: { email: string }) => u.email.toLowerCase() === email.toLowerCase());
@@ -29,7 +29,7 @@ export async function userExists(email: string): Promise<boolean> {
     const params = new URLSearchParams();
     params.append("username", email);
     params.append("password", password);
-    const res = await fetch(`${API_URL}/users/login`, {
+    const res = await fetch(`${API_URL}/user/login`, {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
       body: params.toString(),
@@ -41,7 +41,7 @@ export async function userExists(email: string): Promise<boolean> {
 
 // GET all users (requires token)
 export async function getUsers(token: string) {
-  const res = await fetch(`${API_URL}/users/users/`, {
+  const res = await fetch(`${API_URL}/users/`, {
     headers: token ? { Authorization: `Bearer ${token}` } : {},
   });
   if (!res.ok) throw new Error("Could not fetch users");
@@ -50,7 +50,7 @@ export async function getUsers(token: string) {
 
 // UPDATE user
 export async function updateUser(userId: number, data: unknown, token: string) {
-  const res = await fetch(`${API_URL}/users/${userId}`, {
+  const res = await fetch(`${API_URL}/user/${userId}`, {
     method: "PATCH",
     headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
     body: JSON.stringify(data),
@@ -62,7 +62,7 @@ export async function updateUser(userId: number, data: unknown, token: string) {
 
 // DELETE user
 export async function deleteUser(userId: number, token: string) {
-  const res = await fetch(`${API_URL}/users/${userId}`, {
+  const res = await fetch(`${API_URL}/user/${userId}`, {
     method: "DELETE",
     headers: { Authorization: `Bearer ${token}` },
   });
@@ -72,7 +72,7 @@ export async function deleteUser(userId: number, token: string) {
 
 
 export async function getCurrentUser(token: string) {
-  const res = await fetch(`${API_URL}/users/me`, {
+  const res = await fetch(`${API_URL}/user/me`, {
     headers: token ? { Authorization: `Bearer ${token}` } : {},
   });
   if (!res.ok) throw await res.json();


### PR DESCRIPTION
## Summary
- rename backend user API endpoints to use `/user` prefix
- adjust frontend `usersApi` calls for new paths
- update backend tests for the new endpoints

## Testing
- `pip install httpx`
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ValidationError / OperationalError)*

------
https://chatgpt.com/codex/tasks/task_e_6842a0995ef883229a7bc2e91bf5fef0