### PR TITLE
Fix missing model_rebuild calls

### DIFF
--- a/backend/app/schemas/schema_concept.py
+++ b/backend/app/schemas/schema_concept.py
@@ -37,5 +37,9 @@ class ConceptUpdate(SQLModel):
 
 class ConceptRead(ConceptBase):
     id: int
-    pages_count: Optional[int] = 0    
+    pages_count: Optional[int] = 0
     characteristics: List["CharacteristicRead"] = []
+
+# ensure forward references are resolved at import time
+from app.schemas.schema_characteristic import CharacteristicRead
+ConceptRead.model_rebuild()

--- a/backend/app/schemas/schema_page.py
+++ b/backend/app/schemas/schema_page.py
@@ -43,3 +43,15 @@ class PageRead(PageBase):
     updated_at: Optional[datetime]
     values: List["PageCharacteristicValueRead"] = []
 
+# resolve forward references on import
+from .schema_page_characteristic_value import (
+    PageCharacteristicValueCreate,
+    PageCharacteristicValueUpdate,
+    PageCharacteristicValueRead,
+)
+
+PageCreate.model_rebuild()
+PageUpdate.model_rebuild()
+PageRead.model_rebuild()
+
+


### PR DESCRIPTION
## Summary
- ensure concept schema resolves Characteristic forward references
- ensure page schema rebuilds its forward references

## Testing
- `pytest -q` *(fails: ProxyError connecting to huggingface.co)*

------
https://chatgpt.com/codex/tasks/task_e_684ea210f5288322a15722fab8fa6ef9