### PR TITLE
Add vector DB rebuild control

### DIFF
--- a/backend/tests/test_vectordb.py
+++ b/backend/tests/test_vectordb.py
@@ -1,0 +1,52 @@
+import pytest
+
+WORLD_BUILDER = {
+    "nickname": "builder",
+    "email": "builder@ex.com",
+    "password": "pass",
+    "role": "world builder",
+    "image_url": "no image",
+}
+ADMIN = {
+    "nickname": "admin",
+    "email": "admin@ex.com",
+    "password": "pass",
+    "role": "system admin",
+    "image_url": "no image",
+}
+WRITER = {
+    "nickname": "writer",
+    "email": "writer@ex.com",
+    "password": "pass",
+    "role": "writer",
+    "image_url": "no image",
+}
+
+@pytest.mark.anyio
+async def test_rebuild_vectordb(async_client, create_user, login_and_get_token):
+    await create_user(**WORLD_BUILDER)
+    await create_user(**ADMIN)
+    await create_user(**WRITER)
+
+    wb_token = await login_and_get_token(WORLD_BUILDER["email"], WORLD_BUILDER["password"], WORLD_BUILDER["role"])
+    admin_token = await login_and_get_token(ADMIN["email"], ADMIN["password"], ADMIN["role"])
+    writer_token = await login_and_get_token(WRITER["email"], WRITER["password"], WRITER["role"])
+
+    gw_payload = {"name": "World", "system": "sys", "description": "desc", "logo": "logo"}
+    resp = await async_client.post("/gameworlds/", json=gw_payload, headers={"Authorization": f"Bearer {wb_token}"})
+    assert resp.status_code == 200
+    gw_id = resp.json()["id"]
+
+    concept_payload = {"gameworld_id": gw_id, "name": "Clan", "description": "c"}
+    resp = await async_client.post("/concepts/", json=concept_payload, headers={"Authorization": f"Bearer {admin_token}"})
+    assert resp.status_code == 200
+    concept_id = resp.json()["id"]
+
+    for i in range(3):
+        page = {"gameworld_id": gw_id, "concept_id": concept_id, "name": f"P{i}", "content": "txt"}
+        resp = await async_client.post("/pages/", json=page, headers={"Authorization": f"Bearer {writer_token}"})
+        assert resp.status_code == 200
+
+    resp = await async_client.post(f"/vectordb/{gw_id}/rebuild")
+    assert resp.status_code == 200
+    assert resp.json()["pages_indexed"] == 3

