### PR TITLE
Implement job tracking for vector DB updates

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -10,6 +10,7 @@ class Settings(BaseSettings):
     vector_db_path: str = "./data/vector_db"
     chat_history_dir: str = "./data/chat/{user_id}"
     bulk_job_dir: str = "./data/bulk_jobs"
+    vectordb_job_dir: str = "./data/vector_jobs"
     model_config = SettingsConfigDict(env_file=".env")
 
 settings = Settings()

--- a/backend/app/task_queue.py
+++ b/backend/app/task_queue.py
@@ -52,6 +52,8 @@ from app.api.api_agent import get_agent
 from app.crud.crud_page import get_page
 from app.database import async_session_maker
 from app.config import settings
+from app.crud import crud_vectordb
+from datetime import datetime, timezone
 import json
 from pathlib import Path
 
@@ -77,5 +79,47 @@ def task_bulk_analyze(agent_id: int, page_ids: list[int], job_id: str):
 
         with open(job_path, "w") as f:
             json.dump({"status": "done", "suggestions": suggestions}, f)
+
+    asyncio.run(run())
+
+
+@celery_app.task
+def task_rebuild_vectordb(agent_id: int, job_id: str):
+    async def run():
+        job_dir = Path(settings.vectordb_job_dir)
+        job_dir.mkdir(parents=True, exist_ok=True)
+        job_path = job_dir / f"{job_id}.json"
+        start_time = datetime.now(timezone.utc).isoformat()
+        with open(job_path, "w") as f:
+            json.dump({
+                "status": "processing",
+                "agent_id": agent_id,
+                "job_type": "update_vector_db",
+                "start_time": start_time,
+            }, f)
+
+        async with async_session_maker() as session:
+            agent = await get_agent(session, agent_id)
+            if not agent:
+                with open(job_path, "w") as ff:
+                    json.dump({
+                        "status": "error",
+                        "error": "Agent not found",
+                        "start_time": start_time,
+                    }, ff)
+                return
+
+            count = await crud_vectordb.rebuild_world(session, agent.world_id)
+
+        end_time = datetime.now(timezone.utc).isoformat()
+        with open(job_path, "w") as f:
+            json.dump({
+                "status": "done",
+                "agent_id": agent_id,
+                "job_type": "update_vector_db",
+                "pages_indexed": count,
+                "start_time": start_time,
+                "end_time": end_time,
+            }, f)
 
     asyncio.run(run())

--- a/frontend/src/app/lib/useVectorJobs.ts
+++ b/frontend/src/app/lib/useVectorJobs.ts
@@ -1,0 +1,14 @@
+import useSWR from "swr";
+import { listVectorJobs } from "./vectordbAPI";
+import { useAuth } from "../components/auth/AuthProvider";
+
+export function useVectorJobs() {
+  const { token } = useAuth();
+  const fetcher = () => listVectorJobs(token || "");
+  const { data, error, mutate } = useSWR(
+    token ? ["vector-jobs", token] : null,
+    fetcher,
+    { refreshInterval: 2000 }
+  );
+  return { jobs: data || [], error, mutate };
+}

--- a/frontend/src/app/lib/vectordbAPI.ts
+++ b/frontend/src/app/lib/vectordbAPI.ts
@@ -13,3 +13,20 @@ export async function rebuildVectorDB(token: string, worldId: number) {
   }
   return await res.json();
 }
+
+export async function startVectorUpdate(token: string, agentId: number) {
+  const res = await fetch(`${API_URL}/agents/${agentId}/update_vector_db`, {
+    method: "POST",
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) throw await res.json();
+  return await res.json();
+}
+
+export async function listVectorJobs(token: string) {
+  const res = await fetch(`${API_URL}/agents/vector_jobs`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) throw await res.json();
+  return await res.json();
+}


### PR DESCRIPTION
## Summary
- store background job files in `settings.vectordb_job_dir`
- add async job and endpoints for vector DB rebuild tasks
- expose new API calls to front-end
- show running jobs in Agents Settings page
- add `useVectorJobs` hook to poll job status

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: Could not import sentence_transformers)*

------
https://chatgpt.com/codex/tasks/task_e_684ea992a7348322bbe2c53426e1c3ef