### PR TITLE
Sync writer job status with backend

### DIFF
--- a/backend/app/api/api_agent.py
+++ b/backend/app/api/api_agent.py
@@ -108,6 +108,23 @@ async def writer_job_status(job_id: str):
     return data
 
 
+@router.patch("/writer_jobs/{job_id}")
+async def update_writer_job(job_id: str, payload: dict):
+    from pathlib import Path
+    from app.config import settings
+
+    job_path = Path(settings.writer_job_dir) / f"{job_id}.json"
+    if not job_path.is_file():
+        raise HTTPException(status_code=404, detail="Job not found")
+    with open(job_path) as f:
+        data = json.load(f)
+    data.update(payload)
+    with open(job_path, "w") as f:
+        json.dump(data, f)
+    data["job_id"] = job_id
+    return data
+
+
 @router.get("/writer_jobs")
 async def list_writer_jobs():
     from pathlib import Path

--- a/backend/app/task_queue.py
+++ b/backend/app/task_queue.py
@@ -228,6 +228,7 @@ def task_analyze_page_job(agent_id: int, page_id: int, job_id: str):
                 "page_id": page_id,
                 "job_type": "analyze_page",
                 "start_time": start_time,
+                "action_needed": None,
             }, f)
 
         async with async_session_maker() as session:
@@ -253,6 +254,7 @@ def task_analyze_page_job(agent_id: int, page_id: int, job_id: str):
                 "suggestions": result.get("suggestions", []),
                 "start_time": start_time,
                 "end_time": end_time,
+                "action_needed": "review",
             }, f)
 
     asyncio.run(run())
@@ -284,6 +286,7 @@ def task_generate_pages_job(
                     "merge_groups": merge_groups or [],
                     "suggestions": suggestions or [],
                     "bulk_accept_updates": bulk_accept_updates,
+                    "action_needed": None,
                 },
                 f,
             )
@@ -394,6 +397,7 @@ def task_generate_pages_job(
                     "merge_groups": merge_groups or [],
                     "suggestions": suggestions or [],
                     "bulk_accept_updates": bulk_accept_updates,
+                    "action_needed": "review",
                 },
                 f,
             )

--- a/frontend/src/app/agent_writer/[agentID]/review/[jobID]/page.tsx
+++ b/frontend/src/app/agent_writer/[agentID]/review/[jobID]/page.tsx
@@ -4,7 +4,7 @@ import DashboardLayout from "@/app/components/DashboardLayout";
 import AuthGuard from "@/app/components/auth/AuthGuard";
 import { useAuth } from "@/app/components/auth/AuthProvider";
 import { useEffect, useState } from "react";
-import { getWriterJob } from "@/app/lib/agentAPI";
+import { getWriterJob, updateWriterJob } from "@/app/lib/agentAPI";
 import { useAgentById } from "@/app/lib/useAgentById";
 import { useConcepts } from "@/app/lib/useConcept";
 import { useWorld } from "@/app/lib/useWorld";
@@ -12,7 +12,6 @@ import { Loader2 } from "lucide-react";
 import { getPage, getPagesForConcept, updatePage, createPage } from "@/app/lib/pagesAPI";
 import CreatePageForm from "@/app/components/create_page/CreatePageForm";
 import Image from "next/image";
-import { markWriterJobCompleted } from "../../../../lib/writerJobsStorage";
 
 function buildMergeGroups(suggestions: any[]) {
   const graph = new Map<string, Set<string>>();
@@ -55,11 +54,10 @@ export default function ReviewPage() {
   const { world } = useWorld(agent?.world_id);
 
   useEffect(() => {
-    if (job && generatedPages.length === 0) {
-      const pageName = job.pages ? job.pages.map((p: any) => p.name).join(', ') : '';
-      markWriterJobCompleted(job as any, pageName);
+    if (job && generatedPages.length === 0 && jobID) {
+      updateWriterJob(jobID as string, { action_needed: "done" }, token || "");
     }
-  }, [generatedPages, job]);
+  }, [generatedPages, job, jobID, token]);
 
   useEffect(() => {
     if (!jobID || !token) return;
@@ -227,9 +225,8 @@ export default function ReviewPage() {
                       }
                       setGeneratedPages((g) => {
                         const updated = g.filter((_, i) => i !== idx);
-                        if (updated.length === 0) {
-                          const pageName = g.map((pg) => pg.name).join(', ');
-                          markWriterJobCompleted(job as any, pageName);
+                        if (updated.length === 0 && jobID) {
+                          updateWriterJob(jobID as string, { action_needed: "done" }, token || "");
                         }
                         return updated;
                       });

--- a/frontend/src/app/agent_writer/[agentID]/suggestions/[jobID]/page.tsx
+++ b/frontend/src/app/agent_writer/[agentID]/suggestions/[jobID]/page.tsx
@@ -6,13 +6,12 @@ import { useAuth } from "@/app/components/auth/AuthProvider";
 import { useEffect, useRef, useState } from "react";
 import Image from "next/image";
 import SuggestionCard from "@/app/components/agents/SuggestionCard";
-import { getWriterJob, getBulkJob, startGenerateJob } from "@/app/lib/agentAPI";
+import { getWriterJob, getBulkJob, startGenerateJob, updateWriterJob } from "@/app/lib/agentAPI";
 import { useAgentById } from "@/app/lib/useAgentById";
 import { useConcepts } from "@/app/lib/useConcept";
 import { useWorld } from "@/app/lib/useWorld";
 import { usePages } from "@/app/lib/usePage";
 import { Loader2, AlertTriangle } from "lucide-react";
-import { markWriterJobCompleted } from "../../../../lib/writerJobsStorage";
 
 const STEPS = [
   { label: "Review Lore" },
@@ -200,7 +199,8 @@ export default function SuggestionsPage() {
         mergeGroups,
         bulkAcceptUpdates
       );
-      markWriterJobCompleted(job);
+      if (jobID)
+        await updateWriterJob(jobID as string, { action_needed: "done" }, token || "");
       router.push(`/agent_writer/${agentID}/review/${res.job_id}`);
     } catch (err) {
       console.error(err);

--- a/frontend/src/app/lib/agentAPI.ts
+++ b/frontend/src/app/lib/agentAPI.ts
@@ -198,6 +198,23 @@ export async function listWriterJobs(token: string) {
   return await res.json();
 }
 
+export async function updateWriterJob(
+  jobId: string,
+  data: any,
+  token: string
+) {
+  const res = await fetch(`${API_URL}/agents/writer_jobs/${jobId}`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw await res.text();
+  return await res.json();
+}
+
 export async function startBulkAnalyze(
   agentId: number,
   pageIds: number[],


### PR DESCRIPTION
## Summary
- add an API endpoint to patch writer job files
- include `action_needed` status in writer job JSON from Celery tasks
- expose `updateWriterJob` helper on the frontend
- rely on `action_needed` instead of local storage in writer UIs

## Testing
- `pytest -q` *(fails: blocked on huggingface.co)*

------
https://chatgpt.com/codex/tasks/task_e_68500eac8df083229cf12ecdf963c254