### PR TITLE
Add specialist DB import/export

### DIFF
--- a/frontend/src/app/agents_settings/agent_specialist/page.tsx
+++ b/frontend/src/app/agents_settings/agent_specialist/page.tsx
@@ -12,6 +12,8 @@ import { useSpecialistSources } from "../../lib/useSpecialistSources";
 import { startVectorJob } from "../../lib/specialistAPI";
 import AgentModal from "../../components/agents/AgentModal";
 import SpecialistSourceModal from "../../components/agents/SpecialistSourceModal";
+import ExportVectorDBModal from "../../components/agents/ExportVectorDBModal";
+import ImportVectorDBModal from "../../components/agents/ImportVectorDBModal";
 import { Link as LinkIcon, FileText, FileImage, FileArchive, FileVideo, FileAudio, File } from "lucide-react";
 
 
@@ -237,6 +239,8 @@ export default function SpecialistSettingsPage() {
   const [modalOpen, setModalOpen] = useState(false);
   const [sourceModal, setSourceModal] = useState<{agentId:number, source:any}|null>(null);
   const [selectedAgent, setSelectedAgent] = useState(null as any);
+  const [exportAgent, setExportAgent] = useState(null as any);
+  const [importAgent, setImportAgent] = useState(null as any);
   const [success, setSuccess] = useState("");
   const [npcFlavor, setNpcFlavor] = useState("Manage your specialist agents and their sources here.");
   const [npcQuote] = useState(npcQuotes[Math.floor(Math.random()*npcQuotes.length)]);
@@ -295,10 +299,12 @@ export default function SpecialistSettingsPage() {
                           </div>
                         )}
                       </div>
-                      <div className="flex gap-2">
+                      <div className="flex gap-2 flex-wrap">
                         <button className="px-3 py-1 rounded-lg font-semibold text-white bg-indigo-600 hover:bg-indigo-800 transition text-sm shadow" onClick={()=>{setSelectedAgent(agent);setModalOpen(true);}}>Edit</button>
                         <button className="px-3 py-1 rounded-lg font-semibold text-purple-700 bg-purple-200 hover:bg-yellow-300 transition text-sm shadow border border-purple-300" onClick={()=>handleRebuild(agent.id)}>Rebuild Vector</button>
                         <button className="px-3 py-1 rounded-lg font-semibold text-white bg-sky-600 hover:bg-sky-800 transition text-sm shadow" onClick={()=>setSourceModal({agentId:agent.id,source:null})}>Add Source</button>
+                        <button className="px-3 py-1 rounded-lg font-semibold text-white bg-emerald-600 hover:bg-emerald-800 transition text-sm shadow" onClick={()=>setExportAgent(agent)}>Export DB</button>
+                        <button className="px-3 py-1 rounded-lg font-semibold text-white bg-amber-600 hover:bg-amber-800 transition text-sm shadow" onClick={()=>setImportAgent(agent)}>Import DB</button>
                       </div>
                     </div>
                     {jobsByAgent[agent.id] && <JobStatusScroll jobs={jobsByAgent[agent.id]} />}
@@ -329,6 +335,19 @@ export default function SpecialistSettingsPage() {
                 source={sourceModal.source}
                 onClose={()=>setSourceModal(null)}
                 onSaved={()=>{}}
+              />
+            )}
+            {exportAgent && (
+              <ExportVectorDBModal
+                agent={exportAgent}
+                onClose={()=>setExportAgent(null)}
+              />
+            )}
+            {importAgent && (
+              <ImportVectorDBModal
+                agent={importAgent}
+                onClose={()=>setImportAgent(null)}
+                onImported={()=>{}}
               />
             )}
           </div>

