### PR TITLE
Improve agents settings page

### DIFF
--- a/frontend/src/app/agents_settings/page.tsx
+++ b/frontend/src/app/agents_settings/page.tsx
@@ -19,7 +19,7 @@ export default function AgentsSettingsPage() {
   const [modalOpen, setModalOpen] = useState(false);
   const [selectedAgent, setSelectedAgent] = useState(null);
   const [success, setSuccess] = useState("");
-  const [vdbLoading, setVdbLoading] = useState(false);
+  const [updatingAgentId, setUpdatingAgentId] = useState<number | null>(null);
 
   if (!hasRole(user?.role, "world builder") && !hasRole(user?.role, "system admin")) {
     return (
@@ -58,7 +58,7 @@ export default function AgentsSettingsPage() {
   }
 
   async function handleRebuild(agent) {
-    setVdbLoading(true);
+    setUpdatingAgentId(agent.id);
     try {
       const pages = await getPagesForWorld(agent.world_id, token || "");
       const pageCount = pages.length;
@@ -67,7 +67,7 @@ export default function AgentsSettingsPage() {
         `Rebuilding the vector DB will add ${pageCount} pages and may take around ${estimated} seconds. Continue?`
       );
       if (!proceed) {
-        setVdbLoading(false);
+        setUpdatingAgentId(null);
         return;
       }
       const res = await rebuildVectorDB(token || "", agent.world_id);
@@ -76,7 +76,7 @@ export default function AgentsSettingsPage() {
     } catch (err) {
       setSuccess("Failed to rebuild vector DB");
     } finally {
-      setVdbLoading(false);
+      setUpdatingAgentId(null);
       setTimeout(() => setSuccess(""), 2000);
     }
   }
@@ -121,6 +121,7 @@ export default function AgentsSettingsPage() {
                   setModalOpen(true);
                 }}
                 onRebuild={handleRebuild}
+                updatingAgentId={updatingAgentId}
               />
             )}
           </div>

--- a/frontend/src/app/components/agents/AgentGrid.tsx
+++ b/frontend/src/app/components/agents/AgentGrid.tsx
@@ -1,6 +1,19 @@
 import Image from "next/image";
+import { Loader2 } from "lucide-react";
 
-export default function AgentGrid({ agents, onEdit, onDelete, onRebuild }) {
+export default function AgentGrid({
+  agents,
+  onEdit,
+  onDelete,
+  onRebuild,
+  updatingAgentId,
+}: {
+  agents: any[];
+  onEdit: (a: any) => void;
+  onDelete: (a: any) => void;
+  onRebuild: (a: any) => void;
+  updatingAgentId?: number | null;
+}) {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
       {agents.map(agent => (
@@ -40,12 +53,21 @@ export default function AgentGrid({ agents, onEdit, onDelete, onRebuild }) {
               Delete
             </button>
           </div>
-          <button
-            className="mt-3 px-4 py-1 rounded-lg border border-[var(--primary)] text-[var(--primary)] text-sm hover:bg-[var(--primary)] hover:text-[var(--primary-foreground)] transition"
-            onClick={() => onRebuild(agent)}
-          >
-            Update Vector DB
-          </button>
+          {agent.task === "conversational" && (
+            updatingAgentId === agent.id ? (
+              <div className="mt-3 flex items-center gap-2 text-sm text-[var(--primary)]">
+                <Loader2 className="w-4 h-4 animate-spin" />
+                Wait, I am updating the vector db...
+              </div>
+            ) : (
+              <button
+                className="mt-3 px-4 py-1 rounded-lg border border-[var(--primary)] text-[var(--primary)] text-sm hover:bg-[var(--primary)] hover:text-[var(--primary-foreground)] transition"
+                onClick={() => onRebuild(agent)}
+              >
+                Update Vector DB
+              </button>
+            )
+          )}
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- show vector DB update button only for conversational agents
- show spinner per agent while updating vector DB

## Testing
- `pytest -q` *(fails: ImportError: Could not import sentence_transformers)*

------
https://chatgpt.com/codex/tasks/task_e_684d709bc3bc83228d005f5a0678fba2