### PR TITLE
Add agent settings aliases

### DIFF
--- a/frontend/src/app/agents_settings/agent_conversational/page.tsx
+++ b/frontend/src/app/agents_settings/agent_conversational/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function Page() {
+  redirect("/agents_settings/conversational");
+}

--- a/frontend/src/app/agents_settings/agent_novelist/page.tsx
+++ b/frontend/src/app/agents_settings/agent_novelist/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function Page() {
+  redirect("/agents_settings/story-novelist");
+}

--- a/frontend/src/app/agents_settings/agent_specialists/page.tsx
+++ b/frontend/src/app/agents_settings/agent_specialists/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function Page() {
+  redirect("/agents_settings/specialist");
+}

--- a/frontend/src/app/agents_settings/agent_writers/page.tsx
+++ b/frontend/src/app/agents_settings/agent_writers/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function Page() {
+  redirect("/agents_settings/page-writer");
+}

--- a/frontend/src/app/agents_settings/page.tsx
+++ b/frontend/src/app/agents_settings/page.tsx
@@ -5,10 +5,26 @@ import DashboardLayout from "../components/DashboardLayout";
 import { Bot, BookOpenText, Book, Users2 } from "lucide-react";
 
 const agentTypes = [
-  { path: "conversational", label: "Conversationalists", icon: <Bot className="w-6 h-6" /> },
-  { path: "page-writer", label: "Page Writers", icon: <BookOpenText className="w-6 h-6" /> },
-  { path: "story-novelist", label: "Story Novelists", icon: <Book className="w-6 h-6" /> },
-  { path: "specialist", label: "Specialists", icon: <Users2 className="w-6 h-6" /> },
+  {
+    path: "agent_conversational",
+    label: "Conversationalists",
+    icon: <Bot className="w-6 h-6" />,
+  },
+  {
+    path: "agent_writers",
+    label: "Page Writers",
+    icon: <BookOpenText className="w-6 h-6" />,
+  },
+  {
+    path: "agent_novelist",
+    label: "Story Novelists",
+    icon: <Book className="w-6 h-6" />,
+  },
+  {
+    path: "agent_specialists",
+    label: "Specialists",
+    icon: <Users2 className="w-6 h-6" />,
+  },
 ];
 
 export default function AgentsSettingsIndex() {


### PR DESCRIPTION
## Summary
- add dedicated pages for agent specialist, novelist, writer, and conversational settings
- update agent settings index links to new routes

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: ProxyError - cannot reach huggingface.co)*

------
https://chatgpt.com/codex/tasks/task_e_68570a886cf88322b7ce0d65a58c5845