### PR TITLE
Fix chromadb persistence

### DIFF
--- a/backend/chromadb/__init__.py
+++ b/backend/chromadb/__init__.py
@@ -1,6 +1,9 @@
 class PersistentClient:
     def __init__(self, *args, **kwargs):
         pass
+    def persist(self):
+        """Persist data to disk.  The test stub does nothing."""
+        pass
     def get_or_create_collection(self, name, **kwargs):
         class Collection:
             def add(self, *args, **kwargs):


### PR DESCRIPTION
## Summary
- ensure chromadb PersistentClient is created with a real path
- flush updates to disk when adding pages and rebuilding collections
- update chromadb test stub with persist method

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'celery')*

------
https://chatgpt.com/codex/tasks/task_e_684bd8fecd688322b8a01a6347c79dae