### PR TITLE
Handle rebuild task errors

### DIFF
--- a/backend/app/task_queue.py
+++ b/backend/app/task_queue.py
@@ -109,7 +109,19 @@ def task_rebuild_vectordb(agent_id: int, job_id: str):
                     }, ff)
                 return
 
-            count = await crud_vectordb.rebuild_world(session, agent.world_id)
+            try:
+                count = await crud_vectordb.rebuild_world(session, agent.world_id)
+            except Exception as exc:  # pragma: no cover - defensive
+                with open(job_path, "w") as ff:
+                    json.dump(
+                        {
+                            "status": "error",
+                            "error": str(exc),
+                            "start_time": start_time,
+                        },
+                        ff,
+                    )
+                raise
 
         end_time = datetime.now(timezone.utc).isoformat()
         with open(job_path, "w") as f:


### PR DESCRIPTION
## Summary
- catch exceptions during vectordb rebuild so job files record an error state

## Testing
- `pytest backend/tests/test_vectordb.py::test_rebuild_vectordb -vv` *(fails: ProxyError to huggingface.co)*

------
https://chatgpt.com/codex/tasks/task_e_684eb8a8f1288322bb50d39c8dff565b