### PR TITLE
Fix Celery mapper initialization

### DIFF
--- a/backend/app/task_queue.py
+++ b/backend/app/task_queue.py
@@ -20,6 +20,9 @@ from app.crud.crud_page_links_update import (
     remove_page_refs_from_characteristics,
 )
 
+# Ensure all models are imported so SQLModel can resolve relationships
+import app.models.model_concept  # noqa:F401
+
 @celery_app.task
 def task_auto_crosslink_page_content(page_id: int):
     asyncio.run(auto_crosslink_page_content(page_id))


### PR DESCRIPTION
## Summary
- ensure Celery worker imports Concept model so SQLModel relationships resolve

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: Event loop is closed)*

------
https://chatgpt.com/codex/tasks/task_e_6842c5de506083228c83dc773d8f3ada