### PR TITLE
Enhance specialist sources UI and add name field

### DIFF
--- a/backend/alembic/versions/20240607_02_add_source_name.py
+++ b/backend/alembic/versions/20240607_02_add_source_name.py
@@ -1,0 +1,13 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = '20240607_02'
+down_revision = '20240607_01'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.add_column('specialistsource', sa.Column('name', sa.String(), nullable=True))
+
+def downgrade():
+    op.drop_column('specialistsource', 'name')

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -40,8 +40,12 @@ def _migrate(conn):
     # -- SpecialistSource table --
     if "specialistsource" not in inspector.get_table_names():
         conn.execute(text(
-            "CREATE TABLE specialistsource (id INTEGER PRIMARY KEY AUTOINCREMENT, agent_id INTEGER NOT NULL REFERENCES agent(id), type TEXT NOT NULL, path TEXT, url TEXT, added_at DATETIME NOT NULL)"
+            "CREATE TABLE specialistsource (id INTEGER PRIMARY KEY AUTOINCREMENT, agent_id INTEGER NOT NULL REFERENCES agent(id), name TEXT, type TEXT NOT NULL, path TEXT, url TEXT, added_at DATETIME NOT NULL)"
         ))
+    else:
+        columns = [c["name"] for c in inspector.get_columns("specialistsource")]
+        if "name" not in columns:
+            conn.execute(text("ALTER TABLE specialistsource ADD COLUMN name TEXT"))
 
 async def get_session() -> AsyncSession:
     async with async_session_maker() as session:

