### PR TITLE
Improve agent writer suggestions workflow

### DIFF
--- a/frontend/src/app/agent_writer/[agentID]/review/[jobID]/page.tsx
+++ b/frontend/src/app/agent_writer/[agentID]/review/[jobID]/page.tsx
@@ -261,7 +261,7 @@ function AgentBubble({ agent, children, loading = false }: any) {
           <div className="min-h-[60vh] flex flex-col items-center justify-center px-4">
             <AgentBubble agent={agent}>All pages were updated and created!</AgentBubble>
             <button
-              onClick={() => router.push(`/agent_writer/${agentID}`)}
+              onClick={() => router.push(`/agent_writer?agent=${agentID}`)}
               className="mt-4 px-4 py-2 rounded-xl bg-[var(--primary)] text-white font-bold shadow"
             >
               Return to Agent Writer

--- a/frontend/src/app/agent_writer/[agentID]/suggestions/[jobID]/page.tsx
+++ b/frontend/src/app/agent_writer/[agentID]/suggestions/[jobID]/page.tsx
@@ -81,7 +81,6 @@ export default function SuggestionsPage() {
   const [selectedSuggestions, setSelectedSuggestions] = useState<any[]>([]);
   const [subStep, setSubStep] = useState<'a' | 'b' | 'c'>('a');
   const [loading, setLoading] = useState(false);
-  const [bulkAcceptUpdates, setBulkAcceptUpdates] = useState(false);
 
   const { agent } = useAgentById(Number(agentID));
   const { concepts } = useConcepts(agent?.world_id);
@@ -95,13 +94,19 @@ export default function SuggestionsPage() {
     getWriterJob(jobID as string, token)
       .then((data) => {
         setJob(data);
-        setSelectedSuggestions(data.suggestions || []);
+        const mapped = (data.suggestions || []).map((s: any) =>
+          s.exists && !s.mode ? { ...s, mode: "update" } : s
+        );
+        setSelectedSuggestions(mapped);
       })
       .catch(() => {
         getBulkJob(jobID as string, token)
           .then((data) => {
             setJob(data);
-            setSelectedSuggestions(data.suggestions || []);
+            const mapped = (data.suggestions || []).map((s: any) =>
+              s.exists && !s.mode ? { ...s, mode: "update" } : s
+            );
+            setSelectedSuggestions(mapped);
           })
           .catch(() => {});
       });
@@ -197,13 +202,12 @@ export default function SuggestionsPage() {
         allPages as any[],
         token || "",
         prepared,
-        mergeGroups,
-        bulkAcceptUpdates
+        mergeGroups
       );
       if (jobID)
         await updateWriterJob(jobID as string, { action_needed: "done" }, token || "");
       // router.push(`/agent_writer/${agentID}/review/${res.job_id}`);
-      router.push("/agent_writer");
+      router.push(`/agent_writer?agent=${agentID}`);
     } catch (err) {
       console.error(err);
       alert("Failed to start generation");
@@ -333,22 +337,6 @@ export default function SuggestionsPage() {
                 Back
               </button>
 
-              {subStep === 'c' && (
-                <div className="max-w-screen-2xl mx-auto px-4 mb-4">
-                  <label className="flex items-center gap-2 text-sm font-medium text-[var(--foreground)]">
-                    <input
-                      type="checkbox"
-                      checked={bulkAcceptUpdates}
-                      onChange={(e) => setBulkAcceptUpdates(e.target.checked)}
-                      className="accent-[var(--primary)]"
-                    />
-                    Automatically apply all <span className="font-semibold text-blue-500">Update</span> suggestions without review
-                  </label>
-                  <p className="text-xs text-[var(--muted-foreground)] ml-6 mt-1">
-                    These pages will be directly updated and won’t appear in the next step.
-                  </p>
-                </div>
-              )}
 
               {subStep !== 'c' ? (
                 <button

--- a/frontend/src/app/agent_writer/page.tsx
+++ b/frontend/src/app/agent_writer/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState, useEffect } from "react";
+import { useSearchParams } from "next/navigation";
 import AuthGuard from "../components/auth/AuthGuard";
 import DashboardLayout from "../components/DashboardLayout";
 import { useAuth } from "../components/auth/AuthProvider";
@@ -32,6 +33,7 @@ export default function AgentWriterPage() {
   const { agents, isLoading: agentsLoading } = useAgents();
   const { worlds } = useWorlds();
   const [selectedAgent, setSelectedAgent] = useState<any>(null);
+  const searchParams = useSearchParams();
   const { pages } = usePages(selectedAgent ? { gameworld_id: selectedAgent.world_id } : {});
   const { concepts } = useConcepts(selectedAgent?.world_id);
 
@@ -44,6 +46,15 @@ export default function AgentWriterPage() {
   const [jobs, setJobs] = useState<any[]>([]);
   const { jobs: writerJobs } = useWriterJobs();
   const [jobFeedback, setJobFeedback] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (selectedAgent || agents.length === 0) return;
+    const param = searchParams.get("agent");
+    if (param) {
+      const ag = agents.find((a) => a.id === Number(param));
+      if (ag) setSelectedAgent(ag);
+    }
+  }, [agents, searchParams, selectedAgent]);
 
   useEffect(() => {
     const interval = setInterval(() => {

--- a/frontend/src/app/components/agents/SuggestionCard.tsx
+++ b/frontend/src/app/components/agents/SuggestionCard.tsx
@@ -35,10 +35,27 @@ export default function SuggestionCard({
     }
   
     return (
-      <div className={`border-2 ${isMerged ? 'border-gray-300 bg-gray-100' : backgroundClass} rounded-xl p-4 space-y-3 transition-colors duration-200`}>
-        <div className="flex justify-between items-center">
-          <h3 className="text-lg font-bold text-[var(--primary)]">{suggestion.name}</h3>
-          {subStep === 'a' && (
+      <div
+        className={`border-2 ${
+          isMerged ? "border-gray-300 bg-gray-100" : backgroundClass
+        } rounded-xl p-4 space-y-3 transition-colors duration-200`}
+      >
+        <div className="flex justify-between items-start">
+          <div className="flex items-center gap-2">
+            <h3 className="text-lg font-bold text-[var(--primary)]">
+              {suggestion.name}
+            </h3>
+            <span
+              className={`px-2 py-0.5 rounded-full text-xs font-medium ${
+                isUpdate
+                  ? "bg-blue-200 text-blue-800"
+                  : "bg-green-200 text-green-800"
+              }`}
+            >
+              {isUpdate ? "Update Page" : "New Page"}
+            </span>
+          </div>
+          {subStep === "a" && (
             <button
               className="text-red-500 hover:underline text-sm"
               onClick={() => onRemove(index)}
@@ -96,7 +113,7 @@ export default function SuggestionCard({
               </>
             )}
   
-            {subStep === 'c' && suggestion.mode === "update" && (
+            {subStep === 'c' && (suggestion.mode === "update" || (!suggestion.mode && suggestion.exists)) && (
               <div className="col-span-2">
                 <label className="block text-sm font-semibold mb-1">
                   {suggestion.exists && targetPage

--- a/frontend/src/app/lib/agentAPI.ts
+++ b/frontend/src/app/lib/agentAPI.ts
@@ -163,13 +163,11 @@ export async function startGenerateJob(
   pages: any[],
   token: string,
   suggestions?: any[],
-  mergeGroups?: string[][],
-  bulkAcceptUpdates: boolean = false
+  mergeGroups?: string[][]
 ) {
   const body: any = { pages };
   if (suggestions) body.suggestions = suggestions;
   if (mergeGroups) body.merge_groups = mergeGroups;
-  if (bulkAcceptUpdates) body.bulk_accept_updates = true;
   const res = await fetch(`${API_URL}/agents/${agentId}/pages/${pageId}/generate_job`, {
     method: "POST",
     headers: {


### PR DESCRIPTION
## Summary
- show update/create type chips on suggestion cards
- preselect update suggestions and their target page
- clean up bulk accept option and redirect to agent page
- allow selecting agent via `?agent=` query parameter

## Testing
- `npm run lint` *(fails: next not found)*
- `pytest -q` *(fails: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6856c70da5148322a68ae18b4e812ffd