### PR TITLE
Enhance DashboardWorlds cards

### DIFF
--- a/frontend/src/app/components/worlds/DashboardWorlds.tsx
+++ b/frontend/src/app/components/worlds/DashboardWorlds.tsx
@@ -11,8 +11,7 @@ import { useAuth } from "../auth/AuthProvider";
 import WorldFormModal from "./WorldFormModal";
 import ImportWorldModal from "../importexport/ImportWorldModal";
 import { ConfirmDeleteWorldModal } from "../template/ConfirmModal";
-import { FaEdit, FaTrash } from "react-icons/fa";
-import Image from "next/image";
+import WorldCard from "./WorldCard";
 
 
 export default function DashboardWorlds({
@@ -197,66 +196,17 @@ export default function DashboardWorlds({
         </h1>
         <div className="grid gap-10 sm:gap-12 md:gap-14 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 justify-items-center w-full">
           {worlds.map((world) => (
-            <div
+            <WorldCard
               key={world.id}
-              className="
-                group relative w-[260px] sm:w-[330px] md:w-[380px] max-w-full
-                bg-[var(--card-bg)]/95 rounded-3xl shadow-2xl border border-[var(--border)]
-                flex flex-col items-center p-0 overflow-hidden
-                hover:shadow-3xl hover:scale-105 hover:border-[var(--primary)]/60
-                transition-all duration-200
-              "
-              style={{
-                backdropFilter: "blur(5px) saturate(1.1)",
+              world={world}
+              linkURL={linkURL}
+              showEdit={showEdit}
+              onEdit={(w) => {
+                setEditingWorld(w);
+                setEditModalOpen(true);
               }}
-            >
-              {/* Edit/Delete floating top-right */}
-              {showEdit && hasRole(user?.role, "world builder") && (
-                <div className="absolute right-5 top-5 z-30 flex flex-col gap-3 items-center">
-                  {/* Edit */}
-                  <button
-                    className="p-3 bg-white/70 border border-[var(--primary)] rounded-xl shadow hover:bg-[var(--primary)]/20 hover:scale-110 transition"
-                    title="Edit"
-                    onClick={() => {
-                      setEditingWorld(world);
-                      setEditModalOpen(true);
-                    }}
-                  >
-                    <FaEdit className="text-[var(--primary)]" />
-                  </button>
-                  {/* Delete */}
-                  <button
-                    className="p-3 bg-white/70 border border-red-300 rounded-xl shadow hover:bg-red-100 hover:scale-110 transition"
-                    title="Delete"
-                    onClick={() => setDeletingWorld(world)}
-                  >
-                    <FaTrash className="text-red-500" />
-                  </button>
-                </div>
-              )}
-              <a href={`/${linkURL}/${world.id}`} className="w-full block group">
-                <div className="relative w-full h-[220px] sm:h-[320px] md:h-[250px] overflow-hidden rounded-t-3xl">
-                  <Image
-                    src={world.logo || "/images/worlds/new_game.png"}
-                    alt={world.name}
-                    className="w-full h-full object-cover object-center rounded-t-3xl transition"
-                    width={400}
-                    height={400}
-                  />
-                  <div className="
-                    absolute bottom-0 left-0 w-full
-                    bg-[var(--background)]/55 backdrop-blur-xl
-                    py-4 px-3 flex items-center justify-center
-                    rounded-b-3xl z-10
-                    "
-                  >
-                    <span className="text-xl font-bold text-[var(--primary)] text-center drop-shadow">
-                      {world.name}
-                    </span>
-                  </div>
-                </div>
-              </a>
-            </div>
+              onDelete={(w) => setDeletingWorld(w)}
+            />
           ))}
         </div>
       </div>

--- a/frontend/src/app/components/worlds/WorldCard.tsx
+++ b/frontend/src/app/components/worlds/WorldCard.tsx
@@ -1,0 +1,64 @@
+import Image from "next/image";
+import { useConcepts } from "@/app/lib/useConcept";
+import { useAuth } from "../auth/AuthProvider";
+import { hasRole } from "@/app/lib/roles";
+import { FaEdit, FaTrash } from "react-icons/fa";
+
+export default function WorldCard({ world, linkURL, showEdit, onEdit, onDelete }) {
+  const { user } = useAuth();
+  const { concepts, isLoading } = useConcepts(world.id);
+
+  const conceptCount = concepts.length;
+  const pagesCount = concepts.reduce((sum, c) => sum + (c.pages_count || 0), 0);
+
+  return (
+    <div
+      className="group relative w-[260px] sm:w-[320px] md:w-[360px] bg-[var(--card-bg)]/95 rounded-3xl shadow-2xl border border-[var(--border)] overflow-hidden hover:shadow-3xl hover:scale-105 hover:border-[var(--primary)]/60 transition-all duration-200"
+      style={{ backdropFilter: "blur(5px) saturate(1.1)" }}
+    >
+      {showEdit && hasRole(user?.role, "world builder") && (
+        <div className="absolute right-5 top-5 z-30 flex flex-col gap-3 items-center">
+          <button
+            className="p-3 bg-white/70 border border-[var(--primary)] rounded-xl shadow hover:bg-[var(--primary)]/20 hover:scale-110 transition"
+            title="Edit"
+            onClick={() => onEdit(world)}
+          >
+            <FaEdit className="text-[var(--primary)]" />
+          </button>
+          <button
+            className="p-3 bg-white/70 border border-red-300 rounded-xl shadow hover:bg-red-100 hover:scale-110 transition"
+            title="Delete"
+            onClick={() => onDelete(world)}
+          >
+            <FaTrash className="text-red-500" />
+          </button>
+        </div>
+      )}
+      <a href={`/${linkURL}/${world.id}`} className="block w-full h-full">
+        <div className="relative w-full h-48 sm:h-56 md:h-52">
+          <Image
+            src={world.logo || "/images/worlds/new_game.png"}
+            alt={world.name}
+            fill
+            className="object-cover object-center"
+          />
+        </div>
+        <div className="bg-[var(--background)]/60 backdrop-blur-xl p-4 flex flex-col items-center">
+          <h3 className="text-lg font-bold text-[var(--primary)] mb-1 text-center break-words">
+            {world.name}
+          </h3>
+          <div className="flex gap-3 text-xs text-[var(--foreground)]/80">
+            {isLoading ? (
+              <span>Loading...</span>
+            ) : (
+              <>
+                <span>{conceptCount} concept{conceptCount === 1 ? "" : "s"}</span>
+                <span>{pagesCount} page{pagesCount === 1 ? "" : "s"}</span>
+              </>
+            )}
+          </div>
+        </div>
+      </a>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `WorldCard` component to display individual world stats
- modernize `DashboardWorlds` to use the new card design

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b1d3aa4ec8322aa62e26d9c4e426c