### PR TITLE
Improve Elder chat width and history clearing

### DIFF
--- a/backend/app/api/api_agent.py
+++ b/backend/app/api/api_agent.py
@@ -60,6 +60,13 @@ async def chat_history(agent_id: int, user: User = Depends(get_current_user)):
     return {"messages": messages[-20:]}
 
 
+@router.delete("/{agent_id}/history")
+async def clear_chat_history(agent_id: int, user: User = Depends(get_current_user)):
+    """Remove all stored chat messages between the current user and this agent."""
+    crud_chat_history.clear_history(user.id, agent_id)
+    return {"ok": True}
+
+
 @router.post("/{agent_id}/chat_test")
 async def chat_test(
     agent_id: int,

--- a/backend/app/crud/crud_chat_history.py
+++ b/backend/app/crud/crud_chat_history.py
@@ -29,3 +29,13 @@ def save_history(user_id: int, agent_id: int, messages: list[dict]) -> None:
     file_path = _history_path(user_id, agent_id)
     with open(file_path, "w") as f:
         json.dump(messages, f)
+
+
+def clear_history(user_id: int, agent_id: int) -> None:
+    """Delete chat history for a user and agent if it exists."""
+    file_path = _history_path(user_id, agent_id)
+    if file_path.is_file():
+        try:
+            file_path.unlink()
+        except Exception:
+            pass

--- a/backend/tests/test_agent.py
+++ b/backend/tests/test_agent.py
@@ -75,6 +75,45 @@ async def test_chat_history_saved(async_client, create_user, login_and_get_token
 
 
 @pytest.mark.anyio
+async def test_clear_chat_history(async_client, create_user, login_and_get_token, tmp_path):
+    from app.config import settings
+
+    settings.chat_history_dir = str(tmp_path / "{user_id}")
+
+    user = await create_user("clear@test.com", "pass", "writer")
+    token = await login_and_get_token("clear@test.com", "pass", "writer")
+
+    payload = {"messages": [{"role": "user", "content": "Hello"}]}
+
+    class FakeAgent:
+        world_id = 1
+        personality = "kind"
+        vector_db_update_date = datetime.now(timezone.utc)
+
+    async def fake_chat(session, agent_id, messages):
+        return "Hi"
+
+    with patch("app.api.api_agent.get_agent", return_value=FakeAgent()), \
+         patch("app.api.api_agent.chat_with_agent", side_effect=fake_chat):
+        await async_client.post(
+            "/agents/1/chat",
+            json=payload,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    hist_file = tmp_path / str(user["id"]) / "1.json"
+    assert hist_file.is_file()
+
+    resp = await async_client.delete(
+        "/agents/1/history",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+    assert not hist_file.exists()
+
+
+@pytest.mark.anyio
 async def test_chat_test_endpoint(async_client, create_user, login_and_get_token):
     await create_user("agent@test2.com", "pass", "writer")
     token = await login_and_get_token("agent@test2.com", "pass", "writer")

--- a/frontend/src/app/elders/[id]/page.tsx
+++ b/frontend/src/app/elders/[id]/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef, FormEvent } from "react";
 import DashboardLayout from "../../components/DashboardLayout";
 import AuthGuard from "../../components/auth/AuthGuard";
 import { useAgentById } from "../../lib/useAgentById";
-import { chatWithAgent, getChatHistory, ChatMessage } from "../../lib/agentAPI";
+import { chatWithAgent, getChatHistory, clearChatHistory, ChatMessage } from "../../lib/agentAPI";
 import { useAuth } from "../../components/auth/AuthProvider";
 import Image from "next/image";
 import Link from "next/link";
@@ -67,8 +67,18 @@ export default function ElderChatPage() {
     setLoading(false);
   }
 
-  function clearMessages() {
-    setMessages([]);
+  async function clearMessages() {
+    if (!id) return;
+    const confirmed = window.confirm(
+      "This will permanently delete your chat history with this Elder. Continue?"
+    );
+    if (!confirmed) return;
+    try {
+      await clearChatHistory(id, token || "");
+      setMessages([]);
+    } catch (e) {
+      console.error(e);
+    }
   }
 
   function renderMessageContent(text: string) {
@@ -99,7 +109,7 @@ export default function ElderChatPage() {
     <AuthGuard>
       <DashboardLayout>
         <div className="min-h-screen w-full bg-[var(--background)] text-[var(--foreground)] px-2 sm:px-6 py-8">
-          <div className="max-w-2xl mx-auto flex flex-col h-[calc(100vh-160px)]">
+          <div className="w-full sm:w-[80%] mx-auto flex flex-col h-[calc(100vh-160px)]">
             <div className="flex items-center gap-3 mb-4">
               {agent && (
                 <Image src={agent.logo || "/images/default/avatars/logo.png"} alt={agent.name} width={48} height={48} className="w-12 h-12 rounded-full object-cover border border-[var(--primary)]" />
@@ -107,7 +117,12 @@ export default function ElderChatPage() {
               <h1 className="text-2xl font-serif font-bold text-[var(--primary)] flex-1 truncate">
                 {agent ? agent.name : "..."}
               </h1>
-              <button onClick={clearMessages} className="text-sm text-[var(--primary)] hover:underline">Clear all</button>
+              <button
+                onClick={clearMessages}
+                className="ml-auto px-3 py-1 text-sm rounded-lg bg-red-600 text-white hover:bg-red-700"
+              >
+                Clear chat
+              </button>
             </div>
             <div className="flex-1 overflow-y-auto space-y-4 mb-2 border border-[var(--border)] rounded-xl p-3 bg-[var(--surface)]">
               {messages.map((m, idx) => (

--- a/frontend/src/app/lib/agentAPI.ts
+++ b/frontend/src/app/lib/agentAPI.ts
@@ -102,6 +102,15 @@ export async function getChatHistory(agentId: number, token: string) {
   return data.messages || [];
 }
 
+export async function clearChatHistory(agentId: number, token: string) {
+  const res = await fetch(`${API_URL}/agents/${agentId}/history`, {
+    method: "DELETE",
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) throw await res.text();
+  return await res.json();
+}
+
 export async function analyzePageWithAgent(
   agentId: number,
   pageId: number,


### PR DESCRIPTION
## Summary
- add clear_history helper to CRUD layer
- expose DELETE /agents/{id}/history API
- test chat history clearing
- add clearChatHistory API call in frontend
- widen chat UI and enhance Clear chat button

## Testing
- `npm --prefix frontend run lint` *(fails: `next` not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain_openai')*

------
https://chatgpt.com/codex/tasks/task_e_684c6a41a9648322bb420951b8cebab9