### PR TITLE
Update specialist source uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ pnpm-debug.log*
 *.sqlite3
 test.db
 data/
+.data/
 
 # Deployment
 .vercel

--- a/frontend/src/app/components/agents/SpecialistSourceModal.tsx
+++ b/frontend/src/app/components/agents/SpecialistSourceModal.tsx
@@ -2,8 +2,7 @@
 import { useState, useRef } from "react";
 import ModalContainer from "../template/modalContainer";
 import { M3FloatingInput } from "../template/M3FloatingInput";
-import { uploadFile } from "../../lib/uploadFile";
-import { addSource, deleteSource, SpecialistSource } from "../../lib/specialistAPI";
+import { addSource, deleteSource, SpecialistSource, uploadSourceFile } from "../../lib/specialistAPI";
 import { useAuth } from "../auth/AuthProvider";
 
 export default function SpecialistSourceModal({ agentId, source, onClose, onSaved }) {
@@ -23,24 +22,23 @@ export default function SpecialistSourceModal({ agentId, source, onClose, onSave
     e.preventDefault();
     setSaving(true);
     try {
-      const payload: Partial<SpecialistSource> = {
-        name: form.name,
-        type: form.type,
-      };
       if (form.type === "link") {
-        payload.url = form.url;
+        const payload: Partial<SpecialistSource> = {
+          name: form.name,
+          type: form.type,
+          url: form.url,
+        };
+        await addSource(agentId, payload, token || "");
       } else if (file) {
-        const safeName = form.name?.trim().replace(/[^a-zA-Z0-9_-]/g, "_") || "source";
-        const ext = file.name.split('.').pop();
-        const uploaded = await uploadFile(file, `ai_specialist/${agentId}`, safeName);
-        const relPath = uploaded.replace(/^\/uploads\//, "");
-        payload.path = relPath.startsWith("ai_specialist") ? relPath : `ai_specialist/${agentId}/${safeName}.${ext}`;
-
-        console.log("Payload path:" + payload.path)
+        await uploadSourceFile(agentId, form.name, file, token || "");
       } else if (form.path) {
-        payload.path = form.path;
+        const payload: Partial<SpecialistSource> = {
+          name: form.name,
+          type: form.type,
+          path: form.path,
+        };
+        await addSource(agentId, payload, token || "");
       }
-      await addSource(agentId, payload, token || "");
     } finally {
       setSaving(false);
       onSaved?.();

--- a/frontend/src/app/lib/specialistAPI.ts
+++ b/frontend/src/app/lib/specialistAPI.ts
@@ -31,6 +31,19 @@ export async function addSource(agentId: number, data: Partial<SpecialistSource>
   return (await res.json()) as SpecialistSource;
 }
 
+export async function uploadSourceFile(agentId: number, name: string, file: File, token: string) {
+  const formData = new FormData();
+  formData.append("name", name);
+  formData.append("file", file);
+  const res = await fetch(`${API_URL}/specialist_agents/${agentId}/source_file`, {
+    method: "POST",
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+    body: formData,
+  });
+  if (!res.ok) throw await res.text();
+  return (await res.json()) as SpecialistSource;
+}
+
 export async function deleteSource(agentId: number, sourceId: number, token: string) {
   const res = await fetch(`${API_URL}/specialist_agents/${agentId}/sources/${sourceId}`, {
     method: "DELETE",


### PR DESCRIPTION
## Summary
- backend: add API for uploading specialist source files
- store specialist uploads under `.data/specialist_agents/{id}`
- frontend: call new API and send files directly to the backend
- ignore `.data` directory
- update tests for the new upload workflow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68572778d540832299e3a29a521858bb