### PR TITLE
Fix ChatPromptTemplate invocation

### DIFF
--- a/backend/app/crud/crud_agent.py
+++ b/backend/app/crud/crud_agent.py
@@ -139,7 +139,11 @@ async def chat_with_agent(
     builder.set_finish_point("chat")
     graph = builder.compile()
 
-    response = await graph.ainvoke([HumanMessage(content=query)], {"input": query})
+    # The graph expects only the input mapping. Passing the HumanMessage list
+    # causes the prompt template to receive a list instead of a dict, leading
+    # to `Expected mapping type` errors. The query message is already provided
+    # via the input variable.
+    response = await graph.ainvoke({"input": query})
 
     return {"answer": response[1].content, "sources": sources}
 

--- a/backend/app/crud/crud_specialist_agent.py
+++ b/backend/app/crud/crud_specialist_agent.py
@@ -81,6 +81,9 @@ async def chat_with_specialist(
     builder.set_entry_point("chat")
     builder.set_finish_point("chat")
     graph = builder.compile()
-    response = await graph.ainvoke([HumanMessage(content=query)], {"input": query})
+    # Only pass the prompt variables to the graph. Passing a list of messages
+    # results in the ChatPromptTemplate receiving a list instead of a mapping
+    # and triggers a TypeError. The query is provided via the `input` key.
+    response = await graph.ainvoke({"input": query})
 
     return {"answer": response[1].content, "sources": sources}


### PR DESCRIPTION
## Summary
- correct graph.ainvoke arguments in `crud_agent` and `crud_specialist_agent`

## Testing
- `pytest -q` *(fails: Unable to download HuggingFace model due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68580dcea1d0832280c3ae82ebf18018