### PR TITLE
Enhance Elder chat with source list

### DIFF
--- a/frontend/src/app/elders/[id]/page.tsx
+++ b/frontend/src/app/elders/[id]/page.tsx
@@ -1,16 +1,20 @@
 "use client";
+export const dynamic = "force-dynamic";
 import { useParams } from "next/navigation";
 import { useState, useEffect, useRef, FormEvent } from "react";
+import { motion } from "framer-motion";
 import DashboardLayout from "../../components/DashboardLayout";
 import AuthGuard from "../../components/auth/AuthGuard";
 import { useAgentById } from "../../lib/useAgentById";
-import { chatWithAgent, getChatHistory, clearChatHistory, ChatMessage } from "../../lib/agentAPI";
+import { chatWithAgent, getChatHistory, clearChatHistory, ChatMessage, SourceLink } from "../../lib/agentAPI";
+import { getPage } from "../../lib/pagesAPI";
 import { useAuth } from "../../components/auth/AuthProvider";
 import Image from "next/image";
 import WikiLinkHoverCard from "../../components/editor/WikiLinkHoverCard";
 import { Loader2 } from "lucide-react";
 
 interface Message extends ChatMessage { time: Date }
+interface SourceInfo { title: string; url: string; logo?: string }
 
 export default function ElderChatPage() {
   const params = useParams();
@@ -19,6 +23,7 @@ export default function ElderChatPage() {
   const { agent } = useAgentById(id);
 
   const [messages, setMessages] = useState<Message[]>([]);
+  const [sourceInfos, setSourceInfos] = useState<SourceInfo[]>([]);
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -29,6 +34,8 @@ export default function ElderChatPage() {
       .then((msgs) => {
         const withTime = (msgs as ChatMessage[]).map(m => ({ ...m, time: new Date() }));
         setMessages(withTime);
+        const last = [...withTime].reverse().find(m => m.role === "assistant" && m.sources);
+        if (last && last.sources) updateSourceInfos(last.sources);
         scrollToBottom();
       })
       .catch(() => setMessages([]));
@@ -36,6 +43,29 @@ export default function ElderChatPage() {
 
   function scrollToBottom() {
     setTimeout(() => messagesEndRef.current?.scrollIntoView({ behavior: "smooth" }), 50);
+  }
+
+  async function updateSourceInfos(sources: SourceLink[] = []) {
+    if (!sources.length) {
+      setSourceInfos([]);
+      return;
+    }
+    const infos: SourceInfo[] = await Promise.all(
+      sources.map(async (s) => {
+        let title = s.title;
+        let logo: string | undefined = undefined;
+        const match = s.url.match(/page\/(\d+)/);
+        if (match) {
+          try {
+            const page = await getPage(Number(match[1]), token || "");
+            title = page.name;
+            logo = page.logo;
+          } catch {}
+        }
+        return { title, url: s.url, logo };
+      })
+    );
+    setSourceInfos(infos);
   }
 
   async function handleSend(e: FormEvent) {
@@ -59,6 +89,7 @@ export default function ElderChatPage() {
         arr[arr.length - 1] = { role: "assistant", content: answer, sources, time: new Date() };
         return arr;
       });
+      updateSourceInfos(sources);
       scrollToBottom();
     } catch {
       setMessages(m => {
@@ -66,6 +97,7 @@ export default function ElderChatPage() {
         arr[arr.length - 1] = { role: "assistant", content: "Sorry, something went wrong.", time: new Date() };
         return arr;
       });
+      updateSourceInfos([]);
       scrollToBottom();
     }
     setLoading(false);
@@ -80,6 +112,7 @@ export default function ElderChatPage() {
     try {
       await clearChatHistory(id, token || "");
       setMessages([]);
+      setSourceInfos([]);
     } catch (e) {
       console.error(e);
     }
@@ -129,6 +162,33 @@ export default function ElderChatPage() {
                 Clear chat
               </button>
             </div>
+            {sourceInfos.length > 0 && (
+              <div className="mb-3 flex flex-wrap gap-3">
+                {sourceInfos.map((s) => (
+                  <motion.a
+                    key={s.url}
+                    href={s.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-2 px-2 py-1 rounded-lg bg-[var(--surface-variant)] border border-[var(--border)] hover:bg-[var(--surface)]"
+                    whileHover={{ scale: 1.05 }}
+                  >
+                    {s.logo && (
+                      <Image
+                        src={s.logo}
+                        alt={s.title}
+                        width={32}
+                        height={32}
+                        className="w-8 h-8 rounded object-cover"
+                      />
+                    )}
+                    <span className="text-sm font-semibold text-[var(--foreground)]">
+                      {s.title}
+                    </span>
+                  </motion.a>
+                ))}
+              </div>
+            )}
             <div className="flex-1 overflow-y-auto space-y-4 mb-2 border border-[var(--border)] rounded-xl p-3 bg-[var(--surface)]">
               {messages.map((m, idx) => (
                 <div key={idx} className={`flex ${m.role === "user" ? "justify-end" : "justify-start"}`}>


### PR DESCRIPTION
## Summary
- improve elder chat page with dynamic behavior similar to specialist chat
- show latest message sources with page logo and name
- keep source list synced when chatting or clearing history

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_6857f232d81c832299777c517c8bd320