### PR TITLE
Fix writer job filtering

### DIFF
--- a/frontend/src/app/agents_settings/agent_conversational/page.tsx
+++ b/frontend/src/app/agents_settings/agent_conversational/page.tsx
@@ -305,7 +305,7 @@ const vectorJobsByAgent = vectorJobs
   }, {});
 
 const writerJobsByAgent = writerJobs
-  .filter(j => j.job_type === "analyze_page")
+  .filter(j => j.job_type === "analyze_pages")
   .reduce<Record<number, any[]>>((acc, j) => {
     if (!acc[j.agent_id]) acc[j.agent_id] = [];
     acc[j.agent_id].push(j);

--- a/frontend/src/app/agents_settings/agent_novelist/page.tsx
+++ b/frontend/src/app/agents_settings/agent_novelist/page.tsx
@@ -305,7 +305,7 @@ const vectorJobsByAgent = vectorJobs
   }, {});
 
 const writerJobsByAgent = writerJobs
-  .filter(j => j.job_type === "analyze_page")
+  .filter(j => j.job_type === "analyze_pages")
   .reduce<Record<number, any[]>>((acc, j) => {
     if (!acc[j.agent_id]) acc[j.agent_id] = [];
     acc[j.agent_id].push(j);

--- a/frontend/src/app/agents_settings/agent_writer/page.tsx
+++ b/frontend/src/app/agents_settings/agent_writer/page.tsx
@@ -305,7 +305,7 @@ const vectorJobsByAgent = vectorJobs
   }, {});
 
 const writerJobsByAgent = writerJobs
-  .filter(j => j.job_type === "analyze_page")
+  .filter(j => j.job_type === "analyze_pages")
   .reduce<Record<number, any[]>>((acc, j) => {
     if (!acc[j.agent_id]) acc[j.agent_id] = [];
     acc[j.agent_id].push(j);


### PR DESCRIPTION
## Summary
- fix writer job filtering for agent settings pages so Writer Agent Jobs display correctly

## Testing
- `npm run lint` *(fails: Next.js telemetry details and many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6857205f74d08322bbf5254c7032577d