### PR TITLE
Personalize agent responses with user nickname

### DIFF
--- a/backend/app/api/api_agent.py
+++ b/backend/app/api/api_agent.py
@@ -187,7 +187,12 @@ async def chat(
     history = crud_chat_history.load_history(user.id, agent_id)
     user_msg = msgs[-1] if msgs else {"role": "user", "content": ""}
     chat_messages = history + [user_msg]
-    assistant_resp = await chat_with_agent(session, agent_id, chat_messages)
+    assistant_resp = await chat_with_agent(
+        session,
+        agent_id,
+        chat_messages,
+        user_nickname=user.nickname,
+    )
 
     assistant_msg = {"role": "assistant", "content": assistant_resp["answer"]}
     if assistant_resp.get("sources"):

--- a/backend/app/api/api_specialist.py
+++ b/backend/app/api/api_specialist.py
@@ -234,7 +234,12 @@ async def specialist_chat(
     history = crud_chat_history.load_history(user.id, agent_id)
     user_msg = msgs[-1] if msgs else {"role": "user", "content": ""}
     chat_messages = history + [user_msg]
-    assistant_resp = await chat_with_specialist(session, agent_id, chat_messages)
+    assistant_resp = await chat_with_specialist(
+        session,
+        agent_id,
+        chat_messages,
+        user_nickname=user.nickname,
+    )
     assistant_msg = {"role": "assistant", "content": assistant_resp["answer"]}
     if assistant_resp.get("sources"):
         assistant_msg["sources"] = assistant_resp["sources"]

--- a/backend/app/crud/crud_agent.py
+++ b/backend/app/crud/crud_agent.py
@@ -60,7 +60,11 @@ async def ensure_personality_prompts(personalities: list[str]) -> dict:
 
 
 async def chat_with_agent(
-    session: AsyncSession, agent_id: int, messages: list[dict], n_results: int = 5
+    session: AsyncSession,
+    agent_id: int,
+    messages: list[dict],
+    n_results: int = 5,
+    user_nickname: str | None = None,
 ) -> dict:
     """Return a chat response and source links using OpenAI with world and agent context."""
 
@@ -113,6 +117,7 @@ async def chat_with_agent(
         f"World description: {world.description}\n"
         f"Agent`s personality: {personality}\n"
         f"{tone}\n"
+        + (f"The user you are assisting is named {user_nickname}. Always address them as {user_nickname}.\n" if user_nickname else "")
         "Use the following context and chat history to answer the user's question.\n"
         "Use the agent`s personality to give the tone of your responses. Stick to it, and make it creative!\n"
         "Do not mention any links in your answer.\n"

--- a/backend/app/crud/crud_novel.py
+++ b/backend/app/crud/crud_novel.py
@@ -76,7 +76,9 @@ async def create_novel(
                 {"role": "system", "content": helper_content},
                 {"role": "user", "content": group_text},
             ]
-            helper_resp = await chat_with_agent(session, world_agent_id, helper_msgs)
+            helper_resp = await chat_with_agent(
+                session, world_agent_id, helper_msgs, user_nickname=None
+            )
             world_info = helper_resp.get("answer", "")
 
         prev_summary = " ".join(summaries[-3:])
@@ -102,7 +104,9 @@ async def create_novel(
             {"role": "system", "content": base_prompt},
             {"role": "user", "content": group_text},
         ]
-        resp = await chat_with_agent(session, agent.id, messages)
+        resp = await chat_with_agent(
+            session, agent.id, messages, user_nickname=None
+        )
         output = resp.get("answer", "")
         # Parse output
         if "\nSummary:" in output:
@@ -132,7 +136,9 @@ async def create_novel(
             {"role": "system", "content": critic_prompt},
             {"role": "user", "content": full_summary},
         ]
-        critic_resp = await chat_with_agent(session, critic_agent_id, critic_messages)
+        critic_resp = await chat_with_agent(
+            session, critic_agent_id, critic_messages, user_nickname=None
+        )
         critic_notes = critic_resp.get("answer", "")
 
     # Second rewrite incorporating critic suggestions
@@ -170,7 +176,9 @@ async def create_novel(
             {"role": "system", "content": rewrite_prompt},
             {"role": "user", "content": chunk},
         ]
-        resp = await chat_with_agent(session, agent.id, messages)
+        resp = await chat_with_agent(
+            session, agent.id, messages, user_nickname=None
+        )
         rewritten = resp.get("answer", "")
 
         if world_agent_id:
@@ -178,7 +186,9 @@ async def create_novel(
                 {"role": "system", "content": "Provide additional world details for this text."},
                 {"role": "user", "content": rewritten},
             ]
-            helper_resp = await chat_with_agent(session, world_agent_id, helper_msgs)
+            helper_resp = await chat_with_agent(
+                session, world_agent_id, helper_msgs, user_nickname=None
+            )
             rewritten = rewritten + " " + helper_resp.get("answer", "")
 
         final_sections2.append(rewritten)

--- a/backend/app/crud/crud_specialist_agent.py
+++ b/backend/app/crud/crud_specialist_agent.py
@@ -18,7 +18,11 @@ openai_model = settings.open_ai_model
 
 
 async def chat_with_specialist(
-    session: AsyncSession, agent_id: int, messages: List[dict], n_results: int = 5
+    session: AsyncSession,
+    agent_id: int,
+    messages: List[dict],
+    n_results: int = 5,
+    user_nickname: str | None = None,
 ) -> dict:
     """Generate a chat response using the specialist vector database."""
     agent = await session.get(Agent, agent_id)
@@ -60,6 +64,7 @@ async def chat_with_specialist(
         f"Agent name: {agent_name}\n"
         f"Agent's personality: {personality}\n"
         f"{tone}\n"
+        + (f"The user you are assisting is named {user_nickname}. Always address them as {user_nickname}.\n" if user_nickname else "")
         "Use the following context and chat history to answer the user's question.\n"
         "Add HTML formatting like <p> or <strong> to make responses pleasant.\n"
         "If no relevant information is found in the documents, inform the user."

--- a/frontend/src/app/agent_writer/[agentID]/[pageID]/page.tsx
+++ b/frontend/src/app/agent_writer/[agentID]/[pageID]/page.tsx
@@ -76,7 +76,7 @@ function AgentBubble({ agent, children, loading = false }) {
 
 export default function PageAnalyze() {
   const { agentID, pageID } = useParams();
-  const { token } = useAuth();
+  const { user, token } = useAuth();
   const { page } = usePageById(Number(pageID));
   const { agent } = useAgentById(Number(agentID));
   const { concepts } = useConcepts(agent?.world_id);
@@ -291,7 +291,11 @@ export default function PageAnalyze() {
             {step === 0 && (
               <>
                 <AgentBubble agent={agent}>
-                  <b>Step 1: Review the Old Tome</b><br />“Let us read the ancient page together...”
+                  <b>Step 1: Review the Old Tome</b>
+                  <br />
+                  {user?.nickname
+                    ? `${user.nickname}, let us read the ancient page together...`
+                    : '“Let us read the ancient page together...”'}
                 </AgentBubble>
                 {page && (
                   <div className="bg-[var(--card)] p-6 rounded-xl border border-[var(--border)] shadow max-w-3xl mx-auto">
@@ -321,7 +325,10 @@ export default function PageAnalyze() {
         {subStep === 'a' && (
           <>
             <b>Step 2A: Remove Unworthy Suggestions</b>
-            <br />Begin by eliminating any irrelevant or incorrect suggestions.
+            <br />
+            {user?.nickname
+              ? `${user.nickname}, begin by eliminating any irrelevant or incorrect suggestions.`
+              : 'Begin by eliminating any irrelevant or incorrect suggestions.'}
             <p className="mt-2 text-sm italic text-[var(--muted-foreground)]">
               Click “Remove” on any suggestion you don't want to keep.
             </p>
@@ -330,7 +337,10 @@ export default function PageAnalyze() {
         {subStep === 'b' && (
           <>
             <b>Step 2B: Merge Similar Suggestions</b>
-            <br />Now, group together suggestions that refer to the same topic.
+            <br />
+            {user?.nickname
+              ? `${user.nickname}, now group together suggestions that refer to the same topic.`
+              : 'Now, group together suggestions that refer to the same topic.'}
             <p className="mt-2 text-sm italic text-[var(--muted-foreground)]">
               Use the “Merge With” dropdown on each card to link related suggestions.
             </p>
@@ -339,7 +349,10 @@ export default function PageAnalyze() {
         {subStep === 'c' && (
           <>
             <b>Step 2C: Finalize Pages</b>
-            <br />Time to assign concepts and decide whether to create or update pages.
+            <br />
+            {user?.nickname
+              ? `${user.nickname}, time to assign concepts and decide whether to create or update pages.`
+              : 'Time to assign concepts and decide whether to create or update pages.'}
             <p className="mt-2 text-sm italic text-[var(--muted-foreground)]">
               Set the action, select the target concept, and pick an existing page if updating.
             </p>

--- a/frontend/src/app/agent_writer/[agentID]/suggestions/[jobID]/page.tsx
+++ b/frontend/src/app/agent_writer/[agentID]/suggestions/[jobID]/page.tsx
@@ -74,7 +74,7 @@ function AgentBubble({ agent, children, loading = false }: any) {
 
 export default function SuggestionsPage() {
   const { agentID, jobID } = useParams();
-  const { token } = useAuth();
+  const { user, token } = useAuth();
   const router = useRouter();
 
   const [job, setJob] = useState<any>(null);
@@ -240,7 +240,10 @@ export default function SuggestionsPage() {
                 {subStep === 'a' && (
                   <>
                     <b>Step 2A: Remove Unworthy Suggestions</b>
-                    <br />Begin by eliminating any irrelevant or incorrect suggestions.
+                    <br />
+                    {user?.nickname
+                      ? `${user.nickname}, begin by eliminating any irrelevant or incorrect suggestions.`
+                      : 'Begin by eliminating any irrelevant or incorrect suggestions.'}
                     <p className="mt-2 text-sm italic text-[var(--muted-foreground)]">
                       Click “Remove” on any suggestion you don't want to keep.
                     </p>
@@ -249,7 +252,10 @@ export default function SuggestionsPage() {
                 {subStep === 'b' && (
                   <>
                     <b>Step 2B: Merge Similar Suggestions</b>
-                    <br />Now, group together suggestions that refer to the same topic.
+                    <br />
+                    {user?.nickname
+                      ? `${user.nickname}, now group together suggestions that refer to the same topic.`
+                      : 'Now, group together suggestions that refer to the same topic.'}
                     <p className="mt-2 text-sm italic text-[var(--muted-foreground)]">
                       Use the “Merge With” dropdown on each card to link related suggestions.
                     </p>
@@ -258,7 +264,10 @@ export default function SuggestionsPage() {
                 {subStep === 'c' && (
                   <>
                     <b>Step 2C: Finalize Pages</b>
-                    <br />Time to assign concepts and decide whether to create or update pages.
+                    <br />
+                    {user?.nickname
+                      ? `${user.nickname}, time to assign concepts and decide whether to create or update pages.`
+                      : 'Time to assign concepts and decide whether to create or update pages.'}
                     <p className="mt-2 text-sm italic text-[var(--muted-foreground)]">
                       Set the action, select the target concept, and pick an existing page if updating.
                     </p>


### PR DESCRIPTION
## Summary
- allow agents to know the user's nickname when chatting
- pass nickname through the API and crud functions
- add personalized instructions in the agent writer UI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68599b0959f08322ae80e2b18dc70bde