### PR TITLE
Unify single and multi-page analysis

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -6,17 +6,15 @@ class Settings(BaseSettings):
     debug: bool = False
     allowed_origins: str = "*"
     openai_api_key: str | None = None
-    open_ai_model:str | None = None
+    open_ai_model: str | None = None
     vector_db_path: str = "./data/vector_db"
     chat_history_dir: str = "./data/chat/{user_id}"
-    bulk_job_dir: str = "./data/bulk_jobs"
     vectordb_job_dir: str = "./data/vector_jobs"
-    writer_job_dir: str = "./data/writer_jobs"    
+    writer_job_dir: str = "./data/writer_jobs"
     celery_broker_url: str = "redis://localhost:6379/0"
     celery_result_backend: str = "redis://localhost:6379/0"
-    vector_db_url :str ="localhost"
-    vector_db_port :str = "8001"
+    vector_db_url: str = "localhost"
+    vector_db_port: str = "8001"
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
-    
 
 settings = Settings()

--- a/frontend/src/app/agent_writer/[agentID]/suggestions/[jobID]/page.tsx
+++ b/frontend/src/app/agent_writer/[agentID]/suggestions/[jobID]/page.tsx
@@ -6,7 +6,7 @@ import { useAuth } from "@/app/components/auth/AuthProvider";
 import { useEffect, useRef, useState } from "react";
 import Image from "next/image";
 import SuggestionCard from "@/app/components/agents/SuggestionCard";
-import { getWriterJob, getBulkJob, startGenerateJob, updateWriterJob } from "@/app/lib/agentAPI";
+import { getWriterJob, startGenerateJob, updateWriterJob } from "@/app/lib/agentAPI";
 import { useAgentById } from "@/app/lib/useAgentById";
 import { useConcepts } from "@/app/lib/useConcept";
 import { useWorld } from "@/app/lib/useWorld";
@@ -99,17 +99,7 @@ export default function SuggestionsPage() {
         );
         setSelectedSuggestions(mapped);
       })
-      .catch(() => {
-        getBulkJob(jobID as string, token)
-          .then((data) => {
-            setJob(data);
-            const mapped = (data.suggestions || []).map((s: any) =>
-              s.exists && !s.mode ? { ...s, mode: "update" } : s
-            );
-            setSelectedSuggestions(mapped);
-          })
-          .catch(() => {});
-      });
+      .catch(() => {});
   }, [jobID, token]);
 
   const scrollToCard = (idx: number) => {

--- a/frontend/src/app/lib/agentAPI.ts
+++ b/frontend/src/app/lib/agentAPI.ts
@@ -146,12 +146,16 @@ export async function generatePagesWithAgent(
 
 export async function startAnalyzeJob(
   agentId: number,
-  pageId: number,
+  pageIds: number[],
   token: string
 ) {
-  const res = await fetch(`${API_URL}/agents/${agentId}/pages/${pageId}/analyze_job`, {
+  const res = await fetch(`${API_URL}/agents/${agentId}/analyze_job`, {
     method: "POST",
-    headers: token ? { Authorization: `Bearer ${token}` } : {},
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify({ page_ids: pageIds }),
   });
   if (!res.ok) throw await res.text();
   return await res.json();
@@ -213,27 +217,3 @@ export async function updateWriterJob(
   return await res.json();
 }
 
-export async function startBulkAnalyze(
-  agentId: number,
-  pageIds: number[],
-  token: string
-) {
-  const res = await fetch(`${API_URL}/agents/${agentId}/bulk_analyze`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    },
-    body: JSON.stringify({ page_ids: pageIds }),
-  });
-  if (!res.ok) throw await res.text();
-  return await res.json();
-}
-
-export async function getBulkJob(jobId: string, token: string) {
-  const res = await fetch(`${API_URL}/agents/bulk_jobs/${jobId}`, {
-    headers: token ? { Authorization: `Bearer ${token}` } : {},
-  });
-  if (!res.ok) throw await res.text();
-  return await res.json();
-}

--- a/frontend/src/app/lib/writerJobsStorage.ts
+++ b/frontend/src/app/lib/writerJobsStorage.ts
@@ -46,7 +46,7 @@ export function markWriterJobCompleted(
     agent_id: job.agent_id,
     page_id: job.page_id,
     page_name: pageName,
-    job_type: job.job_type || "bulk_analyze",
+    job_type: job.job_type || "analyze_pages",
     start_time: job.start_time,
     end_time: job.end_time,
     completed_at: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- drop unused bulk job paths from config
- replace bulk analyze endpoint with a generic `analyze_job`
- add new celery task `task_analyze_pages_job`
- update frontend API helpers and writer pages to use the unified job

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_6856d56fed3c832293c9802af0b83267