### PR TITLE
Improve chat history and link handling

### DIFF
--- a/frontend/src/app/lib/agentAPI.ts
+++ b/frontend/src/app/lib/agentAPI.ts
@@ -84,3 +84,12 @@ export async function chatTest(
   if (!res.ok) throw await res.json();
   return await res.json();
 }
+
+export async function getChatHistory(agentId: number, token: string) {
+  const res = await fetch(`${API_URL}/agents/${agentId}/history`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) throw await res.text();
+  const data = await res.json();
+  return data.messages || [];
+}


### PR DESCRIPTION
## Summary
- fetch last messages when selecting an agent in ChatPanel
- parse `[Link for this page: ...]` notes into clickable links
- expose `getChatHistory` helper on the frontend API

## Testing
- `npm run lint` *(fails: '@typescript-eslint/no-unused-vars' and other errors)*
- `pytest -q` *(failed to run due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684c040ca6c483229d819a28e8170dd1