### PR TITLE
Fix ChromaDB rebuild error

### DIFF
--- a/backend/app/crud/crud_vectordb.py
+++ b/backend/app/crud/crud_vectordb.py
@@ -69,8 +69,12 @@ async def add_page(session: AsyncSession, page_id: int):
 
 
 async def rebuild_world(session: AsyncSession, world_id: int):
+    name = f"world_{world_id}"
+    try:
+        _client.delete_collection(name)
+    except Exception:
+        pass
     collection = _get_collection(world_id)
-    collection.delete(where={})
 
     result = await session.execute(select(Page.id).where(Page.gameworld_id == world_id))
     page_ids = [row[0] for row in result.all()]


### PR DESCRIPTION
## Summary
- avoid passing an empty filter on vector DB rebuild by deleting and recreating the collection

## Testing
- `pytest backend/tests/test_vectordb.py::test_rebuild_vectordb -q` *(fails: RuntimeError)*

------
https://chatgpt.com/codex/tasks/task_e_684491d98a1c832284f92f798af67ec7