### PR TITLE
Improve agent chat UX and processing

### DIFF
--- a/backend/tests/test_agent.py
+++ b/backend/tests/test_agent.py
@@ -20,15 +20,13 @@ async def test_chat_endpoint(async_client, create_user, login_and_get_token):
 
     with patch("app.api.api_agent.get_agent", return_value=FakeAgent()), \
          patch("app.api.api_agent.chat_with_agent", side_effect=fake_chat):
-        async with async_client.stream(
-            "POST",
+        resp = await async_client.post(
             "/agents/1/chat",
             json=chat_payload,
             headers={"Authorization": f"Bearer {token}"},
-        ) as resp:
-            text = "".join([chunk async for chunk in resp.aiter_text()])
+        )
         assert resp.status_code == 200
-        assert text == "Hi"
+        assert resp.json()["content"] == "Hi"
 
 
 @pytest.mark.anyio
@@ -52,15 +50,13 @@ async def test_chat_history_saved(async_client, create_user, login_and_get_token
 
     with patch("app.api.api_agent.get_agent", return_value=FakeAgent()), \
          patch("app.api.api_agent.chat_with_agent", side_effect=fake_chat):
-        async with async_client.stream(
-            "POST",
+        resp = await async_client.post(
             "/agents/1/chat",
             json=payload,
             headers={"Authorization": f"Bearer {token}"},
-        ) as resp:
-            text = "".join([chunk async for chunk in resp.aiter_text()])
+        )
     assert resp.status_code == 200
-    assert text == "Hi"
+    assert resp.json()["content"] == "Hi"
 
     hist_file = tmp_path / str(user["id"]) / "1.json"
     with open(hist_file) as f:

--- a/frontend/src/app/components/template/ChatPanel.tsx
+++ b/frontend/src/app/components/template/ChatPanel.tsx
@@ -2,6 +2,7 @@
 import { FaComments } from "react-icons/fa";
 import { useState, useRef, FormEvent } from "react";
 import Image from "next/image";
+import { Loader2 } from "lucide-react";
 import { useAgents } from "../../lib/useAgents";
 import { useAuth } from "../auth/AuthProvider";
 import { chatWithAgent, ChatMessage } from "../../lib/agentAPI";
@@ -42,18 +43,19 @@ export default function ChatPanel({ open, onOpen, onClose }) {
     setInput("");
     scrollToBottom();
     setLoading(true);
-    let assistantText = "";
     setMessages(m => [...m, { role: "assistant", content: "" }]);
     try {
-      await chatWithAgent(selectedAgentId, updated, token || "", chunk => {
-        assistantText += chunk;
-        setMessages(m => {
-          const arr = [...m];
-          arr[arr.length - 1] = { role: "assistant", content: assistantText };
-          return arr;
-        });
-        scrollToBottom();
+      const assistantText = await chatWithAgent(
+        selectedAgentId,
+        updated,
+        token || ""
+      );
+      setMessages(m => {
+        const arr = [...m];
+        arr[arr.length - 1] = { role: "assistant", content: assistantText };
+        return arr;
       });
+      scrollToBottom();
     } catch {
       setMessages(m => [
         ...m.slice(0, -1),
@@ -127,7 +129,17 @@ export default function ChatPanel({ open, onOpen, onClose }) {
                       : "bg-white text-purple-800"
                   } rounded-xl px-3 py-2 shadow max-w-[80%] whitespace-pre-wrap`}
                 >
-                  {m.content}
+                  {loading &&
+                  idx === messages.length - 1 &&
+                  m.role === "assistant" &&
+                  m.content === "" ? (
+                    <span className="flex items-center gap-2">
+                      <Loader2 className="animate-spin w-4 h-4" />
+                      Wait a second, let me read about it...
+                    </span>
+                  ) : (
+                    m.content
+                  )}
                 </div>
               </div>
             ))}

--- a/frontend/src/app/lib/agentAPI.ts
+++ b/frontend/src/app/lib/agentAPI.ts
@@ -51,8 +51,7 @@ export async function deleteAgent(id: number, token: string) {
 export async function chatWithAgent(
   agentId: number,
   messages: ChatMessage[],
-  token: string,
-  onToken?: (chunk: string) => void
+  token: string
 ) {
   const res = await fetch(`${API_URL}/agents/${agentId}/chat`, {
     method: "POST",
@@ -65,18 +64,8 @@ export async function chatWithAgent(
 
   if (!res.ok) throw await res.text();
 
-  const reader = res.body?.getReader();
-  if (!reader) return "";
-  const decoder = new TextDecoder();
-  let result = "";
-  while (true) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    const chunk = decoder.decode(value);
-    result += chunk;
-    onToken?.(chunk);
-  }
-  return result;
+  const data = await res.json();
+  return data.content || "";
 }
 
 export async function chatTest(


### PR DESCRIPTION
## Summary
- finalize agent responses server-side before sending to clients
- adjust tests for non-streaming chat
- update `chatWithAgent` API helper
- show spinner while agent reads message in ChatPanel

## Testing
- `pip install -q httpx pytest pytest-asyncio`
- `pip install -q sqlmodel sqlalchemy aiosqlite pytest-cov fastapi 'pydantic>=2' aiofiles httpcore starlette uvicorn jinja2 bcrypt passlib email_validator python-multipart cryptography python-jose`
- `pip install -q requests`
- `pip install -q beautifulsoup4`
- `pip install -q langchain_openai langgraph chromadb sentence_transformers`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain_openai')*

------
https://chatgpt.com/codex/tasks/task_e_684bf7f9b5288322bbd32b05be1b150e