### PR TITLE
Add agents settings frontend

### DIFF
--- a/frontend/src/app/agents_settings/page.tsx
+++ b/frontend/src/app/agents_settings/page.tsx
@@ -1,0 +1,128 @@
+"use client";
+import { useState } from "react";
+import AuthGuard from "../components/auth/AuthGuard";
+import DashboardLayout from "../components/DashboardLayout";
+import { useAuth } from "../components/auth/AuthProvider";
+import { hasRole } from "../lib/roles";
+import { useAgents } from "../lib/useAgents";
+import { useWorlds } from "../lib/userWorlds";
+import AgentGrid from "../components/agents/AgentGrid";
+import AgentModal from "../components/agents/AgentModal";
+import { rebuildVectorDB } from "../lib/vectordbAPI";
+
+export default function AgentsSettingsPage() {
+  const { user, token } = useAuth();
+  const { agents, mutate, isLoading, error } = useAgents();
+  const { worlds } = useWorlds();
+  const [search, setSearch] = useState("");
+  const [modalOpen, setModalOpen] = useState(false);
+  const [selectedAgent, setSelectedAgent] = useState(null);
+  const [success, setSuccess] = useState("");
+  const [vdbLoading, setVdbLoading] = useState(false);
+
+  if (!hasRole(user?.role, "world builder") && !hasRole(user?.role, "system admin")) {
+    return (
+      <DashboardLayout>
+        <div className="p-10 text-2xl text-red-600 font-bold">Not authorized</div>
+      </DashboardLayout>
+    );
+  }
+
+  const filtered = agents.filter(a =>
+    a.name?.toLowerCase().includes(search.toLowerCase())
+  );
+
+  function handleCreate() {
+    setSelectedAgent(null);
+    setModalOpen(true);
+  }
+
+  function handleEdit(agent) {
+    setSelectedAgent(agent);
+    setModalOpen(true);
+  }
+
+  function handleModalSave() {
+    mutate();
+    setModalOpen(false);
+    setSuccess("Agent saved successfully!");
+    setTimeout(() => setSuccess(""), 2000);
+  }
+
+  function handleModalDelete() {
+    mutate();
+    setModalOpen(false);
+    setSuccess("Agent deleted successfully!");
+    setTimeout(() => setSuccess(""), 2000);
+  }
+
+  async function handleRebuild(agent) {
+    setVdbLoading(true);
+    try {
+      await rebuildVectorDB(token || "", agent.world_id);
+      setSuccess("Vector DB updated!");
+    } catch (err) {
+      setSuccess("Failed to rebuild vector DB");
+    } finally {
+      setVdbLoading(false);
+      setTimeout(() => setSuccess(""), 2000);
+    }
+  }
+
+  return (
+    <AuthGuard>
+      <DashboardLayout>
+        <div className="min-h-screen w-full bg-[var(--background)] text-[var(--foreground)] transition-colors duration-300 px-2 sm:px-6 py-8">
+          <div className="mx-auto max-w-5xl w-full">
+            <div className="flex items-center justify-between mb-7">
+              <h1 className="text-xl sm:text-2xl font-serif font-bold text-[var(--primary)] tracking-tight">
+                Agents Settings
+              </h1>
+              <button
+                className="px-4 py-2 rounded-xl font-bold bg-[var(--primary)] text-[var(--primary-foreground)] shadow"
+                onClick={handleCreate}
+              >
+                + Add Agent
+              </button>
+            </div>
+            <input
+              className="px-4 py-2 rounded-xl border border-[var(--primary)] bg-[var(--card-bg)] text-[var(--foreground)] placeholder-[var(--primary)]/60 focus:outline-none focus:ring-2 focus:ring-[var(--primary)] text-base mb-6 w-full"
+              placeholder="Search agents..."
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+            />
+            {success && (
+              <div className="bg-[var(--primary)] text-[var(--primary-foreground)] px-4 py-2 rounded-xl shadow mb-4 text-sm">
+                {success}
+              </div>
+            )}
+            {isLoading ? (
+              <div className="text-lg text-[var(--primary)] animate-pulse">Loading agents...</div>
+            ) : error ? (
+              <div className="text-lg text-red-500">Error loading agents.</div>
+            ) : (
+              <AgentGrid
+                agents={filtered}
+                onEdit={handleEdit}
+                onDelete={a => {
+                  setSelectedAgent(a);
+                  setModalOpen(true);
+                }}
+                onRebuild={handleRebuild}
+              />
+            )}
+          </div>
+          {modalOpen && (
+            <AgentModal
+              agent={selectedAgent}
+              onClose={() => setModalOpen(false)}
+              onSave={handleModalSave}
+              onDelete={handleModalDelete}
+              worlds={worlds}
+            />
+          )}
+        </div>
+      </DashboardLayout>
+    </AuthGuard>
+  );
+}

