### PR TITLE
Improve chat output with page sources

### DIFF
--- a/backend/app/api/api_agent.py
+++ b/backend/app/api/api_agent.py
@@ -44,14 +44,22 @@ async def chat(
     history = crud_chat_history.load_history(user.id, agent_id)
     user_msg = msgs[-1] if msgs else {"role": "user", "content": ""}
     chat_messages = history + [user_msg]
-    assistant_text = await chat_with_agent(session, agent_id, chat_messages)
+    assistant_resp = await chat_with_agent(session, agent_id, chat_messages)
 
     new_history = (
-        history + [user_msg, {"role": "assistant", "content": assistant_text}]
+        history
+        + [
+            user_msg,
+            {
+                "role": "assistant",
+                "content": assistant_resp["answer"],
+                "sources": assistant_resp["sources"],
+            },
+        ]
     )[-20:]
     crud_chat_history.save_history(user.id, agent_id, new_history)
 
-    return JSONResponse({"content": assistant_text})
+    return JSONResponse(assistant_resp)
 
 
 @router.get("/{agent_id}/history")

--- a/backend/app/crud/crud_vectordb.py
+++ b/backend/app/crud/crud_vectordb.py
@@ -110,6 +110,7 @@ async def add_page(session: AsyncSession, page_id: int):
         "page_id": page.id,
         "gameworld_id": page.gameworld_id,
         "concept_id": page.concept_id,
+        "title": page.name,
     }
 
     # print (f" --- API VECTORDB - Adding this document: {document}")

--- a/backend/tests/test_agent.py
+++ b/backend/tests/test_agent.py
@@ -16,7 +16,7 @@ async def test_chat_endpoint(async_client, create_user, login_and_get_token):
         vector_db_update_date = datetime.now(timezone.utc)
 
     async def fake_chat(session, agent_id, messages):
-        return "Hi"
+        return {"answer": "Hi", "sources": []}
 
     with patch("app.api.api_agent.get_agent", return_value=FakeAgent()), \
          patch("app.api.api_agent.chat_with_agent", side_effect=fake_chat):
@@ -26,7 +26,7 @@ async def test_chat_endpoint(async_client, create_user, login_and_get_token):
             headers={"Authorization": f"Bearer {token}"},
         )
         assert resp.status_code == 200
-        assert resp.json()["content"] == "Hi"
+        assert resp.json()["answer"] == "Hi"
 
 
 @pytest.mark.anyio
@@ -46,7 +46,7 @@ async def test_chat_history_saved(async_client, create_user, login_and_get_token
         vector_db_update_date = datetime.now(timezone.utc)
 
     async def fake_chat(session, agent_id, messages):
-        return "Hi"
+        return {"answer": "Hi", "sources": []}
 
     with patch("app.api.api_agent.get_agent", return_value=FakeAgent()), \
          patch("app.api.api_agent.chat_with_agent", side_effect=fake_chat):
@@ -56,7 +56,7 @@ async def test_chat_history_saved(async_client, create_user, login_and_get_token
             headers={"Authorization": f"Bearer {token}"},
         )
     assert resp.status_code == 200
-    assert resp.json()["content"] == "Hi"
+    assert resp.json()["answer"] == "Hi"
 
     hist_file = tmp_path / str(user["id"]) / "1.json"
     with open(hist_file) as f:
@@ -91,7 +91,7 @@ async def test_clear_chat_history(async_client, create_user, login_and_get_token
         vector_db_update_date = datetime.now(timezone.utc)
 
     async def fake_chat(session, agent_id, messages):
-        return "Hi"
+        return {"answer": "Hi", "sources": []}
 
     with patch("app.api.api_agent.get_agent", return_value=FakeAgent()), \
          patch("app.api.api_agent.chat_with_agent", side_effect=fake_chat):

--- a/frontend/src/app/lib/agentAPI.ts
+++ b/frontend/src/app/lib/agentAPI.ts
@@ -1,8 +1,11 @@
 import { API_URL } from "./config";
 
+export type SourceLink = { title: string; url: string };
+
 export type ChatMessage = {
   role: "system" | "user" | "assistant";
   content: string;
+  sources?: SourceLink[];
 };
 
 export async function getAgents(
@@ -73,7 +76,7 @@ export async function chatWithAgent(
   if (!res.ok) throw await res.text();
 
   const data = await res.json();
-  return data.content || "";
+  return data as { answer: string; sources: SourceLink[] };
 }
 
 export async function chatTest(


### PR DESCRIPTION
## Summary
- return structured answers from chat agent including source links
- ensure at least five pages are considered for context
- index page titles in vector metadata
- adjust API responses and history storage
- update frontend chat components to display source links
- extend tests for new answer format

## Testing
- `pip install -r backend/requirements.txt`
- `pip install 'pydantic[email]'`
- `pip install sentence-transformers`
- `pytest -q` *(fails: ProxyError when downloading model)*

------
https://chatgpt.com/codex/tasks/task_e_684dbf9ce7dc832296388ef712096275