### PR TITLE
Display page name for chat sources with preview

### DIFF
--- a/frontend/src/app/components/template/ChatPanel.tsx
+++ b/frontend/src/app/components/template/ChatPanel.tsx
@@ -5,12 +5,11 @@ import Image from "next/image";
 import { Loader2 } from "lucide-react";
 import { useAgents } from "../../lib/useAgents";
 import { useAuth } from "../auth/AuthProvider";
-import Link from "next/link";
+import WikiLinkHoverCard from "../editor/WikiLinkHoverCard";
 import {
   chatWithAgent,
   ChatMessage,
   getChatHistory,
-  SourceLink,
 } from "../../lib/agentAPI";
 
 export default function ChatPanel({ open, onOpen, onClose }) {
@@ -95,10 +94,12 @@ export default function ChatPanel({ open, onOpen, onClose }) {
           </span>
         ))}
         {msg.sources && msg.sources.length > 0 && (
-          <ul className="mt-1 text-xs text-purple-600 underline space-y-1">
+          <ul className="mt-1 text-xs space-y-1">
             {msg.sources.map((s) => (
               <li key={s.url}>
-                <Link href={s.url}>{s.title}</Link>
+                <WikiLinkHoverCard href={s.url}>
+                  {`<link ${s.title}>`}
+                </WikiLinkHoverCard>
               </li>
             ))}
           </ul>

--- a/frontend/src/app/elders/[id]/page.tsx
+++ b/frontend/src/app/elders/[id]/page.tsx
@@ -4,10 +4,10 @@ import { useState, useEffect, useRef, FormEvent } from "react";
 import DashboardLayout from "../../components/DashboardLayout";
 import AuthGuard from "../../components/auth/AuthGuard";
 import { useAgentById } from "../../lib/useAgentById";
-import { chatWithAgent, getChatHistory, clearChatHistory, ChatMessage, SourceLink } from "../../lib/agentAPI";
+import { chatWithAgent, getChatHistory, clearChatHistory, ChatMessage } from "../../lib/agentAPI";
 import { useAuth } from "../../components/auth/AuthProvider";
 import Image from "next/image";
-import Link from "next/link";
+import WikiLinkHoverCard from "../../components/editor/WikiLinkHoverCard";
 import { Loader2 } from "lucide-react";
 
 interface Message extends ChatMessage { time: Date }
@@ -96,12 +96,12 @@ export default function ElderChatPage() {
           </span>
         ))}
         {msg.sources && msg.sources.length > 0 && (
-          <ul className="mt-1 text-xs text-[var(--primary)] underline space-y-1">
+          <ul className="mt-1 text-xs space-y-1">
             {msg.sources.map((s) => (
               <li key={s.url}>
-                <Link href={s.url} className="wiki-link">
-                  {s.title}
-                </Link>
+                <WikiLinkHoverCard href={s.url}>
+                  {`<link ${s.title}>`}
+                </WikiLinkHoverCard>
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary
- show page name using `<link ...>` format in source references
- wrap source references with `WikiLinkHoverCard` to preview pages on hover

## Testing
- `npm run lint` *(fails: various ESLint errors)*
- `pytest -q` *(fails: ImportError for email-validator)*

------
https://chatgpt.com/codex/tasks/task_e_684dc5e141088322a8b9e831f5baf83b