### PR TITLE
Restrict chat panel agents & task dropdown

### DIFF
--- a/frontend/src/app/components/agents/AgentModal.tsx
+++ b/frontend/src/app/components/agents/AgentModal.tsx
@@ -144,11 +144,21 @@ export default function AgentModal({ agent, onClose, onSave, onDelete, worlds })
           value={form.personality}
           onChange={e => setForm(f => ({ ...f, personality: e.target.value }))}
         />
-        <M3FloatingInput
-          label="Task"
-          value={form.task}
-          onChange={e => setForm(f => ({ ...f, task: e.target.value }))}
-        />
+        <div className="relative">
+          <select
+            className="peer w-full px-4 pt-6 pb-2 text-[var(--foreground)] bg-[var(--surface)] border-2 border-[var(--border)] rounded-xl outline-none focus:border-[var(--primary)] transition-colors text-base"
+            value={form.task}
+            onChange={e => setForm(f => ({ ...f, task: e.target.value }))}
+            required
+          >
+            <option value="conversational">conversational</option>
+            <option value="page writer">page writer</option>
+            <option value="story novelist">story novelist</option>
+          </select>
+          <label className="absolute left-3 top-1.5 text-base text-[var(--primary)] font-semibold pointer-events-none">
+            Task
+          </label>
+        </div>
         <div className="relative">
           <select
             className="peer w-full px-4 pt-6 pb-2 text-[var(--foreground)] bg-[var(--surface)] border-2 border-[var(--border)] rounded-xl outline-none focus:border-[var(--primary)] transition-colors text-base"

--- a/frontend/src/app/components/template/ChatPanel.tsx
+++ b/frontend/src/app/components/template/ChatPanel.tsx
@@ -27,7 +27,9 @@ export default function ChatPanel({ open, onOpen, onClose }) {
   const { agents, isLoading: agentsLoading } = useAgents();
   const { token } = useAuth();
   const messagesEndRef = useRef<HTMLDivElement>(null);
-  const availableAgents = agents.filter(a => a.vector_db_update_date);
+  const availableAgents = agents.filter(
+    a => a.vector_db_update_date && a.task === "conversational"
+  );
   const selectedAgent =
     selectedAgentId !== null
       ? agents.find(a => a.id === selectedAgentId)


### PR DESCRIPTION
## Summary
- filter agents in ChatPanel to only show those with task `"conversational"`
- use a dropdown for the Agent task field with three predefined options

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_684c0b2dfb488322a29aa93028eb1390