--- a/backend/app/models/model_specialist_source.py
+++ b/backend/app/models/model_specialist_source.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 class SpecialistSource(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     agent_id: int = Field(foreign_key="agent.id")
+    name: Optional[str] = None
     type: str  # 'file' or 'link'
     path: Optional[str] = None
     url: Optional[str] = None

--- a/backend/app/schemas/schema_specialist_source.py
+++ b/backend/app/schemas/schema_specialist_source.py
@@ -3,6 +3,7 @@ from typing import Optional
 from datetime import datetime
 
 class SpecialistSourceCreate(BaseModel):
+    name: Optional[str] = None
     type: str
     path: Optional[str] = None
     url: Optional[str] = None

--- a/backend/tests/test_specialist.py
+++ b/backend/tests/test_specialist.py
@@ -21,7 +21,7 @@ async def test_specialist_sources(async_client, create_user, login_and_get_token
 
     resp = await async_client.post(
         f"/specialist_agents/{agent_id}/sources",
-        json={"type": "file", "path": str(file_path)},
+        json={"name": "doc", "type": "file", "path": str(file_path)},
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 200
@@ -32,7 +32,9 @@ async def test_specialist_sources(async_client, create_user, login_and_get_token
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 200
-    assert len(resp.json()) == 1
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["name"] == "doc"
 
     resp = await async_client.post(
         f"/specialist_agents/{agent_id}/rebuild_vectors",

--- a/frontend/src/app/agents_settings/agent_specialist/page.tsx
+++ b/frontend/src/app/agents_settings/agent_specialist/page.tsx
@@ -1,170 +1,228 @@
 "use client";
 import { useState } from "react";
+import { Bot, Sparkles, Wand2, Search } from "lucide-react";
 import AuthGuard from "../../components/auth/AuthGuard";
 import DashboardLayout from "../../components/DashboardLayout";
+import { useAuth } from "../../components/auth/AuthProvider";
+import { hasRole } from "../../lib/roles";
 import { useAgents } from "../../lib/useAgents";
 import { useWorlds } from "../../lib/userWorlds";
-import { useAuth } from "../../components/auth/AuthProvider";
-import AgentModal from "../../components/agents/AgentModal";
 import { useSpecialistJobs } from "../../lib/useSpecialistJobs";
 import { useSpecialistSources } from "../../lib/useSpecialistSources";
-import { addSource, deleteSource, startVectorJob } from "../../lib/specialistAPI";
+import { startVectorJob } from "../../lib/specialistAPI";
+import AgentModal from "../../components/agents/AgentModal";
+import SpecialistSourceModal from "../../components/agents/SpecialistSourceModal";
 
-function JobList({ agentId }) {
-  const { jobs } = useSpecialistJobs();
-  const list = jobs.filter((j) => j.agent_id === agentId);
-  if (!list.length) return null;
+// ----- NPC Guide -----
+const npcQuotes = [
+  "Welcome, archivist! Your specialists await new knowledge.",
+  "A tidy archive is a powerful tool.",
+  "Feed your specialists well, and they will answer wisely.",
+];
+function GuildmasterGuide({ status, quote, flavor }) {
   return (
-    <div className="mt-2 text-sm bg-purple-50 p-2 rounded">
-      <div className="font-semibold mb-1">Jobs</div>
-      <ul className="list-disc ml-5">
-        {list.map((j) => (
-          <li key={j.job_id || j.start_time}>
-            {j.status} {j.documents_indexed !== undefined && `- ${j.documents_indexed} docs`}
-            {j.start_time && (
-              <span className="ml-2 text-xs text-gray-600">
-                {new Date(j.start_time).toLocaleString()}
-              </span>
-            )}
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-}
-
-function SourcesManager({ agentId }) {
-  const { token } = useAuth();
-  const { sources, mutate } = useSpecialistSources(agentId);
-  const [type, setType] = useState("link");
-  const [value, setValue] = useState("");
-
-  async function handleAdd() {
-    if (!value) return;
-    const payload: any = { type };
-    if (type === "link") payload.url = value;
-    else payload.path = value;
-    await addSource(agentId, payload, token || "");
-    setValue("");
-    mutate();
-  }
-
-  async function handleDelete(id: number) {
-    await deleteSource(agentId, id, token || "");
-    mutate();
-  }
-
-  return (
-    <div className="mt-2">
-      <div className="font-semibold text-sm">Sources</div>
-      <ul className="ml-4 list-disc text-sm">
-        {sources.map((s: any) => (
-          <li key={s.id} className="flex items-center gap-2">
-            <span>{s.type === "link" ? s.url : s.path}</span>
-            <button
-              className="text-red-600 text-xs"
-              onClick={() => handleDelete(s.id)}
-            >
-              delete
-            </button>
-          </li>
-        ))}
-      </ul>
-      <div className="flex gap-2 mt-2">
-        <select value={type} onChange={(e) => setType(e.target.value)} className="border px-1 text-sm">
-          <option value="link">link</option>
-          <option value="file">file</option>
-        </select>
-        <input
-          className="border flex-1 px-2 text-sm"
-          placeholder={type === "link" ? "URL" : "Path"}
-          value={value}
-          onChange={(e) => setValue(e.target.value)}
-        />
-        <button className="px-2 bg-indigo-600 text-white text-sm rounded" onClick={handleAdd}>add</button>
+    <div className="flex gap-4 items-center rounded-xl p-4 mb-4 bg-gradient-to-r from-indigo-50 via-purple-50 to-white shadow border border-indigo-100">
+      <div className="flex flex-col items-center">
+        <div className="w-14 h-14 bg-indigo-200 rounded-full flex items-center justify-center shadow-inner text-indigo-700 text-3xl border-4 border-indigo-300">
+          🧙‍♂️
+        </div>
+        <span className="text-xs text-indigo-600 mt-1 font-mono">Archivist</span>
+      </div>
+      <div className="flex-1">
+        <div className="text-indigo-900 font-semibold italic">{quote}</div>
+        <div className="text-xs text-indigo-700 mt-1">{flavor}</div>
+        {status && (
+          <div className="text-sm bg-indigo-200 text-indigo-900 rounded px-3 py-1 mt-2 w-fit font-semibold shadow-sm">{status}</div>
+        )}
       </div>
     </div>
   );
 }
 
+// ----- Avatar -----
+function AgentAvatar({ name, logo }) {
+  const initials = name
+    .split(" ")
+    .map(n => n[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+  return (
+    <div className="w-10 h-10 rounded-full bg-indigo-100 flex items-center justify-center text-lg font-bold text-indigo-700 shadow-inner border-2 border-indigo-200 overflow-hidden">
+      {logo ? (
+        <img src={logo} alt={name} className="object-cover w-full h-full" onError={e => { e.currentTarget.style.display = "none"; e.currentTarget.parentNode.textContent = initials; }} />
+      ) : (
+        initials
+      )}
+    </div>
+  );
+}
+
+// ----- Job Status -----
+function JobStatusScroll({ jobs }) {
+  if (!jobs || !jobs.length) return null;
+  const active = jobs.filter(j => j.status === "queued" || j.status === "processing" || j.status === "running");
+  const finished = jobs.filter(j => j.status === "done" || j.status === "error").slice(-3);
+
+  const render = job => {
+    if (job.status === "processing" || job.status === "running") return (<><span className="animate-pulse">⏳</span> Running</>);
+    if (job.status === "queued") return (<><span>🕓</span> Queued</>);
+    if (job.status === "done") return (<><span>✅</span> Done</>);
+    if (job.status === "error") return (<><span>❌</span> Error</>);
+    return <>🔄 {job.status}</>;
+  };
+
+  return (
+    <div className="bg-purple-50 border border-indigo-200 rounded-xl p-2 mt-2 shadow-inner">
+      <div className="font-semibold text-yellow-900 mb-1 flex items-center gap-1">
+        <Wand2 className="w-4 h-4 text-yellow-600" /> Vector Update Progress
+      </div>
+      {active.length > 0 && (
+        <>
+          <div className="font-semibold text-indigo-700">Active Jobs:</div>
+          <ul className="pl-3 text-sm text-yellow-900 mb-2">
+            {active.map((j, idx) => (
+              <li key={j.job_id || idx}>{render(j)}</li>
+            ))}
+          </ul>
+        </>
+      )}
+      {finished.length > 0 && (
+        <>
+          <div className="font-semibold text-indigo-700 mt-2">Recent Jobs:</div>
+          <ul className="pl-3 text-sm text-yellow-900">
+            {finished.map((j, idx) => (
+              <li key={j.job_id || idx}>{render(j)}</li>
+            ))}
+          </ul>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ----- Source Cards -----
+function SourceCard({ source, onEdit }) {
+  return (
+    <div className="border border-indigo-100 bg-white rounded-xl p-3 shadow flex flex-col">
+      <div className="font-semibold text-indigo-800">{source.name}</div>
+      <div className="text-sm break-all">
+        {source.type === "link" ? source.url : source.path}
+      </div>
+      <div className="text-xs text-gray-500 mt-1">
+        Added: {new Date(source.added_at).toLocaleString()}
+      </div>
+      <button className="mt-2 text-indigo-600 text-xs self-end" onClick={() => onEdit(source)}>
+        Edit
+      </button>
+    </div>
+  );
+}
+
+// ----- Main Page -----
 export default function SpecialistSettingsPage() {
+  const { user, token } = useAuth();
   const { agents, mutate } = useAgents();
   const { worlds } = useWorlds();
-  const { token } = useAuth();
+  const { jobs } = useSpecialistJobs();
   const [modalOpen, setModalOpen] = useState(false);
-  const [selected, setSelected] = useState(null as any);
-  const { mutate: refreshJobs } = useSpecialistJobs();
+  const [sourceModal, setSourceModal] = useState<{agentId:number, source:any}|null>(null);
+  const [selectedAgent, setSelectedAgent] = useState(null as any);
+  const [success, setSuccess] = useState("");
+  const [npcFlavor, setNpcFlavor] = useState("Manage your specialist agents and their sources here.");
+  const [npcQuote] = useState(npcQuotes[Math.floor(Math.random()*npcQuotes.length)]);
 
-  const specialists = agents.filter((a) => a.task === "specialist");
-
-  function handleEdit(agent: any) {
-    setSelected(agent);
-    setModalOpen(true);
-  }
-  function handleCreate() {
-    setSelected(null);
-    setModalOpen(true);
-  }
-  function handleSave() {
-    mutate();
-    setModalOpen(false);
-  }
-  function handleDelete() {
-    mutate();
-    setModalOpen(false);
+  if (!hasRole(user?.role, "world builder") && !hasRole(user?.role, "system admin")) {
+    return (
+      <DashboardLayout>
+        <div className="p-10 text-2xl text-red-600 font-bold">Not authorized</div>
+      </DashboardLayout>
+    );
   }
 
-  async function handleRebuild(id: number) {
-    await startVectorJob(id, token || "");
-    refreshJobs();
+  const specialists = agents.filter(a => a.task === "specialist");
+  const jobsByAgent = jobs.reduce<Record<number, any[]>>((acc,j)=>{ if(!acc[j.agent_id]) acc[j.agent_id]=[]; acc[j.agent_id].push(j); return acc; },{});
+
+  async function handleRebuild(agentId:number) {
+    setNpcFlavor("Rebuilding vectors...");
+    await startVectorJob(agentId, token||"");
+    setNpcFlavor("Job queued!");
   }
 
   return (
     <AuthGuard>
       <DashboardLayout>
-        <div className="min-h-screen w-full p-6 text-indigo-900">
-          <h1 className="text-2xl font-bold mb-4">Specialist Agents</h1>
-          <button className="mb-4 px-4 py-2 bg-indigo-600 text-white rounded" onClick={handleCreate}>
-            Add Agent
-          </button>
-          <div className="space-y-6">
-            {specialists.map((a) => (
-              <div key={a.id} className="border p-4 rounded-xl shadow">
-                <div className="flex justify-between items-center">
-                  <div>
-                    <div className="font-bold text-lg">{a.name}</div>
-                    <div className="text-sm">
-                      World: {worlds.find((w) => w.id === a.world_id)?.name || ""}
+        <div className="min-h-screen w-full text-indigo-900 px-2 sm:px-6 py-8">
+          <div className="mx-auto max-w-5xl w-full">
+            <GuildmasterGuide status={success} quote={npcQuote} flavor={npcFlavor} />
+
+            <div className="flex flex-col sm:flex-row gap-4 items-center justify-between mb-5">
+              <div className="flex gap-2">
+                <button className="flex gap-2 items-center px-5 py-2 rounded-xl font-bold bg-indigo-600 text-white shadow hover:bg-indigo-800 border border-indigo-500 transition" onClick={()=>{setSelectedAgent(null);setModalOpen(true);}}>
+                  <Sparkles className="w-5 h-5" /> Add Agent
+                </button>
+              </div>
+              <div className="flex items-center gap-2 bg-white border border-indigo-200 px-4 py-2 rounded-xl shadow-inner w-full sm:w-[340px]">
+                <Search className="w-5 h-5 text-indigo-400" />
+                <input className="bg-transparent outline-none flex-1 text-base text-indigo-700 placeholder-indigo-400" placeholder="Search agents..." onChange={()=>{}} />
+              </div>
+            </div>
+
+            <div className="space-y-6">
+              {specialists.map(agent => {
+                const { sources } = useSpecialistSources(agent.id);
+                return (
+                  <div key={agent.id} className="border border-indigo-100 bg-white/80 rounded-2xl shadow p-4">
+                    <div className="flex items-center gap-4">
+                      <AgentAvatar name={agent.name} logo={agent.logo} />
+                      <div className="flex-1">
+                        <div className="font-bold text-indigo-800">{agent.name}</div>
+                        <div className="text-sm text-indigo-700 opacity-70">
+                          World: <span className="font-semibold">{worlds?.find(w => w.id === agent.world_id)?.name || "???"}</span>
+                        </div>
+                        {agent.specialist_update_date && (
+                          <div className="text-sm text-indigo-700 opacity-70">
+                            Vector DB updated: <span className="font-semibold">{new Date(agent.specialist_update_date).toLocaleString()}</span>
+                          </div>
+                        )}
+                      </div>
+                      <div className="flex gap-2">
+                        <button className="px-3 py-1 rounded-lg font-semibold text-white bg-indigo-600 hover:bg-indigo-800 transition text-sm shadow" onClick={()=>{setSelectedAgent(agent);setModalOpen(true);}}>Edit</button>
+                        <button className="px-3 py-1 rounded-lg font-semibold text-purple-700 bg-purple-200 hover:bg-yellow-300 transition text-sm shadow border border-purple-300" onClick={()=>handleRebuild(agent.id)}>Rebuild Vector</button>
+                        <button className="px-3 py-1 rounded-lg font-semibold text-white bg-sky-600 hover:bg-sky-800 transition text-sm shadow" onClick={()=>setSourceModal({agentId:agent.id,source:null})}>Add Source</button>
+                      </div>
                     </div>
-                    {a.specialist_update_date && (
-                      <div className="text-sm text-gray-600">
-                        Vector DB updated: {new Date(a.specialist_update_date).toLocaleString()}
+                    {jobsByAgent[agent.id] && <JobStatusScroll jobs={jobsByAgent[agent.id]} />}
+                    {sources && sources.length > 0 && (
+                      <div className="mt-3 grid sm:grid-cols-2 md:grid-cols-3 gap-3">
+                        {sources.map(src => (
+                          <SourceCard key={src.id} source={src} onEdit={(s)=>setSourceModal({agentId:agent.id,source:s})} />
+                        ))}
                       </div>
                     )}
                   </div>
-                  <div className="flex gap-2">
-                    <button className="px-3 py-1 text-sm bg-indigo-500 text-white rounded" onClick={() => handleEdit(a)}>
-                      Edit
-                    </button>
-                    <button className="px-3 py-1 text-sm bg-purple-600 text-white rounded" onClick={() => handleRebuild(a.id)}>
-                      Generate Vector DB
-                    </button>
-                  </div>
-                </div>
-                <JobList agentId={a.id} />
-                <SourcesManager agentId={a.id} />
-              </div>
-            ))}
+                );
+              })}
+            </div>
+
+            {modalOpen && (
+              <AgentModal
+                agent={selectedAgent}
+                onClose={()=>setModalOpen(false)}
+                onSave={()=>{mutate();setModalOpen(false);}}
+                onDelete={()=>{mutate();setModalOpen(false);}}
+                worlds={worlds}
+              />
+            )}
+            {sourceModal && (
+              <SpecialistSourceModal
+                agentId={sourceModal.agentId}
+                source={sourceModal.source}
+                onClose={()=>setSourceModal(null)}
+                onSaved={()=>{}}
+              />
+            )}
           </div>
-          {modalOpen && (
-            <AgentModal
-              agent={selected}
-              onClose={() => setModalOpen(false)}
-              onSave={handleSave}
-              onDelete={handleDelete}
-              worlds={worlds}
-            />
-          )}
         </div>
       </DashboardLayout>
     </AuthGuard>

--- a/frontend/src/app/components/agents/SpecialistSourceModal.tsx
+++ b/frontend/src/app/components/agents/SpecialistSourceModal.tsx
@@ -1,0 +1,114 @@
+"use client";
+import { useState, useRef } from "react";
+import ModalContainer from "../template/modalContainer";
+import { M3FloatingInput } from "../template/M3FloatingInput";
+import { uploadFile } from "../../lib/uploadFile";
+import { addSource, deleteSource, SpecialistSource } from "../../lib/specialistAPI";
+import { useAuth } from "../auth/AuthProvider";
+
+export default function SpecialistSourceModal({ agentId, source, onClose, onSaved }) {
+  const { token } = useAuth();
+  const isEdit = !!source;
+  const [form, setForm] = useState<SpecialistSource>({
+    name: source?.name || "",
+    type: source?.type || "link",
+    path: source?.path,
+    url: source?.url,
+  });
+  const [file, setFile] = useState<File | null>(null);
+  const [saving, setSaving] = useState(false);
+  const fileRef = useRef<HTMLInputElement | null>(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSaving(true);
+    try {
+      const payload: Partial<SpecialistSource> = {
+        name: form.name,
+        type: form.type,
+      };
+      if (form.type === "link") {
+        payload.url = form.url;
+      } else if (file) {
+        const safeName = form.name?.trim().replace(/[^a-zA-Z0-9_-]/g, "_") || "source";
+        const ext = file.name.split('.').pop();
+        const uploaded = await uploadFile(file, `ai_specialist/${agentId}`, safeName);
+        const relPath = uploaded.replace(/^\/uploads\//, "");
+        payload.path = relPath.startsWith("ai_specialist") ? relPath : `ai_specialist/${agentId}/${safeName}.${ext}`;
+      } else if (form.path) {
+        payload.path = form.path;
+      }
+      await addSource(agentId, payload, token || "");
+    } finally {
+      setSaving(false);
+      onSaved?.();
+      onClose();
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!isEdit || !source?.id) return;
+    setSaving(true);
+    try {
+      await deleteSource(agentId, source.id, token || "");
+    } finally {
+      setSaving(false);
+      onSaved?.();
+      onClose();
+    }
+  };
+
+  return (
+    <ModalContainer title={isEdit ? "Edit Source" : "Add Source"} onClose={onClose}>
+      <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
+        <M3FloatingInput
+          label="Name"
+          value={form.name || ""}
+          onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
+          required
+        />
+        <div className="relative">
+          <select
+            className="peer w-full px-4 pt-6 pb-2 text-[var(--foreground)] bg-[var(--surface)] border-2 border-[var(--border)] rounded-xl outline-none focus:border-[var(--primary)] transition-colors text-base"
+            value={form.type}
+            onChange={e => setForm(f => ({ ...f, type: e.target.value }))}
+          >
+            <option value="link">link</option>
+            <option value="file">file</option>
+          </select>
+          <label className="absolute left-3 top-1.5 text-base text-[var(--primary)] font-semibold pointer-events-none">
+            Type
+          </label>
+        </div>
+        {form.type === "link" ? (
+          <M3FloatingInput
+            label="URL"
+            value={form.url || ""}
+            onChange={e => setForm(f => ({ ...f, url: e.target.value }))}
+            required
+          />
+        ) : (
+          <div>
+            <label className="block text-[var(--primary)] font-semibold text-sm mb-1">File</label>
+            <input
+              type="file"
+              ref={fileRef}
+              onChange={e => setFile(e.target.files?.[0] || null)}
+              className="block w-full rounded-xl border border-[var(--primary)] px-2 py-2 bg-[var(--surface-variant)] text-[var(--foreground)] focus:outline-none"
+            />
+          </div>
+        )}
+        <div className="flex justify-end gap-2 mt-4">
+          {isEdit && (
+            <button type="button" onClick={handleDelete} className="px-4 py-2 rounded-xl bg-red-600 text-white text-sm" disabled={saving}>
+              Delete
+            </button>
+          )}
+          <button type="submit" className="px-5 py-2 rounded-xl bg-[var(--primary)] text-[var(--primary-foreground)] font-bold text-sm" disabled={saving}>
+            {saving ? "Saving..." : "Save"}
+          </button>
+        </div>
+      </form>
+    </ModalContainer>
+  );
+}

--- a/frontend/src/app/lib/specialistAPI.ts
+++ b/frontend/src/app/lib/specialistAPI.ts
@@ -1,14 +1,24 @@
 import { API_URL } from "./config";
 
+export type SpecialistSource = {
+  id?: number;
+  agent_id?: number;
+  name?: string;
+  type: string;
+  path?: string;
+  url?: string;
+  added_at?: string;
+};
+
 export async function listSources(agentId: number, token: string) {
   const res = await fetch(`${API_URL}/specialist_agents/${agentId}/sources`, {
     headers: token ? { Authorization: `Bearer ${token}` } : {},
   });
   if (!res.ok) throw await res.text();
-  return await res.json();
+  return (await res.json()) as SpecialistSource[];
 }
 
-export async function addSource(agentId: number, data: any, token: string) {
+export async function addSource(agentId: number, data: Partial<SpecialistSource>, token: string) {
   const res = await fetch(`${API_URL}/specialist_agents/${agentId}/sources`, {
     method: "POST",
     headers: {
@@ -18,7 +28,7 @@ export async function addSource(agentId: number, data: any, token: string) {
     body: JSON.stringify(data),
   });
   if (!res.ok) throw await res.text();
-  return await res.json();
+  return (await res.json()) as SpecialistSource;
 }
 
 export async function deleteSource(agentId: number, sourceId: number, token: string) {

--- a/frontend/src/app/lib/useSpecialistSources.ts
+++ b/frontend/src/app/lib/useSpecialistSources.ts
@@ -1,5 +1,5 @@
 import useSWR from "swr";
-import { listSources } from "./specialistAPI";
+import { listSources, SpecialistSource } from "./specialistAPI";
 import { useAuth } from "../components/auth/AuthProvider";
 
 export function useSpecialistSources(agentId: number) {
@@ -9,5 +9,5 @@ export function useSpecialistSources(agentId: number) {
     token && agentId ? ["specialist-sources", agentId, token] : null,
     fetcher
   );
-  return { sources: data || [], error, mutate };
+  return { sources: (data as SpecialistSource[]) || [], error, mutate };
 }


### PR DESCRIPTION
## Summary
- allow specialist sources to store a `name` column
- migrate database to include `name`
- add `SpecialistSourceModal` for adding/editing sources
- revamp specialist agent settings page with agent avatars and source cards
- expose source types in API hooks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_68571c5e90f483229a18f326c434bfb0