### PR TITLE
Display system names for specialists

### DIFF
--- a/frontend/src/app/ai_specialist/page.tsx
+++ b/frontend/src/app/ai_specialist/page.tsx
@@ -14,6 +14,8 @@ export default function AISpecialistPage() {
 
   const specialists = agents.filter(a => a.task === "specialist");
   const worldName = (id: number) => worlds.find(w => w.id === id)?.name || "";
+  const worldSystem = (id: number) =>
+    worlds.find(w => w.id === id)?.system || "";
 
   return (
     <AuthGuard>
@@ -40,6 +42,7 @@ export default function AISpecialistPage() {
                     <Image src={a.logo || "/images/default/avatars/logo.png"} alt={a.name} width={100} height={100} className="rounded-full object-cover border-2 border-fuchsia-300 shadow mb-2" />
                     <span className="text-xl font-bold text-indigo-800">{a.name}</span>
                     <span className="text-sm text-fuchsia-700">{worldName(a.world_id)}</span>
+                    <span className="text-xs text-indigo-700">System: {worldSystem(a.world_id)}</span>
                   </button>
                 ))
               )}

--- a/frontend/src/app/worlds/[worldID]/page.tsx
+++ b/frontend/src/app/worlds/[worldID]/page.tsx
@@ -294,7 +294,7 @@ export default function WorldDetailPage({ params }) {
             {agent.name}
           </h3>
           <p className="text-xs text-[var(--foreground)]/70">
-            {agent.task === "specialist" ? "Specialist" : "Elder"}
+            {agent.task === "specialist" ? `Specialist on ${world.system}` : "Elder"}
           </p>
         </Link>
       ))}


### PR DESCRIPTION
## Summary
- show which RPG system each AI specialist focuses on in `/ai_specialist`
- show world system next to specialists on world pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6857c2cc39dc8322b080995bf8e33dec