### PR TITLE
Add concept info in agent writer review

### DIFF
--- a/frontend/src/app/agent_writer/[agentID]/[pageID]/page.tsx
+++ b/frontend/src/app/agent_writer/[agentID]/[pageID]/page.tsx
@@ -559,6 +559,24 @@ export default function PageAnalyze() {
                         </div>
                       )}
 
+                    {concepts && (
+                        (() => {
+                          const c = concepts.find((con: any) => con.id === generatedPages[activeGen].concept_id);
+                          return c ? (
+                            <div className="flex items-center gap-3 mb-4">
+                              <Image
+                                src={c.logo || "/images/default/concepts/logo.png"}
+                                alt={c.name}
+                                width={48}
+                                height={48}
+                                className="rounded border border-[var(--primary)] object-cover"
+                              />
+                              <span className="font-semibold text-lg text-[var(--primary)]">{c.name}</span>
+                            </div>
+                          ) : null;
+                        })()
+                      )}
+
                     <CreatePageForm
                         selectedWorld={world}
                         selectedConcept={concepts?.find((c: any) => c.id === generatedPages[activeGen].concept_id)}


### PR DESCRIPTION
## Summary
- show the concept logo and name before the page form in the agent writer flow

## Testing
- `npm run lint` *(fails: `next` not found)*
- `pytest -q` *(fails: network access to huggingface blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684d922b9cd48322a506176524830ef4