### PR TITLE
Update agent settings UX

### DIFF
--- a/frontend/src/app/agents_settings/page.tsx
+++ b/frontend/src/app/agents_settings/page.tsx
@@ -84,13 +84,15 @@ function JobStatusScroll({ jobs }) {
   if (!jobs || !jobs.length) return null;
 
   // Split jobs into active and completed/error
-  const activeJobs = jobs.filter(j => j.status === "queued" || j.status === "running");
+  const activeJobs = jobs.filter(j =>
+    j.status === "queued" || j.status === "running" || j.status === "processing"
+  );
   const finishedJobs = jobs
     .filter(j => j.status === "finished" || j.status === "done" || j.status === "error")
     .slice(-3); // Last 3 only
 
   function renderJobStatus(job) {
-    if (job.status === "running") {
+    if (job.status === "running" || job.status === "processing") {
       return (
         <>
           <span className="animate-pulse">⏳</span> Running: {job.progress || "In progress..."}
@@ -186,7 +188,9 @@ function WriterJobStatusScroll({ jobs }) {
   if (!jobs || !jobs.length) return null;
 
   // Active and finished jobs
-  const activeJobs = jobs.filter(j => j.status === "queued" || j.status === "running");
+  const activeJobs = jobs.filter(j =>
+    j.status === "queued" || j.status === "running" || j.status === "processing"
+  );
   const finishedJobs = jobs
     .filter(j => j.status === "finished" || j.status === "done" || j.status === "error")
     .slice(-5);
@@ -201,7 +205,7 @@ function WriterJobStatusScroll({ jobs }) {
       <li className="mb-1">
         {/* Status */}
         <span>
-          {job.status === "running" && <><span className="animate-pulse">⏳</span> Running</>}
+          {(job.status === "running" || job.status === "processing") && <><span className="animate-pulse">⏳</span> Running</>}
           {job.status === "queued" && <><span>🕓</span> Queued</>}
           {(job.status === "finished" || job.status === "done") && <><span>✅</span> Done</>}
           {job.status === "error" && <><span>❌</span> Error</>}
@@ -525,6 +529,13 @@ return (
             icon={<Book className="w-6 h-6 text-purple-500" />}
             agents={filtered.filter((a) => a.task === "story novelist")}
             task="story novelist"
+            canRebuild={false}
+          />
+          <AgentGuildTable
+            title="Specialists’ Corner"
+            icon={<Users2 className="w-6 h-6 text-teal-500" />}
+            agents={filtered.filter((a) => a.task === "specialist")}
+            task="specialist"
             canRebuild={false}
           />
 

--- a/frontend/src/app/components/agents/AgentModal.tsx
+++ b/frontend/src/app/components/agents/AgentModal.tsx
@@ -146,6 +146,7 @@ export default function AgentModal({ agent, onClose, onSave, onDelete, worlds })
             <option value="conversational">conversational</option>
             <option value="page writer">page writer</option>
             <option value="story novelist">story novelist</option>
+            <option value="specialist">specialist</option>
           </select>
           <label className="absolute left-3 top-1.5 text-base text-[var(--primary)] font-semibold pointer-events-none">
             Task


### PR DESCRIPTION
## Summary
- show queued and processing vector update jobs
- allow new "specialist" agent type
- display specialists alongside other agents

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sentence_transformers')*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ca0b8de88322bb9154b9401e4556