### PR TITLE
Add specialist export with sources

### DIFF
--- a/backend/app/schemas/schema_agent.py
+++ b/backend/app/schemas/schema_agent.py
@@ -14,6 +14,7 @@ class AgentRead(AgentCreate):
     created_at: datetime
     updated_at: datetime
     vector_db_update_date: Optional[datetime] = None
+    specialist_update_date: Optional[datetime] = None
 
     class Config:
         orm_mode = True
@@ -25,4 +26,5 @@ class AgentUpdate(BaseModel):
     task: Optional[str] = None
     world_id: Optional[int] = None
     vector_db_update_date: Optional[datetime] = None
+    specialist_update_date: Optional[datetime] = None
 

--- a/frontend/src/app/components/agents/ExportVectorDBModal.tsx
+++ b/frontend/src/app/components/agents/ExportVectorDBModal.tsx
@@ -15,7 +15,7 @@ export default function ExportVectorDBModal({ agent, onClose }) {
     setError("");
     try {
       const blob = await exportVectorDB(agent.id, token || "");
-      downloadBlob(blob, `agent_${agent.id}_vectordb.json`);
+      downloadBlob(blob, `agent_${agent.id}_export.json`);
       onClose();
     } catch (err) {
       setError("Failed to export vector DB");


### PR DESCRIPTION
## Summary
- bundle specialist sources with vector DB when exporting
- import bundled sources and vector DB in a single step
- allow deleting all specialist sources in CRUD
- expose `specialist_update_date` through API schemas
- rename export filename on the frontend

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_6857ec868be0832287b37e6d6125dea1