### PR TITLE
Process full agent chat response

### DIFF
--- a/backend/app/api/api_agent.py
+++ b/backend/app/api/api_agent.py
@@ -42,10 +42,7 @@ async def chat(
     history = crud_chat_history.load_history(user.id, agent_id)
     user_msg = msgs[-1] if msgs else {"role": "user", "content": ""}
     chat_messages = history + [user_msg]
-    assistant_text = ""
-
-    async for token in chat_with_agent(session, agent_id, chat_messages):
-        assistant_text += token
+    assistant_text = await chat_with_agent(session, agent_id, chat_messages)
 
     new_history = (
         history + [user_msg, {"role": "assistant", "content": assistant_text}]

--- a/backend/tests/test_agent.py
+++ b/backend/tests/test_agent.py
@@ -16,7 +16,7 @@ async def test_chat_endpoint(async_client, create_user, login_and_get_token):
         vector_db_update_date = datetime.now(timezone.utc)
 
     async def fake_chat(session, agent_id, messages):
-        yield "Hi"
+        return "Hi"
 
     with patch("app.api.api_agent.get_agent", return_value=FakeAgent()), \
          patch("app.api.api_agent.chat_with_agent", side_effect=fake_chat):
@@ -46,7 +46,7 @@ async def test_chat_history_saved(async_client, create_user, login_and_get_token
         vector_db_update_date = datetime.now(timezone.utc)
 
     async def fake_chat(session, agent_id, messages):
-        yield "Hi"
+        return "Hi"
 
     with patch("app.api.api_agent.get_agent", return_value=FakeAgent()), \
          patch("app.api.api_agent.chat_with_agent", side_effect=fake_chat):


### PR DESCRIPTION
## Summary
- modify `chat_with_agent` to return the full text response instead of streaming tokens
- update API endpoint to use the new return value
- adjust tests for the non-streaming behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684bfcbe1ce08322b5b2e6422ba86f6a