### PR TITLE
Implement chat test interface

### DIFF
--- a/frontend/src/app/chat_test/page.tsx
+++ b/frontend/src/app/chat_test/page.tsx
@@ -1,0 +1,120 @@
+"use client";
+import { useState, useRef, FormEvent } from "react";
+import AuthGuard from "../components/auth/AuthGuard";
+import DashboardLayout from "../components/DashboardLayout";
+import { useAuth } from "../components/auth/AuthProvider";
+import { hasRole } from "../lib/roles";
+import { useAgents } from "../lib/useAgents";
+import { ChatMessage, chatTest } from "../lib/agentAPI";
+import Image from "next/image";
+
+export default function ChatTestPage() {
+  const { user, token } = useAuth();
+  const { agents, isLoading } = useAgents();
+  const [selectedAgentId, setSelectedAgentId] = useState<number | null>(null);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [loading, setLoading] = useState(false);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  if (!hasRole(user?.role, "system admin")) {
+    return (
+      <DashboardLayout>
+        <div className="p-10 text-2xl text-red-600 font-bold">Not authorized</div>
+      </DashboardLayout>
+    );
+  }
+
+  const availableAgents = agents.filter(a => a.vector_db_update_date);
+
+  function scrollToBottom() {
+    setTimeout(() => messagesEndRef.current?.scrollIntoView({ behavior: "smooth" }), 50);
+  }
+
+  async function handleSend(e: FormEvent) {
+    e.preventDefault();
+    if (!input.trim() || selectedAgentId === null) return;
+    const newMsg: ChatMessage = { role: "user", content: input.trim() };
+    const updated = [...messages, newMsg];
+    setMessages(updated);
+    setInput("");
+    scrollToBottom();
+    setLoading(true);
+    try {
+      const res = await chatTest(selectedAgentId, updated, token || "");
+      const docs = res.documents || [];
+      const withDocs = [...updated, ...docs.map((d: any) => ({ role: "assistant", content: d.document }))];
+      setMessages(withDocs);
+      scrollToBottom();
+    } catch {
+      setMessages(m => [...m, { role: "assistant", content: "Error." }]);
+    }
+    setLoading(false);
+  }
+
+  return (
+    <AuthGuard>
+      <DashboardLayout>
+        <div className="min-h-screen w-full bg-[var(--background)] text-[var(--foreground)] px-2 sm:px-6 py-8">
+          {selectedAgentId === null ? (
+            <div className="mx-auto max-w-xl flex flex-col gap-4">
+              <h1 className="text-xl font-bold text-[var(--primary)] text-center mb-4">Select an Agent</h1>
+              {isLoading ? (
+                <div className="text-center">Loading agents...</div>
+              ) : (
+                availableAgents.map(a => (
+                  <button
+                    key={a.id}
+                    onClick={() => setSelectedAgentId(a.id)}
+                    className="flex items-center gap-3 px-3 py-2 rounded-xl border border-[var(--primary)] hover:bg-[var(--primary)]/10"
+                  >
+                    <Image src={a.logo || "/images/default/avatars/logo.png"} alt={a.name} width={32} height={32} className="w-8 h-8 rounded object-cover" />
+                    <span className="font-semibold text-[var(--primary)]">{a.name}</span>
+                  </button>
+                ))
+              )}
+            </div>
+          ) : (
+            <div className="mx-auto max-w-xl flex flex-col h-[calc(100vh-160px)]">
+              <div className="flex items-center justify-between mb-3">
+                <h2 className="text-lg font-bold text-[var(--primary)]">
+                  {agents.find(a => a.id === selectedAgentId)?.name}
+                </h2>
+                <button
+                  onClick={() => { setSelectedAgentId(null); setMessages([]); }}
+                  className="text-sm text-[var(--primary)] hover:underline"
+                >
+                  Change
+                </button>
+              </div>
+              <div className="flex-1 overflow-y-auto space-y-4 mb-2 border border-[var(--border)] rounded-xl p-3 bg-[var(--surface)]">
+                {messages.map((m, idx) => (
+                  <div key={idx} className={`flex ${m.role === "user" ? "justify-end" : "justify-start"}`}>
+                    <div className={`${m.role === "user" ? "bg-[var(--primary)] text-[var(--primary-foreground)]" : "bg-[var(--surface-variant)]"} rounded-xl px-3 py-2 shadow max-w-[80%] whitespace-pre-wrap`}>{m.content}</div>
+                  </div>
+                ))}
+                <div ref={messagesEndRef}></div>
+              </div>
+              <form onSubmit={handleSend} className="mt-2 flex gap-2">
+                <input
+                  className="flex-1 rounded-xl border border-[var(--primary)] p-2 bg-[var(--surface)] text-[var(--foreground)] placeholder-[var(--primary)]/70 focus:outline-none"
+                  value={input}
+                  onChange={e => setInput(e.target.value)}
+                  placeholder="Type your message..."
+                  disabled={loading}
+                />
+                <button
+                  type="submit"
+                  className="px-4 py-2 rounded-xl bg-[var(--primary)] text-[var(--primary-foreground)] disabled:opacity-50"
+                  disabled={loading || !input.trim()}
+                >
+                  Send
+                </button>
+              </form>
+            </div>
+          )}
+        </div>
+      </DashboardLayout>
+    </AuthGuard>
+  );
+}

--- a/frontend/src/app/lib/agentAPI.ts
+++ b/frontend/src/app/lib/agentAPI.ts
@@ -78,3 +78,20 @@ export async function chatWithAgent(
   }
   return result;
 }
+
+export async function chatTest(
+  agentId: number,
+  messages: ChatMessage[],
+  token: string
+) {
+  const res = await fetch(`${API_URL}/agents/${agentId}/chat_test`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify({ messages }),
+  });
+  if (!res.ok) throw await res.json();
+  return await res.json();
+}

--- a/frontend/src/app/system_settings/page.tsx
+++ b/frontend/src/app/system_settings/page.tsx
@@ -103,6 +103,24 @@ export default function UserManagementPage() {
               </Link>
             </div>
 
+            {/* Chat Test Area */}
+            <div className="bg-[var(--surface)] border border-[var(--border)] rounded-2xl shadow-sm p-6 w-full flex flex-col gap-2">
+              <div className="flex items-center gap-2 mb-2">
+                <Bot className="w-6 h-6 text-[var(--primary)]" />
+                <div className="text-[var(--primary)] font-bold text-lg">Chat Test</div>
+              </div>
+              <div className="text-[var(--foreground)]/80 text-sm mb-3">
+                Debug vector DB queries by chatting with agents.
+              </div>
+              <Link
+                href="/chat_test"
+                className="inline-flex items-center gap-2 px-5 py-2 rounded-xl font-bold bg-[var(--primary)] text-[var(--primary-foreground)] shadow hover:bg-[var(--accent)] hover:text-[var(--background)] border border-[var(--primary)] transition w-fit"
+              >
+                <Bot className="w-5 h-5" />
+                Go to Chat Test
+              </Link>
+            </div>
+
             {/* User Management Area */}
             <div className="bg-[var(--surface)] border border-[var(--border)] rounded-2xl shadow-sm p-6 w-full flex flex-col gap-2">
               <div className="flex items-center gap-2 mb-2">


### PR DESCRIPTION
## Summary
- add API endpoint `POST /agents/{agent_id}/chat_test` to inspect vector DB documents
- update agent API library with `chatTest` helper
- create `chat_test` page for system admins
- link chat test from system settings
- adjust chat endpoint test and add coverage for chat_test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846a35c52d08322a13ffb393cce9985