### PR TITLE
Specialist agent sources management

### DIFF
--- a/backend/app/api/api_specialist.py
+++ b/backend/app/api/api_specialist.py
@@ -1,5 +1,8 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
+from uuid import uuid4
+import json
+from pathlib import Path
 
 from app.dependencies import get_current_user
 from app.models.model_user import User
@@ -7,6 +10,8 @@ from app.database import get_session
 from app.crud import crud_specialist_source, crud_specialist_vectordb
 from app.models.model_specialist_source import SpecialistSource
 from app.schemas.schema_specialist_source import SpecialistSourceCreate, SpecialistSourceRead
+from app.task_queue import task_rebuild_specialist_vectors
+from app.config import settings
 
 router = APIRouter(prefix="/specialist_agents", tags=["SpecialistAgents"], dependencies=[Depends(get_current_user)])
 
@@ -30,3 +35,38 @@ async def remove_source(agent_id: int, source_id: int, session: AsyncSession = D
 async def rebuild_vectors(agent_id: int, session: AsyncSession = Depends(get_session)):
     count = await crud_specialist_vectordb.rebuild_agent(session, agent_id)
     return {"documents_indexed": count}
+
+
+@router.post("/{agent_id}/rebuild_vectors_async")
+async def rebuild_vectors_async(agent_id: int, user: User = Depends(get_current_user)):
+    job_id = uuid4().hex
+    job_dir = Path(settings.specialist_job_dir)
+    job_dir.mkdir(parents=True, exist_ok=True)
+    job_path = job_dir / f"{job_id}.json"
+    with open(job_path, "w") as f:
+        json.dump({"status": "queued", "agent_id": agent_id, "job_type": "rebuild_specialist_vectors"}, f)
+    task_rebuild_specialist_vectors.delay(agent_id, job_id)
+    return {"job_id": job_id}
+
+
+@router.get("/vector_jobs/{job_id}")
+async def specialist_vector_job_status(job_id: str):
+    job_path = Path(settings.specialist_job_dir) / f"{job_id}.json"
+    if not job_path.is_file():
+        raise HTTPException(status_code=404, detail="Job not found")
+    with open(job_path) as f:
+        data = json.load(f)
+    return data
+
+
+@router.get("/vector_jobs")
+async def list_vector_jobs():
+    job_dir = Path(settings.specialist_job_dir)
+    job_dir.mkdir(parents=True, exist_ok=True)
+    jobs = []
+    for p in job_dir.glob("*.json"):
+        with open(p) as f:
+            data = json.load(f)
+        data["job_id"] = p.stem
+        jobs.append(data)
+    return jobs

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
     chat_history_dir: str = "./data/chat/{user_id}"
     vectordb_job_dir: str = "./data/vector_jobs"
     writer_job_dir: str = "./data/writer_jobs"
+    specialist_job_dir: str = "./data/specialist_jobs"
     celery_broker_url: str = "redis://localhost:6379/0"
     celery_result_backend: str = "redis://localhost:6379/0"
     vector_db_url: str = "localhost"

--- a/frontend/src/app/agents_settings/specialist/page.tsx
+++ b/frontend/src/app/agents_settings/specialist/page.tsx
@@ -1,0 +1,172 @@
+"use client";
+import { useState } from "react";
+import AuthGuard from "../../components/auth/AuthGuard";
+import DashboardLayout from "../../components/DashboardLayout";
+import { useAgents } from "../../lib/useAgents";
+import { useWorlds } from "../../lib/userWorlds";
+import { useAuth } from "../../components/auth/AuthProvider";
+import AgentModal from "../../components/agents/AgentModal";
+import { useSpecialistJobs } from "../../lib/useSpecialistJobs";
+import { useSpecialistSources } from "../../lib/useSpecialistSources";
+import { addSource, deleteSource, startVectorJob } from "../../lib/specialistAPI";
+
+function JobList({ agentId }) {
+  const { jobs } = useSpecialistJobs();
+  const list = jobs.filter((j) => j.agent_id === agentId);
+  if (!list.length) return null;
+  return (
+    <div className="mt-2 text-sm bg-purple-50 p-2 rounded">
+      <div className="font-semibold mb-1">Jobs</div>
+      <ul className="list-disc ml-5">
+        {list.map((j) => (
+          <li key={j.job_id || j.start_time}>
+            {j.status} {j.documents_indexed !== undefined && `- ${j.documents_indexed} docs`}
+            {j.start_time && (
+              <span className="ml-2 text-xs text-gray-600">
+                {new Date(j.start_time).toLocaleString()}
+              </span>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function SourcesManager({ agentId }) {
+  const { token } = useAuth();
+  const { sources, mutate } = useSpecialistSources(agentId);
+  const [type, setType] = useState("link");
+  const [value, setValue] = useState("");
+
+  async function handleAdd() {
+    if (!value) return;
+    const payload: any = { type };
+    if (type === "link") payload.url = value;
+    else payload.path = value;
+    await addSource(agentId, payload, token || "");
+    setValue("");
+    mutate();
+  }
+
+  async function handleDelete(id: number) {
+    await deleteSource(agentId, id, token || "");
+    mutate();
+  }
+
+  return (
+    <div className="mt-2">
+      <div className="font-semibold text-sm">Sources</div>
+      <ul className="ml-4 list-disc text-sm">
+        {sources.map((s: any) => (
+          <li key={s.id} className="flex items-center gap-2">
+            <span>{s.type === "link" ? s.url : s.path}</span>
+            <button
+              className="text-red-600 text-xs"
+              onClick={() => handleDelete(s.id)}
+            >
+              delete
+            </button>
+          </li>
+        ))}
+      </ul>
+      <div className="flex gap-2 mt-2">
+        <select value={type} onChange={(e) => setType(e.target.value)} className="border px-1 text-sm">
+          <option value="link">link</option>
+          <option value="file">file</option>
+        </select>
+        <input
+          className="border flex-1 px-2 text-sm"
+          placeholder={type === "link" ? "URL" : "Path"}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+        />
+        <button className="px-2 bg-indigo-600 text-white text-sm rounded" onClick={handleAdd}>add</button>
+      </div>
+    </div>
+  );
+}
+
+export default function SpecialistSettingsPage() {
+  const { agents, mutate } = useAgents();
+  const { worlds } = useWorlds();
+  const { token } = useAuth();
+  const [modalOpen, setModalOpen] = useState(false);
+  const [selected, setSelected] = useState(null as any);
+  const { mutate: refreshJobs } = useSpecialistJobs();
+
+  const specialists = agents.filter((a) => a.task === "specialist");
+
+  function handleEdit(agent: any) {
+    setSelected(agent);
+    setModalOpen(true);
+  }
+  function handleCreate() {
+    setSelected(null);
+    setModalOpen(true);
+  }
+  function handleSave() {
+    mutate();
+    setModalOpen(false);
+  }
+  function handleDelete() {
+    mutate();
+    setModalOpen(false);
+  }
+
+  async function handleRebuild(id: number) {
+    await startVectorJob(id, token || "");
+    refreshJobs();
+  }
+
+  return (
+    <AuthGuard>
+      <DashboardLayout>
+        <div className="min-h-screen w-full p-6 text-indigo-900">
+          <h1 className="text-2xl font-bold mb-4">Specialist Agents</h1>
+          <button className="mb-4 px-4 py-2 bg-indigo-600 text-white rounded" onClick={handleCreate}>
+            Add Agent
+          </button>
+          <div className="space-y-6">
+            {specialists.map((a) => (
+              <div key={a.id} className="border p-4 rounded-xl shadow">
+                <div className="flex justify-between items-center">
+                  <div>
+                    <div className="font-bold text-lg">{a.name}</div>
+                    <div className="text-sm">
+                      World: {worlds.find((w) => w.id === a.world_id)?.name || ""}
+                    </div>
+                    {a.specialist_update_date && (
+                      <div className="text-sm text-gray-600">
+                        Vector DB updated: {new Date(a.specialist_update_date).toLocaleString()}
+                      </div>
+                    )}
+                  </div>
+                  <div className="flex gap-2">
+                    <button className="px-3 py-1 text-sm bg-indigo-500 text-white rounded" onClick={() => handleEdit(a)}>
+                      Edit
+                    </button>
+                    <button className="px-3 py-1 text-sm bg-purple-600 text-white rounded" onClick={() => handleRebuild(a.id)}>
+                      Generate Vector DB
+                    </button>
+                  </div>
+                </div>
+                <JobList agentId={a.id} />
+                <SourcesManager agentId={a.id} />
+              </div>
+            ))}
+          </div>
+          {modalOpen && (
+            <AgentModal
+              agent={selected}
+              onClose={() => setModalOpen(false)}
+              onSave={handleSave}
+              onDelete={handleDelete}
+              worlds={worlds}
+            />
+          )}
+        </div>
+      </DashboardLayout>
+    </AuthGuard>
+  );
+}

--- a/frontend/src/app/lib/specialistAPI.ts
+++ b/frontend/src/app/lib/specialistAPI.ts
@@ -1,0 +1,48 @@
+import { API_URL } from "./config";
+
+export async function listSources(agentId: number, token: string) {
+  const res = await fetch(`${API_URL}/specialist_agents/${agentId}/sources`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) throw await res.text();
+  return await res.json();
+}
+
+export async function addSource(agentId: number, data: any, token: string) {
+  const res = await fetch(`${API_URL}/specialist_agents/${agentId}/sources`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw await res.text();
+  return await res.json();
+}
+
+export async function deleteSource(agentId: number, sourceId: number, token: string) {
+  const res = await fetch(`${API_URL}/specialist_agents/${agentId}/sources/${sourceId}`, {
+    method: "DELETE",
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) throw await res.text();
+  return await res.json();
+}
+
+export async function startVectorJob(agentId: number, token: string) {
+  const res = await fetch(`${API_URL}/specialist_agents/${agentId}/rebuild_vectors_async`, {
+    method: "POST",
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) throw await res.text();
+  return await res.json();
+}
+
+export async function listVectorJobs(token: string) {
+  const res = await fetch(`${API_URL}/specialist_agents/vector_jobs`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) throw await res.text();
+  return await res.json();
+}

--- a/frontend/src/app/lib/useSpecialistJobs.ts
+++ b/frontend/src/app/lib/useSpecialistJobs.ts
@@ -1,0 +1,14 @@
+import useSWR from "swr";
+import { listVectorJobs } from "./specialistAPI";
+import { useAuth } from "../components/auth/AuthProvider";
+
+export function useSpecialistJobs() {
+  const { token } = useAuth();
+  const fetcher = () => listVectorJobs(token || "");
+  const { data, error, mutate } = useSWR(
+    token ? ["specialist-jobs", token] : null,
+    fetcher,
+    { refreshInterval: 2000 }
+  );
+  return { jobs: data || [], error, mutate };
+}

--- a/frontend/src/app/lib/useSpecialistSources.ts
+++ b/frontend/src/app/lib/useSpecialistSources.ts
@@ -1,0 +1,13 @@
+import useSWR from "swr";
+import { listSources } from "./specialistAPI";
+import { useAuth } from "../components/auth/AuthProvider";
+
+export function useSpecialistSources(agentId: number) {
+  const { token } = useAuth();
+  const fetcher = () => listSources(agentId, token || "");
+  const { data, error, mutate } = useSWR(
+    token && agentId ? ["specialist-sources", agentId, token] : null,
+    fetcher
+  );
+  return { sources: data || [], error, mutate };
+}


### PR DESCRIPTION
## Summary
- support async specialist vector jobs
- expose new specialist endpoints for sources and job status
- add specialist job dir setting
- implement frontend page to manage specialist sources and trigger vector rebuild
- add hooks and APIs for specialist agents

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_68570f8228ec8322b00b303a8514ba6e