### PR TITLE
Add vector DB update date for agents

### DIFF
--- a/backend/app/models/model_agent.py
+++ b/backend/app/models/model_agent.py
@@ -11,4 +11,5 @@ class Agent(SQLModel, table=True):
     world_id: int = Field(foreign_key="gameworld.id")
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    vector_db_update_date: Optional[datetime] = None
 

--- a/backend/app/schemas/schema_agent.py
+++ b/backend/app/schemas/schema_agent.py
@@ -13,6 +13,7 @@ class AgentRead(AgentCreate):
     id: int
     created_at: datetime
     updated_at: datetime
+    vector_db_update_date: Optional[datetime] = None
 
     class Config:
         orm_mode = True
@@ -23,4 +24,5 @@ class AgentUpdate(BaseModel):
     personality: Optional[str] = None
     task: Optional[str] = None
     world_id: Optional[int] = None
+    vector_db_update_date: Optional[datetime] = None
 

--- a/frontend/src/app/agents_settings/page.tsx
+++ b/frontend/src/app/agents_settings/page.tsx
@@ -72,6 +72,7 @@ export default function AgentsSettingsPage() {
       }
       const res = await rebuildVectorDB(token || "", agent.world_id);
       setSuccess(`Vector DB updated! ${res.pages_indexed} pages indexed.`);
+      mutate();
     } catch (err) {
       setSuccess("Failed to rebuild vector DB");
     } finally {

--- a/frontend/src/app/components/agents/AgentGrid.tsx
+++ b/frontend/src/app/components/agents/AgentGrid.tsx
@@ -21,6 +21,11 @@ export default function AgentGrid({ agents, onEdit, onDelete, onRebuild }) {
           <div className="text-xs text-[var(--foreground)]/70 mb-2">
             World ID: {agent.world_id}
           </div>
+          {agent.vector_db_update_date && (
+            <div className="text-xs text-[var(--foreground)]/70 mb-2">
+              Vector DB updated: {new Date(agent.vector_db_update_date).toLocaleString()}
+            </div>
+          )}
           <div className="flex gap-2 mt-1">
             <button
               className="px-3 py-1 rounded-lg bg-[var(--primary)] text-[var(--primary-foreground)] text-sm shadow"


### PR DESCRIPTION
## Summary
- add `vector_db_update_date` to Agent model and schemas
- migrate DB to include column if missing
- mark date when rebuilding vector DB for a world
- display vector DB update date in Agents page and refresh list after rebuild

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'Undefined' from 'pydantic.fields')*

------
https://chatgpt.com/codex/tasks/task_e_684589aafadc8322b3fb810a0dbd2627