### PR TITLE
Fix infinite loop on page creation

### DIFF
--- a/frontend/src/app/components/create_page/CreatePageForm.tsx
+++ b/frontend/src/app/components/create_page/CreatePageForm.tsx
@@ -18,6 +18,8 @@ type PageFormValues = {
   [key: string]: unknown;
 };
 
+const EMPTY_VALUES: PageFormValues = {};
+
 interface PageFormProps {
   selectedWorld: unknown;
   selectedConcept: unknown;
@@ -33,7 +35,7 @@ export default function PageForm({
   selectedConcept,
   token,
   onSuccess,
-  initialValues = {},
+  initialValues = EMPTY_VALUES,
   onSubmit,
   mode = "create"
 }: PageFormProps) {


### PR DESCRIPTION
## Summary
- avoid recreating default props in `CreatePageForm`

## Testing
- `npm run lint` *(fails: several lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ca81b6b088322b1338ead32650a29