### PR TITLE
Enhance specialist chat UI with source downloads

### DIFF
--- a/backend/app/crud/crud_specialist_source.py
+++ b/backend/app/crud/crud_specialist_source.py
@@ -21,6 +21,9 @@ async def get_sources(session: AsyncSession, agent_id: int) -> List[SpecialistSo
     result = await session.execute(select(SpecialistSource).where(SpecialistSource.agent_id == agent_id))
     return result.scalars().all()
 
+async def get_source(session: AsyncSession, source_id: int) -> Optional[SpecialistSource]:
+    return await session.get(SpecialistSource, source_id)
+
 async def delete_source(session: AsyncSession, source_id: int) -> bool:
     obj = await session.get(SpecialistSource, source_id)
     if not obj:

--- a/backend/tests/test_specialist.py
+++ b/backend/tests/test_specialist.py
@@ -39,6 +39,14 @@ async def test_specialist_sources(async_client, create_user, login_and_get_token
     assert len(data) == 1
     assert data[0]["name"] == "doc"
 
+    resp = await async_client.get(
+        f"/specialist_agents/{agent_id}/sources/{source_id}/download",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.headers["content-disposition"].startswith("attachment")
+    assert resp.content == b"hello world"
+
     resp = await async_client.post(
         f"/specialist_agents/{agent_id}/rebuild_vectors",
         headers={"Authorization": f"Bearer {token}"},

--- a/frontend/src/app/lib/specialistAPI.ts
+++ b/frontend/src/app/lib/specialistAPI.ts
@@ -55,6 +55,14 @@ export async function deleteSource(agentId: number, sourceId: number, token: str
   return await res.json();
 }
 
+export async function downloadSource(agentId: number, sourceId: number, token: string) {
+  const res = await fetch(`${API_URL}/specialist_agents/${agentId}/sources/${sourceId}/download`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) throw await res.text();
+  return await res.blob();
+}
+
 export async function startVectorJob(agentId: number, token: string) {
   const res = await fetch(`${API_URL}/specialist_agents/${agentId}/rebuild_vectors_async`, {
     method: "POST",


### PR DESCRIPTION
## Summary
- allow downloading a specialist source file from the backend
- expose API helper to download sources
- display a "Knowledge Tomes" sidebar listing sources with download buttons
- replace text input with multiline textarea on specialist chat page
- test specialist source download endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_6857c3e98e8c8322a74238cc501a5638