--- a/frontend/src/app/components/agents/ExportVectorDBModal.tsx
+++ b/frontend/src/app/components/agents/ExportVectorDBModal.tsx
@@ -1,0 +1,59 @@
+"use client";
+import { useState } from "react";
+import ModalContainer from "../template/modalContainer";
+import { exportVectorDB } from "../../lib/specialistAPI";
+import { downloadBlob } from "../../lib/importExportAPI";
+import { useAuth } from "../auth/AuthProvider";
+
+export default function ExportVectorDBModal({ agent, onClose }) {
+  const { token } = useAuth();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleExport() {
+    setLoading(true);
+    setError("");
+    try {
+      const blob = await exportVectorDB(agent.id, token || "");
+      downloadBlob(blob, `agent_${agent.id}_vectordb.json`);
+      onClose();
+    } catch (err) {
+      setError("Failed to export vector DB");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (!agent) return null;
+
+  return (
+    <ModalContainer title="Export Vector DB" onClose={onClose}>
+      <div className="space-y-4">
+        <p className="text-sm text-[var(--foreground)]">
+          Download the vector database for <b>{agent.name}</b> as a JSON file.
+        </p>
+        {error && (
+          <div className="text-red-600 text-sm">{error}</div>
+        )}
+        <div className="flex justify-end gap-3">
+          <button
+            type="button"
+            className="px-5 py-2 rounded-xl font-bold bg-[var(--primary)] text-[var(--primary-foreground)] hover:bg-[var(--accent)] transition"
+            onClick={handleExport}
+            disabled={loading}
+          >
+            {loading ? "Exporting..." : "Download"}
+          </button>
+          <button
+            type="button"
+            className="px-5 py-2 rounded-xl font-semibold border border-[var(--border)] bg-[var(--surface)] text-[var(--primary)]"
+            onClick={onClose}
+            disabled={loading}
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </ModalContainer>
+  );
+}

--- a/frontend/src/app/components/agents/ImportVectorDBModal.tsx
+++ b/frontend/src/app/components/agents/ImportVectorDBModal.tsx
@@ -1,0 +1,65 @@
+"use client";
+import { useState } from "react";
+import ModalContainer from "../template/modalContainer";
+import { importVectorDB } from "../../lib/specialistAPI";
+import { useAuth } from "../auth/AuthProvider";
+
+export default function ImportVectorDBModal({ agent, onClose, onImported }) {
+  const { token } = useAuth();
+  const [file, setFile] = useState<File | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleImport(e) {
+    e.preventDefault();
+    if (!file) return;
+    setLoading(true);
+    setError("");
+    try {
+      await importVectorDB(agent.id, file, token || "");
+      onImported?.();
+      onClose();
+    } catch (err) {
+      setError("Failed to import vector DB");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (!agent) return null;
+
+  return (
+    <ModalContainer title="Import Vector DB" onClose={onClose}>
+      <form className="flex flex-col gap-4" onSubmit={handleImport}>
+        <p className="text-sm text-[var(--foreground)]">
+          Replace <b>{agent.name}</b>'s vector database with data from a JSON file.
+        </p>
+        <input
+          type="file"
+          accept=".json,application/json"
+          onChange={e => setFile(e.target.files?.[0] || null)}
+          className="rounded-xl border border-[var(--primary)] px-3 py-2 bg-[var(--surface)] text-[var(--primary)]"
+          disabled={loading}
+        />
+        {error && <div className="text-red-600 text-sm">{error}</div>}
+        <div className="flex justify-end gap-3">
+          <button
+            type="submit"
+            className="px-5 py-2 rounded-xl font-bold bg-[var(--primary)] text-[var(--primary-foreground)] hover:bg-[var(--accent)] transition"
+            disabled={loading || !file}
+          >
+            {loading ? "Importing..." : "Import"}
+          </button>
+          <button
+            type="button"
+            className="px-5 py-2 rounded-xl font-semibold border border-[var(--border)] bg-[var(--surface)] text-[var(--primary)]"
+            onClick={onClose}
+            disabled={loading}
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </ModalContainer>
+  );
+}

--- a/frontend/src/app/lib/specialistAPI.ts
+++ b/frontend/src/app/lib/specialistAPI.ts
@@ -106,3 +106,23 @@ export async function clearSpecialistHistory(agentId: number, token: string) {
   if (!res.ok) throw await res.text();
   return await res.json();
 }
+
+export async function exportVectorDB(agentId: number, token: string) {
+  const res = await fetch(`${API_URL}/specialist_agents/${agentId}/export_vectordb`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) throw await res.text();
+  return await res.blob();
+}
+
+export async function importVectorDB(agentId: number, file: File, token: string) {
+  const formData = new FormData();
+  formData.append("file", file);
+  const res = await fetch(`${API_URL}/specialist_agents/${agentId}/import_vectordb`, {
+    method: "POST",
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+    body: formData,
+  });
+  if (!res.ok) throw await res.text();
+  return await res.json();
+}


### PR DESCRIPTION
## Summary
- add functions to export/import specialist vector DB
- expose export/import endpoints
- support export/import from the frontend
- provide modal UIs for exporting/importing vector DBs

## Testing
- `pytest -q` *(fails: requests.exceptions.ProxyError)*

------
https://chatgpt.com/codex/tasks/task_e_6857b78a984c8322bc3bee42d1048e30