### PR TITLE
Add job progress info for specialist vector rebuild

### DIFF
--- a/frontend/src/app/agents_settings/agent_specialist/page.tsx
+++ b/frontend/src/app/agents_settings/agent_specialist/page.tsx
@@ -72,6 +72,40 @@ function JobStatusScroll({ jobs }) {
     return <>🔄 {job.status}</>;
   };
 
+  const renderProgress = job => {
+    if (job.progress) {
+      return <div className="text-xs text-indigo-700 ml-5">{job.progress}</div>;
+    }
+    return null;
+  };
+
+  const renderDocs = job => {
+    if (job.documents_indexed !== undefined && job.documents_indexed !== null) {
+      return (
+        <div className="text-xs text-gray-700 ml-5">
+          Documents indexed: <span className="font-semibold">{job.documents_indexed}</span>
+        </div>
+      );
+    }
+    return null;
+  };
+
+  const renderTime = job => {
+    const start = job.start_time ? new Date(job.start_time) : null;
+    const end = job.end_time ? new Date(job.end_time) : null;
+    let dur = "";
+    if (start && end) {
+      const diff = (end.getTime() - start.getTime()) / 1000;
+      dur = ` (${Math.round(diff)}s)`;
+    }
+    return (
+      <div className="text-xs text-gray-500 ml-5">
+        Start: {start ? start.toLocaleString() : "?"}
+        {end && <> | End: {end.toLocaleString()}{dur}</>}
+      </div>
+    );
+  };
+
   return (
     <div className="bg-purple-50 border border-indigo-200 rounded-xl p-2 mt-2 shadow-inner">
       <div className="font-semibold text-yellow-900 mb-1 flex items-center gap-1">
@@ -82,7 +116,11 @@ function JobStatusScroll({ jobs }) {
           <div className="font-semibold text-indigo-700">Active Jobs:</div>
           <ul className="pl-3 text-sm text-yellow-900 mb-2">
             {active.map((j, idx) => (
-              <li key={j.job_id || idx}>{render(j)}</li>
+              <li key={j.job_id || idx} className="mb-1">
+                {render(j)}
+                {renderProgress(j)}
+                {renderTime(j)}
+              </li>
             ))}
           </ul>
         </>
@@ -92,7 +130,11 @@ function JobStatusScroll({ jobs }) {
           <div className="font-semibold text-indigo-700 mt-2">Recent Jobs:</div>
           <ul className="pl-3 text-sm text-yellow-900">
             {finished.map((j, idx) => (
-              <li key={j.job_id || idx}>{render(j)}</li>
+              <li key={j.job_id || idx} className="mb-1">
+                {render(j)}
+                {renderDocs(j)}
+                {renderTime(j)}
+              </li>
             ))}
           </ul>
         </>


### PR DESCRIPTION
## Summary
- track rebuild progress in `rebuild_specialist_vectors`
- expose `rebuild_agent_with_progress` helper for specialist jobs
- show progress and runtime info in specialist settings page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_68572f9afde48322856247c8d5d7ad0f