### PR TITLE
Fix Next.js build by wrapping search params in Suspense

### DIFF
--- a/frontend/src/app/agent_writer/page.tsx
+++ b/frontend/src/app/agent_writer/page.tsx
@@ -1,5 +1,6 @@
 "use client";
-import { useState, useEffect } from "react";
+export const dynamic = "force-dynamic";
+import { useState, useEffect, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 import AuthGuard from "../components/auth/AuthGuard";
 import DashboardLayout from "../components/DashboardLayout";
@@ -27,7 +28,7 @@ const JOB_LABELS = {
   generate_pages: "Update/Create Pages",
 };
 
-export default function AgentWriterPage() {
+function AgentWriterPageContent() {
   const { user, token } = useAuth();
   const { agents, isLoading: agentsLoading } = useAgents();
   const { worlds } = useWorlds();
@@ -380,5 +381,13 @@ export default function AgentWriterPage() {
         </div>
       </DashboardLayout>
     </AuthGuard>
+  );
+}
+
+export default function AgentWriterPage() {
+  return (
+    <Suspense>
+      <AgentWriterPageContent />
+    </Suspense>
   );
 }

--- a/frontend/src/app/ai_novelist/create_novel/page.tsx
+++ b/frontend/src/app/ai_novelist/create_novel/page.tsx
@@ -1,11 +1,13 @@
 "use client";
+export const dynamic = "force-dynamic";
 import DashboardLayout from "../../components/DashboardLayout";
 import AuthGuard from "../../components/auth/AuthGuard";
 import { useAuth } from "../../components/auth/AuthProvider";
 import { hasRole } from "../../lib/roles";
 import { useSearchParams } from "next/navigation";
+import { Suspense } from "react";
 
-export default function CreateNovelPage() {
+function CreateNovelPageContent() {
   const { user } = useAuth();
   const searchParams = useSearchParams();
   const agentId = searchParams.get("agent");
@@ -31,5 +33,13 @@ export default function CreateNovelPage() {
         </div>
       </DashboardLayout>
     </AuthGuard>
+  );
+}
+
+export default function CreateNovelPage() {
+  return (
+    <Suspense>
+      <CreateNovelPageContent />
+    </Suspense>
   );
 }

--- a/frontend/src/app/ai_specialist/specialist_chat/page.tsx
+++ b/frontend/src/app/ai_specialist/specialist_chat/page.tsx
@@ -1,9 +1,11 @@
 "use client";
+export const dynamic = "force-dynamic";
 import DashboardLayout from "../../components/DashboardLayout";
 import AuthGuard from "../../components/auth/AuthGuard";
 import { useSearchParams } from "next/navigation";
+import { Suspense } from "react";
 
-export default function SpecialistChatPage() {
+function SpecialistChatPageContent() {
   const searchParams = useSearchParams();
   const agentId = searchParams.get("agent");
 
@@ -20,5 +22,13 @@ export default function SpecialistChatPage() {
         </div>
       </DashboardLayout>
     </AuthGuard>
+  );
+}
+
+export default function SpecialistChatPage() {
+  return (
+    <Suspense>
+      <SpecialistChatPageContent />
+    </Suspense>
   );
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,14 +1,15 @@
-// Shrecknet hero with left-aligned true 2x2 grid, logo top, login+hero text right
 "use client";
+// Shrecknet hero with left-aligned true 2x2 grid, logo top, login+hero text right
+export const dynamic = "force-dynamic";
 import { useAuth } from "./components/auth/AuthProvider";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, Suspense } from "react";
 import Image from "next/image";
 import AuthCard from "./components/auth/AuthCard";
 import Starfield from "./components/template/Starfield";
 import Features from "./components/landing/Features";
 
-export default function LoginPage() {
+function LoginPageContent() {
   const { user, loading } = useAuth();
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -66,5 +67,13 @@ export default function LoginPage() {
         </div>
       </section>
     </main>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginPageContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- wrap pages that call `useSearchParams` with `Suspense`
- keep `use client` directives as the first statement

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6856f9538c188322b5a7108a93da2a10