### PR TITLE
Enhance login page with feature cards

### DIFF
--- a/frontend/src/app/components/landing/FeatureCard.tsx
+++ b/frontend/src/app/components/landing/FeatureCard.tsx
@@ -1,0 +1,12 @@
+"use client";
+import { ReactNode } from "react";
+
+export default function FeatureCard({ icon, title, children }: { icon: ReactNode; title: string; children: ReactNode }) {
+  return (
+    <div className="flex flex-col items-center text-center p-4 rounded-2xl bg-[var(--surface)]/70 backdrop-blur-md shadow-xl border border-[var(--border)] hover:shadow-2xl transition-all">
+      <div className="mb-3 text-[var(--primary)]">{icon}</div>
+      <div className="font-semibold mb-2 text-lg">{title}</div>
+      <div className="text-sm text-[var(--foreground)]/80">{children}</div>
+    </div>
+  );
+}

--- a/frontend/src/app/components/landing/Features.tsx
+++ b/frontend/src/app/components/landing/Features.tsx
@@ -1,0 +1,37 @@
+"use client";
+import FeatureCard from "./FeatureCard";
+import { Globe, Users, Bot, Dice5 } from "lucide-react";
+
+export default function Features() {
+  const features = [
+    {
+      icon: <Globe className="w-8 h-8" />,
+      title: "Forge Worlds",
+      desc: "Build and expand rich RPG settings with pages, concepts and groups.",
+    },
+    {
+      icon: <Users className="w-8 h-8" />,
+      title: "Collaborate",
+      desc: "Invite players and co-writers to shape your adventures together.",
+    },
+    {
+      icon: <Bot className="w-8 h-8" />,
+      title: "NPC Agents",
+      desc: "Create AI-powered agents to help narrate and manage lore.",
+    },
+    {
+      icon: <Dice5 className="w-8 h-8" />,
+      title: "Virtual Table",
+      desc: "Jump into your online table powered by Foundry with a single click.",
+    },
+  ];
+  return (
+    <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 w-full max-w-4xl mt-10">
+      {features.map((f) => (
+        <FeatureCard key={f.title} icon={f.icon} title={f.title}>
+          {f.desc}
+        </FeatureCard>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -5,6 +5,7 @@ import { useEffect } from "react";
 import Image from "next/image";
 import AuthCard from "./components/auth/AuthCard";
 import Starfield from "./components/template/Starfield";
+import Features from "./components/landing/Features";
 
 export default function LoginPage() {
   const { user, loading } = useAuth();
@@ -84,12 +85,17 @@ export default function LoginPage() {
                 You Build, We Forge!
               </div>
       <div className="relative z-10 w-full flex flex-col items-center">
-      
-      <AuthCard />    
+
+      <AuthCard />
       </div>
       {/* Auth Form */}
-      
+
 </section>
+
+      {/* Feature cards */}
+      <section className="relative z-10 w-full flex justify-center px-4 mt-6">
+        <Features />
+      </section>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- add reusable `FeatureCard` component
- list key app features on the login page
- refine login layout to showcase cards

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684b19f653e083228f0a9ec300a69d88