### PR TITLE
Enforce login redirect globally

### DIFF
--- a/frontend/src/app/components/auth/AuthCard.tsx
+++ b/frontend/src/app/components/auth/AuthCard.tsx
@@ -43,7 +43,7 @@ enum FormMode {
   FIRST_USER,
 }
 
-export default function AuthCard() {
+export default function AuthCard({ initialError = null }: { initialError?: string | null }) {
   const [formMode, setFormMode] = useState<FormMode>(FormMode.LOGIN);
   const [usersExist, setUsersExist] = useState<boolean | null>(null);
   const [form, setForm] = useState({
@@ -52,7 +52,7 @@ export default function AuthCard() {
     nickname: "",
   });
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(initialError);
   const [info, setInfo] = useState<string | null>(null);
 
   const { setToken, setRedirectAfterLogin, getRedirectAfterLogin } = useAuth();

--- a/frontend/src/app/components/auth/GlobalAuthRedirect.tsx
+++ b/frontend/src/app/components/auth/GlobalAuthRedirect.tsx
@@ -1,0 +1,19 @@
+"use client";
+import { useEffect } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { useAuth } from "./AuthProvider";
+
+export default function GlobalAuthRedirect() {
+  const { isLoggedIn, loading, setRedirectAfterLogin } = useAuth();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (!loading && !isLoggedIn && pathname !== "/") {
+      setRedirectAfterLogin(pathname);
+      router.replace("/?firstLogin=1");
+    }
+  }, [loading, isLoggedIn, pathname, router, setRedirectAfterLogin]);
+
+  return null;
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import "./globals.css";
 import { AuthProvider } from "./components/auth/AuthProvider";
+import GlobalAuthRedirect from "./components/auth/GlobalAuthRedirect";
 import { ThemeProvider } from "./hooks/useThemes";
 import Script from 'next/script';
 
@@ -18,8 +19,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         </Script>
       </head>
       <body>
-        
-        <AuthProvider> <ThemeProvider>{children}</ThemeProvider></AuthProvider>
+
+        <AuthProvider>
+          <ThemeProvider>
+            <GlobalAuthRedirect />
+            {children}
+          </ThemeProvider>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,7 +1,7 @@
 // Shrecknet hero with left-aligned true 2x2 grid, logo top, login+hero text right
 "use client";
 import { useAuth } from "./components/auth/AuthProvider";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 import Image from "next/image";
 import AuthCard from "./components/auth/AuthCard";
@@ -11,6 +11,8 @@ import Features from "./components/landing/Features";
 export default function LoginPage() {
   const { user, loading } = useAuth();
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const firstLogin = searchParams.get("firstLogin");
 
   useEffect(() => {
     if (!loading && user) {
@@ -59,7 +61,7 @@ export default function LoginPage() {
             className="w-full max-w-md mx-auto rounded-2xl shadow-2xl border border-white/20 backdrop-blur-[18px] bg-white/10 p-7 animate-fadeIn flex flex-col gap-2"
             style={{ boxShadow: "0 8px 60px 0 #7b2ff244, 0 2px 10px #2e205988" }}
           >
-            <AuthCard />
+            <AuthCard initialError={firstLogin ? "Please log in first" : undefined} />
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- enforce login redirect for all pages via `GlobalAuthRedirect`
- show `firstLogin` messages on the login page
- support an initial error in `AuthCard`

## Testing
- `npm run lint` *(fails: numerous existing lint errors)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6855d10e6d3c8322aea231797c074f68