### PR TITLE
Add bulk page processing

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -9,6 +9,7 @@ class Settings(BaseSettings):
     open_ai_model:str | None = None
     vector_db_path: str = "./data/vector_db"
     chat_history_dir: str = "./data/chat/{user_id}"
+    bulk_job_dir: str = "./data/bulk_jobs"
     model_config = SettingsConfigDict(env_file=".env")
 
 settings = Settings()

--- a/frontend/src/app/agent_writer/[agentID]/bulk_review/[jobID]/page.tsx
+++ b/frontend/src/app/agent_writer/[agentID]/bulk_review/[jobID]/page.tsx
@@ -1,0 +1,43 @@
+"use client";
+import { useParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import DashboardLayout from "../../../components/DashboardLayout";
+import AuthGuard from "../../../components/auth/AuthGuard";
+import { useAuth } from "../../../components/auth/AuthProvider";
+import { getBulkJob } from "../../../lib/agentAPI";
+
+export default function BulkReview() {
+  const { agentID, jobID } = useParams();
+  const { token } = useAuth();
+  const [job, setJob] = useState<any>(null);
+
+  useEffect(() => {
+    if (!jobID || !token) return;
+    getBulkJob(jobID as string, token)
+      .then((data) => setJob(data))
+      .catch((e) => console.error(e));
+  }, [jobID, token]);
+
+  const suggestions = job?.suggestions || [];
+
+  return (
+    <AuthGuard>
+      <DashboardLayout>
+        <div className="p-6 text-[var(--foreground)]">
+          <h1 className="text-2xl font-bold mb-4">Bulk Suggestions</h1>
+          {suggestions.length === 0 ? (
+            <p>No suggestions ready.</p>
+          ) : (
+            <ul className="list-disc pl-4 space-y-2">
+              {suggestions.map((s: any, idx: number) => (
+                <li key={idx}>
+                  {s.name} ({s.concept}) - from {s.source_page_name}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </DashboardLayout>
+    </AuthGuard>
+  );
+}

--- a/frontend/src/app/lib/agentAPI.ts
+++ b/frontend/src/app/lib/agentAPI.ts
@@ -143,3 +143,28 @@ export async function generatePagesWithAgent(
   if (!res.ok) throw await res.text();
   return await res.json();
 }
+
+export async function startBulkAnalyze(
+  agentId: number,
+  pageIds: number[],
+  token: string
+) {
+  const res = await fetch(`${API_URL}/agents/${agentId}/bulk_analyze`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify({ page_ids: pageIds }),
+  });
+  if (!res.ok) throw await res.text();
+  return await res.json();
+}
+
+export async function getBulkJob(jobId: string, token: string) {
+  const res = await fetch(`${API_URL}/agents/bulk_jobs/${jobId}`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) throw await res.text();
+  return await res.json();
+}


### PR DESCRIPTION
## Summary
- allow Celery jobs for bulk page analysis
- support merging suggestions when multiple pages are analyzed
- expose API endpoints to start and check bulk jobs
- wire bulk-processing UI into agent writer page
- show job status and link to review results
- add review page for bulk job results

## Testing
- `pip install -r requirements.txt -q`
- `pip install email_validator -q`
- `pytest -q` *(fails: ImportError: sentence-transformers)*

------
https://chatgpt.com/codex/tasks/task_e_684e99644d7c832281533fa8822473a3