--- a/frontend/src/app/components/agents/AgentGrid.tsx
+++ b/frontend/src/app/components/agents/AgentGrid.tsx
@@ -1,0 +1,48 @@
+import Image from "next/image";
+
+export default function AgentGrid({ agents, onEdit, onDelete, onRebuild }) {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+      {agents.map(agent => (
+        <div
+          key={agent.id}
+          className="relative bg-[var(--card-bg)] rounded-2xl border border-[var(--border)] shadow-xl flex flex-col items-center p-6"
+        >
+          <Image
+            src={agent.logo || "/images/default/avatars/logo.png"}
+            alt={agent.name}
+            width={400}
+            height={400}
+            className="w-20 h-20 rounded-full object-cover mb-3"
+          />
+          <div className="text-lg font-bold text-[var(--primary)] mb-1 truncate w-full text-center">
+            {agent.name}
+          </div>
+          <div className="text-xs text-[var(--foreground)]/70 mb-2">
+            World ID: {agent.world_id}
+          </div>
+          <div className="flex gap-2 mt-1">
+            <button
+              className="px-3 py-1 rounded-lg bg-[var(--primary)] text-[var(--primary-foreground)] text-sm shadow"
+              onClick={() => onEdit(agent)}
+            >
+              Edit
+            </button>
+            <button
+              className="px-3 py-1 rounded-lg bg-red-600 text-white text-sm shadow"
+              onClick={() => onDelete(agent)}
+            >
+              Delete
+            </button>
+          </div>
+          <button
+            className="mt-3 px-4 py-1 rounded-lg border border-[var(--primary)] text-[var(--primary)] text-sm hover:bg-[var(--primary)] hover:text-[var(--primary-foreground)] transition"
+            onClick={() => onRebuild(agent)}
+          >
+            Update Vector DB
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/app/components/agents/AgentModal.tsx
+++ b/frontend/src/app/components/agents/AgentModal.tsx
@@ -1,0 +1,143 @@
+"use client";
+import { useState, useEffect } from "react";
+import { createAgent, updateAgent, deleteAgent } from "../../lib/agentAPI";
+import { useAuth } from "../auth/AuthProvider";
+import ModalContainer from "../template/modalContainer";
+import { M3FloatingInput } from "../template/M3FloatingInput";
+
+export default function AgentModal({ agent, onClose, onSave, onDelete, worlds }) {
+  const { token } = useAuth();
+  const isEdit = !!agent;
+  const [form, setForm] = useState({
+    name: "",
+    logo: "",
+    personality: "",
+    task: "",
+    world_id: worlds?.[0]?.id || "",
+  });
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    setForm({
+      name: agent?.name || "",
+      logo: agent?.logo || "",
+      personality: agent?.personality || "",
+      task: agent?.task || "",
+      world_id: agent?.world_id || worlds?.[0]?.id || "",
+    });
+    setError("");
+  }, [agent, worlds]);
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setSaving(true);
+    setError("");
+    try {
+      const payload = {
+        name: form.name,
+        logo: form.logo,
+        personality: form.personality,
+        task: form.task,
+        world_id: Number(form.world_id),
+      };
+      if (isEdit) {
+        await updateAgent(agent.id, payload, token || "");
+      } else {
+        await createAgent(payload, token || "");
+      }
+      onSave?.();
+    } catch (err) {
+      setError(err?.detail || err?.message || "Failed to save agent");
+      setSaving(false);
+      return;
+    }
+    setSaving(false);
+  }
+
+  async function handleDelete() {
+    if (!isEdit) return;
+    setSaving(true);
+    setError("");
+    try {
+      await deleteAgent(agent.id, token || "");
+      onDelete?.();
+    } catch (err) {
+      setError(err?.detail || err?.message || "Failed to delete agent");
+      setSaving(false);
+      return;
+    }
+    setSaving(false);
+  }
+
+  if (!worlds) return null;
+
+  return (
+    <ModalContainer title={isEdit ? "Edit Agent" : "Create Agent"} onClose={onClose}>
+      {error && (
+        <div className="bg-red-100 text-red-700 rounded-lg px-3 py-2 mb-3 text-sm">
+          {error}
+        </div>
+      )}
+      <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
+        <M3FloatingInput
+          label="Name"
+          value={form.name}
+          onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
+          required
+        />
+        <M3FloatingInput
+          label="Logo URL"
+          value={form.logo}
+          onChange={e => setForm(f => ({ ...f, logo: e.target.value }))}
+        />
+        <M3FloatingInput
+          label="Personality"
+          value={form.personality}
+          onChange={e => setForm(f => ({ ...f, personality: e.target.value }))}
+        />
+        <M3FloatingInput
+          label="Task"
+          value={form.task}
+          onChange={e => setForm(f => ({ ...f, task: e.target.value }))}
+        />
+        <div className="relative">
+          <select
+            className="peer w-full px-4 pt-6 pb-2 text-[var(--foreground)] bg-[var(--surface)] border-2 border-[var(--border)] rounded-xl outline-none focus:border-[var(--primary)] transition-colors text-base"
+            value={form.world_id}
+            onChange={e => setForm(f => ({ ...f, world_id: e.target.value }))}
+            required
+          >
+            {worlds.map(w => (
+              <option key={w.id} value={w.id}>
+                {w.name}
+              </option>
+            ))}
+          </select>
+          <label className="absolute left-3 top-1.5 text-base text-[var(--primary)] font-semibold pointer-events-none">
+            World
+          </label>
+        </div>
+        <div className="flex gap-3 mt-4 justify-end">
+          {isEdit && (
+            <button
+              type="button"
+              onClick={handleDelete}
+              className="px-4 py-2 rounded-xl bg-red-600 text-white text-sm"
+              disabled={saving}
+            >
+              Delete
+            </button>
+          )}
+          <button
+            type="submit"
+            className="px-5 py-2 rounded-xl bg-[var(--primary)] text-[var(--primary-foreground)] font-bold text-sm"
+            disabled={saving}
+          >
+            {saving ? "Saving..." : "Save"}
+          </button>
+        </div>
+      </form>
+    </ModalContainer>
+  );
+}

--- a/frontend/src/app/lib/agentAPI.ts
+++ b/frontend/src/app/lib/agentAPI.ts
@@ -5,6 +5,49 @@ export type ChatMessage = {
   content: string;
 };
 
+export async function getAgents(
+  token: string,
+  params: { world_id?: number } = {}
+) {
+  const query = new URLSearchParams();
+  if (params.world_id !== undefined)
+    query.append("world_id", params.world_id.toString());
+  const res = await fetch(`${API_URL}/agents/?${query.toString()}`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) throw new Error("Could not fetch agents");
+  return await res.json();
+}
+
+export async function createAgent(data: unknown, token: string) {
+  const res = await fetch(`${API_URL}/agents/`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw await res.json();
+  return await res.json();
+}
+
+export async function updateAgent(id: number, data: unknown, token: string) {
+  const res = await fetch(`${API_URL}/agents/${id}`, {
+    method: "PATCH",
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw await res.json();
+  return await res.json();
+}
+
+export async function deleteAgent(id: number, token: string) {
+  const res = await fetch(`${API_URL}/agents/${id}`, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw await res.json();
+  return await res.json();
+}
+
 export async function chatWithAgent(
   worldId: number,
   messages: ChatMessage[],

--- a/frontend/src/app/lib/useAgents.ts
+++ b/frontend/src/app/lib/useAgents.ts
@@ -1,0 +1,13 @@
+import useSWR from "swr";
+import { getAgents } from "./agentAPI";
+import { useAuth } from "../components/auth/AuthProvider";
+
+export function useAgents(world_id?: number) {
+  const { token } = useAuth();
+  const fetcher = () => getAgents(token || "", { world_id });
+  const { data, error, mutate, isLoading } = useSWR(
+    token ? ["agents", world_id || "all", token] : null,
+    fetcher
+  );
+  return { agents: data || [], error, mutate, isLoading };
+}


### PR DESCRIPTION
## Summary
- implement CRUD endpoints for agents in `agentAPI`
- add `useAgents` hook
- create `AgentGrid` and `AgentModal` components
- add new `/agents_settings/` page with AuthGuard + DashboardLayout
- use existing avatar logo fallback
- remove unused agent logo placeholder

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844a2de7244832287bb7533cbd3237a