--- a/frontend/src/app/lib/vectordbAPI.ts
+++ b/frontend/src/app/lib/vectordbAPI.ts
@@ -1,0 +1,15 @@
+import { API_URL } from "./config";
+
+export async function rebuildVectorDB(token: string, worldId: number) {
+  const res = await fetch(`${API_URL}/vectordb/${worldId}/rebuild`, {
+    method: "POST",
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) {
+    let err;
+    try { err = await res.json(); }
+    catch { err = await res.text(); }
+    throw err;
+  }
+  return await res.json();
+}

--- a/frontend/src/app/system_settings/page.tsx
+++ b/frontend/src/app/system_settings/page.tsx
@@ -5,15 +5,63 @@ import { hasRole } from "../lib/roles";
 import { useAuth } from "../components/auth/AuthProvider";
 import { useState } from "react";
 import ImportWorldModal from "../components/importexport/ImportWorldModal";
-import { Download, Upload, Users2 } from "lucide-react";
+import { Download, Upload, Users2, Database } from "lucide-react";
 import Link from "next/link";
 import ExportWorldModal from "../components/importexport/ExportWorldModal";
+import { useWorlds } from "../lib/userWorlds";
+import { rebuildVectorDB } from "../lib/vectordbAPI";
+import { getPagesForWorld } from "../lib/pagesAPI";
 
 export default function UserManagementPage() {
-  const { user } = useAuth();
+  const { user, token } = useAuth();
+  const { worlds } = useWorlds();
   const [importModalOpen, setImportModalOpen] = useState(false);
-  const [success, setSuccess] = useState("");  
-    const [exportModalOpen, setExportModalOpen] = useState(false);
+  const [success, setSuccess] = useState("");
+  const [exportModalOpen, setExportModalOpen] = useState(false);
+  const [selectedWorldId, setSelectedWorldId] = useState("");
+  const [vdbLoading, setVdbLoading] = useState(false);
+  const [vdbProgress, setVdbProgress] = useState("");
+  const [vdbError, setVdbError] = useState("");
+
+  async function handleRebuild() {
+    if (!selectedWorldId) return;
+    setVdbLoading(true);
+    setVdbError("");
+    let pageCount = 0;
+    try {
+      const pages = await getPagesForWorld(Number(selectedWorldId), token || "");
+      pageCount = pages.length;
+    } catch (err) {
+      // ignore count error
+    }
+    if (pageCount) {
+      setVdbProgress(
+        `Indexing ${pageCount} pages (est. 0.3s/page)...`
+      );
+    } else {
+      setVdbProgress("Indexing pages...");
+    }
+    const start = Date.now();
+    try {
+      const res = await rebuildVectorDB(token || "", Number(selectedWorldId));
+      const elapsed = (Date.now() - start) / 1000;
+      const perPage = pageCount
+        ? (elapsed / pageCount).toFixed(2)
+        : elapsed.toFixed(2);
+      setSuccess(
+        `Vector DB updated! Indexed ${res.pages_indexed} pages (${perPage}s/page).`
+      );
+    } catch (err) {
+      setVdbError("Failed to rebuild vector DB.");
+    } finally {
+      setVdbLoading(false);
+      setVdbProgress("");
+      setTimeout(() => {
+        setSuccess("");
+        setVdbError("");
+      }, 3000);
+    }
+  }
 
   if (!hasRole(user?.role, "system admin")) {
     return (
@@ -81,7 +129,45 @@ export default function UserManagementPage() {
                   setTimeout(() => setSuccess(""), 2000);
                 }}
               />
-            <ExportWorldModal open={exportModalOpen} onClose={() => setExportModalOpen(false)} />              
+            <ExportWorldModal open={exportModalOpen} onClose={() => setExportModalOpen(false)} />
+            </div>
+
+            {/* Vector DB Rebuild Area */}
+            <div className="bg-[var(--surface)] border border-[var(--border)] rounded-2xl shadow-sm p-6 w-full flex flex-col gap-3">
+              <div className="flex items-center gap-2 mb-2">
+                <Database className="w-6 h-6 text-[var(--primary)]" />
+                <div className="text-[var(--primary)] font-bold text-lg">Vector Database</div>
+              </div>
+              <div className="text-[var(--foreground)]/80 text-sm">
+                Rebuild the vector database for a selected world to update search indexes.
+              </div>
+              <div className="flex flex-col sm:flex-row gap-4 mt-2 items-end">
+                <select
+                  className="flex-1 px-3 py-2 rounded-xl border border-[var(--primary)] bg-[var(--surface)] text-[var(--primary)] focus:outline-none"
+                  value={selectedWorldId}
+                  onChange={e => setSelectedWorldId(e.target.value)}
+                  disabled={vdbLoading}
+                >
+                  <option value="">— Choose World —</option>
+                  {worlds.map(w => (
+                    <option key={w.id} value={w.id}>{w.name}</option>
+                  ))}
+                </select>
+                <button
+                  type="button"
+                  className="px-5 py-2 rounded-xl font-bold border border-[var(--primary)] shadow transition bg-[var(--primary)] text-[var(--primary-foreground)] hover:bg-[var(--accent)] hover:text-[var(--background)] disabled:opacity-60"
+                  onClick={handleRebuild}
+                  disabled={vdbLoading || !selectedWorldId}
+                >
+                  {vdbLoading ? "Rebuilding..." : "Build Vector DB"}
+                </button>
+              </div>
+              {vdbProgress && (
+                <div className="text-sm text-[var(--primary)] mt-2">{vdbProgress}</div>
+              )}
+              {vdbError && (
+                <div className="text-sm text-red-600 mt-2">{vdbError}</div>
+              )}
             </div>
 
             {/* User Management Area */}


### PR DESCRIPTION
## Summary
- add vector database API helper
- implement new rebuild card on the system settings page
- cover rebuild endpoint with a new backend test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68448ea8f51c83228f69c03d9784b95f