### PR TITLE
Enable streaming agent chats

### DIFF
--- a/backend/tests/test_agent.py
+++ b/backend/tests/test_agent.py
@@ -1,5 +1,6 @@
 import pytest
 from unittest.mock import patch
+from datetime import datetime, timezone
 
 @pytest.mark.anyio
 async def test_chat_endpoint(async_client, create_user, login_and_get_token):
@@ -7,20 +8,26 @@ async def test_chat_endpoint(async_client, create_user, login_and_get_token):
     token = await login_and_get_token("agent@test.com", "pass", "writer")
 
     chat_payload = {"messages": [{"role": "user", "content": "Hello"}]}
-    with patch("app.crud.crud_agent.OpenAI") as MockOpenAI, \
-         patch("app.crud.crud_vectordb.query_world", return_value=[{"document": "info"}]):
-        mock_client = MockOpenAI.return_value
-        class Response:
-            choices = [type("Choice", (), {"message": type("Message", (), {"content": "Hi"})()})()]
 
-        mock_client.chat.completions.create.return_value = Response()
-        resp = await async_client.post(
+    class FakeAgent:
+        world_id = 1
+        personality = "kind"
+        vector_db_update_date = datetime.now(timezone.utc)
+
+    async def fake_chat(session, agent_id, messages):
+        yield "Hi"
+
+    with patch("app.api.api_agent.get_agent", return_value=FakeAgent()), \
+         patch("app.crud.crud_agent.chat_with_agent", side_effect=fake_chat):
+        async with async_client.stream(
+            "POST",
             "/agents/1/chat",
             json=chat_payload,
             headers={"Authorization": f"Bearer {token}"},
-        )
-        assert resp.status_code == 200, resp.text
-        assert resp.json()["response"] == "Hi"
+        ) as resp:
+            text = "".join([chunk async for chunk in resp.aiter_text()])
+        assert resp.status_code == 200
+        assert text == "Hi"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- stream chat completion chunks when talking to agents
- allow chat endpoint to check agent DB update time
- adapt tests for streaming responses

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_68459619301c832285322169fa9ff04a