### PR TITLE
Improve writer agent UI and suggestion dedupe

### DIFF
--- a/backend/app/crud/crud_page_analysis.py
+++ b/backend/app/crud/crud_page_analysis.py
@@ -2,6 +2,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from langchain_openai import ChatOpenAI
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from langchain_core.prompts import ChatPromptTemplate
+from typing import Dict, List
 
 from app.config import settings
 from app.models.model_page import Page
@@ -10,9 +11,37 @@ from app.models.model_concept import Concept
 from app.crud import crud_page, crud_concept
 
 
+def _valid_name(name: str) -> bool:
+    if not name:
+        return False
+    n = name.lower()
+    invalid = ["not explicitly", "not mentioned", "no extra", "não há menção", "nao ha mencao", "none"]
+    for term in invalid:
+        if term in n:
+            return False
+    return True
+
+
+async def _choose_concept(llm: ChatOpenAI, name: str, content: str, options: List[Concept]) -> str:
+    prompt = ChatPromptTemplate.from_messages([
+        ("system", "Choose the most appropriate concept for the given name. Respond with the concept name only."),
+        (
+            "user",
+            "Name: {name}\nOptions: {opts}\nExcerpt: {text}\nAnswer with only one concept name.",
+        ),
+    ])
+    opts = "; ".join([f"{c.name}: {c.description or ''}" for c in options])
+    chain = prompt | llm
+    resp = await chain.ainvoke({"name": name, "opts": opts, "text": content[:1000]})
+    return resp.content.strip()
+
+
 async def analyze_page(session: AsyncSession, agent: Agent, page: Page):
     """Analyze page content and return concept-based page suggestions."""
-    concepts = await crud_concept.get_concepts(session, gameworld_id=page.gameworld_id, auto_generated=True)
+    concepts = await crud_concept.get_concepts(
+        session, gameworld_id=page.gameworld_id, auto_generated=True
+    )
+    concepts_by_id: Dict[int, Concept] = {c.id: c for c in concepts}
     existing_pages = await crud_page.get_pages(session, gameworld_id=page.gameworld_id)
     page_map = {(p.concept_id, p.name.lower()): True for p in existing_pages}
 
@@ -21,12 +50,15 @@ async def analyze_page(session: AsyncSession, agent: Agent, page: Page):
 
     llm = ChatOpenAI(api_key=settings.openai_api_key or "sk-test", model=settings.open_ai_model)
 
-    suggestions: list[dict] = []
+    suggestions_by_name: Dict[str, List[dict]] = {}
     for concept in concepts:
         found: set[str] = set()
         prompt = ChatPromptTemplate.from_messages([
-            ("system", f"List all unique {concept.name} mentioned in the text. {concept.description or ''} Return a comma separated list."),
-            ("user", "{text}")
+            (
+                "system",
+                f"List all unique {concept.name} mentioned in the text. {concept.description or ''} Return a comma separated list.",
+            ),
+            ("user", "{text}"),
         ])
         chain = prompt | llm
         for chunk in docs:
@@ -34,12 +66,26 @@ async def analyze_page(session: AsyncSession, agent: Agent, page: Page):
             names = [n.strip() for n in resp.content.split(',') if n.strip()]
             found.update(names)
         for name in sorted(found):
+            if not _valid_name(name):
+                continue
             exists = (concept.id, name.lower()) in page_map
-            suggestions.append({
+            entry = {
                 "name": name,
                 "concept_id": concept.id,
                 "concept": concept.name,
                 "exists": exists,
-            })
-    return {"suggestions": suggestions}
+            }
+            suggestions_by_name.setdefault(name, []).append(entry)
+
+    final_suggestions: List[dict] = []
+    for name, entries in suggestions_by_name.items():
+        if len(entries) == 1:
+            final_suggestions.append(entries[0])
+            continue
+        option_concepts = [concepts_by_id[e["concept_id"]] for e in entries]
+        best = await _choose_concept(llm, name, page.content or "", option_concepts)
+        chosen = next((e for e in entries if e["concept"] == best), entries[0])
+        final_suggestions.append(chosen)
+
+    return {"suggestions": final_suggestions}
 

--- a/frontend/src/app/agent_writer/[agentID]/[pageID]/page.tsx
+++ b/frontend/src/app/agent_writer/[agentID]/[pageID]/page.tsx
@@ -8,6 +8,8 @@ import { usePageById } from "../../../lib/usePageById";
 import { useAgentById } from "../../../lib/useAgentById";
 import { analyzePageWithAgent } from "../../../lib/agentAPI";
 import Image from "next/image";
