### PR TITLE
Add AI Novelist page and sidebar link

### DIFF
--- a/frontend/src/app/ai_novelist/create_novel/page.tsx
+++ b/frontend/src/app/ai_novelist/create_novel/page.tsx
@@ -1,0 +1,35 @@
+"use client";
+import DashboardLayout from "../../components/DashboardLayout";
+import AuthGuard from "../../components/auth/AuthGuard";
+import { useAuth } from "../../components/auth/AuthProvider";
+import { hasRole } from "../../lib/roles";
+import { useSearchParams } from "next/navigation";
+
+export default function CreateNovelPage() {
+  const { user } = useAuth();
+  const searchParams = useSearchParams();
+  const agentId = searchParams.get("agent");
+
+  if (!hasRole(user?.role, "writer")) {
+    return (
+      <DashboardLayout>
+        <div className="p-10 text-2xl text-red-600 font-bold">Not authorized</div>
+      </DashboardLayout>
+    );
+  }
+
+  return (
+    <AuthGuard>
+      <DashboardLayout>
+        <div className="min-h-screen w-full flex items-center justify-center text-indigo-900 px-2 sm:px-6 py-10">
+          <div className="text-center">
+            <h1 className="text-2xl font-bold mb-4">AI Novelist - Coming Soon</h1>
+            {agentId && (
+              <p className="text-lg text-indigo-700">Selected novelist ID: {agentId}</p>
+            )}
+          </div>
+        </div>
+      </DashboardLayout>
+    </AuthGuard>
+  );
+}

--- a/frontend/src/app/ai_novelist/page.tsx
+++ b/frontend/src/app/ai_novelist/page.tsx
@@ -1,0 +1,63 @@
+"use client";
+import AuthGuard from "../components/auth/AuthGuard";
+import DashboardLayout from "../components/DashboardLayout";
+import { useAuth } from "../components/auth/AuthProvider";
+import { hasRole } from "../lib/roles";
+import { useAgents } from "../lib/useAgents";
+import { useWorlds } from "../lib/userWorlds";
+import Image from "next/image";
+import { BookOpen, PenLine } from "lucide-react";
+import { useRouter } from "next/navigation";
+
+export default function AINovelistPage() {
+  const { user } = useAuth();
+  const { agents, isLoading } = useAgents();
+  const { worlds } = useWorlds();
+  const router = useRouter();
+
+  if (!hasRole(user?.role, "writer")) {
+    return (
+      <DashboardLayout>
+        <div className="p-10 text-2xl text-red-600 font-bold">Not authorized</div>
+      </DashboardLayout>
+    );
+  }
+
+  const novelists = agents.filter(a => a.task === "story novelist");
+  const worldName = (id: number) => worlds.find(w => w.id === id)?.name || "";
+
+  return (
+    <AuthGuard>
+      <DashboardLayout>
+        <div className="min-h-screen w-full text-indigo-900 px-2 sm:px-6 py-12">
+          <div className="mx-auto max-w-3xl flex flex-col gap-8 items-center">
+            <div className="w-full flex flex-col items-center gap-4 bg-gradient-to-br from-indigo-100/70 via-purple-100/80 to-white/80 rounded-2xl shadow-xl p-8 border border-indigo-200">
+              <BookOpen className="w-12 h-12 text-indigo-400 mb-2" />
+              <h1 className="text-3xl font-bold text-indigo-700 text-center font-serif mb-1">Choose your Novelist</h1>
+              <p className="text-center text-lg text-indigo-900/80 mb-2">
+                Let an AI Novelist weave epic stories from your world's lore.
+              </p>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-8 mt-6 w-full">
+              {isLoading ? (
+                <div className="col-span-2 text-center text-lg">Summoning Novelists...</div>
+              ) : (
+                novelists.map(a => (
+                  <button
+                    key={a.id}
+                    onClick={() => router.push(`/ai_novelist/create_novel?agent=${a.id}`)}
+                    className="flex flex-col items-center gap-2 p-6 rounded-2xl shadow-lg border border-indigo-200 bg-white hover:scale-105 hover:shadow-2xl transition-all"
+                  >
+                    <Image src={a.logo || "/images/default/avatars/logo.png"} alt={a.name} width={100} height={100} className="rounded-full object-cover border-2 border-fuchsia-300 shadow mb-2" />
+                    <span className="text-xl font-bold text-indigo-800">{a.name}</span>
+                    <span className="text-sm text-fuchsia-700">{worldName(a.world_id)}</span>
+                  </button>
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+      </DashboardLayout>
+    </AuthGuard>
+  );
+}

--- a/frontend/src/app/components/template/Sidebar.tsx
+++ b/frontend/src/app/components/template/Sidebar.tsx
@@ -12,7 +12,7 @@ import GroupRoundedIcon from "@mui/icons-material/GroupRounded";
 import CasinoRoundedIcon from "@mui/icons-material/CasinoRounded";
 import BuildRoundedIcon from "@mui/icons-material/BuildRounded";
 import PersonEditAlt1RoundedIcon from "@mui/icons-material/EditRounded";
-import { Bot, BookOpenText } from "lucide-react";
+import { Bot, BookOpenText, PenLine } from "lucide-react";
 
 export default function Sidebar({ mobileOpen = false, setMobileOpen = () => {} }) {
   const { user, token, isLoading: authLoading, refreshUser } = useAuth();
@@ -60,6 +60,13 @@ export default function Sidebar({ mobileOpen = false, setMobileOpen = () => {} }
       label: "AI Writer",
       icon: <Bot fontSize="medium" />,
       href: "/agent_writer",
+      external: false,
+      show: user && ["writer", "system admin"].includes(user.role),
+    },
+    {
+      label: "AI Novelist",
+      icon: <PenLine fontSize="medium" />,
+      href: "/ai_novelist",
       external: false,
       show: user && ["writer", "system admin"].includes(user.role),
     },


### PR DESCRIPTION
## Summary
- add `/ai_novelist` page listing story novelist agents
- create placeholder `/ai_novelist/create_novel` page
- expose "AI Novelist" in sidebar for users with role `writer`

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q` *(fails: ProxyError during huggingface download)*
- `npm install`
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6856d6b08440832293b20da16e46d23f