+import TabMenu from "../../../components/world_builder/TabMenu";
+import { Loader2 } from "lucide-react";
 
 export default function PageAnalyze() {
   const { agentID, pageID } = useParams();
@@ -16,9 +18,11 @@ export default function PageAnalyze() {
   const { agent } = useAgentById(Number(agentID));
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<any>(null);
+  const [activeTab, setActiveTab] = useState<"content" | "suggestions">("content");
 
   async function handleAnalyze() {
     if (!agentID || !pageID || !token) return;
+    setActiveTab("suggestions");
     setLoading(true);
     try {
       const data = await analyzePageWithAgent(Number(agentID), Number(pageID), token);
@@ -42,27 +46,53 @@ export default function PageAnalyze() {
               </div>
             )}
             {page && (
-              <div className="flex gap-4">
-                <div className="flex-1">
-                  <h2 className="text-lg font-semibold mb-2">{page.name}</h2>
-                  <div className="prose prose-invert" dangerouslySetInnerHTML={{ __html: page.content }} />
-                </div>
-                <div className="w-48 shrink-0 flex flex-col items-start gap-2">
-                  <button onClick={handleAnalyze} disabled={loading} className="px-3 py-2 rounded-xl bg-[var(--primary)] text-[var(--primary-foreground)] hover:bg-[var(--accent)] disabled:opacity-50">
-                    {loading ? "Processing..." : `Ask ${agent?.name}`}
+              <div className="flex flex-col gap-4">
+                <h2 className="text-lg font-semibold">{page.name}</h2>
+                <div className="flex items-center justify-between">
+                  <TabMenu
+                    activeTab={activeTab}
+                    onTabChange={(t) => setActiveTab(t as "content" | "suggestions")}
+                    tabs={[
+                      { value: "content", label: "Content" },
+                      { value: "suggestions", label: "Suggestions" },
+                    ]}
+                  />
+                  <button
+                    onClick={handleAnalyze}
+                    disabled={loading}
+                    className="px-3 py-2 rounded-xl bg-[var(--primary)] text-[var(--primary-foreground)] hover:bg-[var(--accent)] disabled:opacity-50 ml-4"
+                  >
+                    {loading ? (
+                      <span className="flex items-center gap-2"><Loader2 className="w-4 h-4 animate-spin" /> Loading</span>
+                    ) : (
+                      `Ask ${agent?.name}`
+                    )}
                   </button>
-                  {result && (
-                    <div className="text-sm mt-2">
-                      <h3 className="font-semibold mb-1">Suggestions</h3>
-                      {result.suggestions?.map((s:any, idx:number) => (
-                        <div key={idx} className="flex items-center justify-between border-b border-[var(--border)] py-1">
-                          <span>{s.name} ({s.concept})</span>
-                          <span className="text-xs text-[var(--foreground)]/70">{s.exists ? "existing" : "new"}</span>
-                        </div>
-                      ))}
-                    </div>
-                  )}
                 </div>
+
+                {activeTab === "content" && (
+                  <div className="prose prose-invert" dangerouslySetInnerHTML={{ __html: page.content }} />
+                )}
+
+                {activeTab === "suggestions" && (
+                  <div className="text-sm mt-2 min-h-[60px]">
+                    {loading && (
+                      <div className="flex justify-center py-4"><Loader2 className="w-5 h-5 animate-spin" /></div>
+                    )}
+                    {!loading && result && (
+                      <>
+                        <h3 className="font-semibold mb-1">Suggestions</h3>
+                        {result.suggestions?.map((s:any, idx:number) => (
+                          <div key={idx} className="flex items-center justify-between border-b border-[var(--border)] py-1">
+                            <span>{s.name} ({s.concept})</span>
+                            <span className="text-xs text-[var(--foreground)]/70">{s.exists ? "existing" : "new"}</span>
+                          </div>
+                        ))}
+                        {result.suggestions?.length === 0 && <div>No suggestions.</div>}
+                      </>
+                    )}
+                  </div>
+                )}
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- show page content and agent suggestions in tabs
- add loader icon when fetching suggestions
- deduplicate page suggestions in backend using LLM and filter noisy items

## Testing
- `pytest -q` *(fails: ImportError: No module named 'pydantic_settings')*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684c267c99948322b680f6177dfb4b77