### PR TITLE
Add world chat avatar

### DIFF
--- a/frontend/src/app/components/DashboardLayout.tsx
+++ b/frontend/src/app/components/DashboardLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useState, PropsWithChildren } from "react";
+import React, { useState, PropsWithChildren, useEffect } from "react";
 import TopBar from "./template/TopBar";
 import Sidebar from "./template/Sidebar";
 import ChatPanel from "./template/ChatPanel";
@@ -8,6 +8,18 @@ import { FaBars } from "react-icons/fa";
 export default function DashboardLayout({ children }: PropsWithChildren) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [chatOpen, setChatOpen] = useState(false);
+  const [chatDefaultAgentId, setChatDefaultAgentId] = useState<number | null>(null);
+  const [chatDefaultInput, setChatDefaultInput] = useState<string>("");
+
+  useEffect(() => {
+    function handleOpen(e: any) {
+      if (e.detail?.agentId !== undefined) setChatDefaultAgentId(e.detail.agentId);
+      if (e.detail?.input !== undefined) setChatDefaultInput(e.detail.input);
+      setChatOpen(true);
+    }
+    window.addEventListener("openChatPanel", handleOpen);
+    return () => window.removeEventListener("openChatPanel", handleOpen);
+  }, []);
 
   return (
     <div className="relative bg-[var(--background)] min-h-screen w-full flex">
@@ -39,6 +51,8 @@ export default function DashboardLayout({ children }: PropsWithChildren) {
         open={chatOpen}
         onOpen={() => setChatOpen(true)}
         onClose={() => setChatOpen(false)}
+        defaultAgentId={chatDefaultAgentId}
+        defaultInput={chatDefaultInput}
       />
     </div>
   );

--- a/frontend/src/app/components/template/ChatPanel.tsx
+++ b/frontend/src/app/components/template/ChatPanel.tsx
@@ -12,7 +12,19 @@ import {
   getChatHistory,
 } from "../../lib/agentAPI";
 
-export default function ChatPanel({ open, onOpen, onClose }) {
+export default function ChatPanel({
+  open,
+  onOpen,
+  onClose,
+  defaultAgentId = null,
+  defaultInput = "",
+}: {
+  open: boolean;
+  onOpen: () => void;
+  onClose: () => void;
+  defaultAgentId?: number | null;
+  defaultInput?: string;
+}) {
   const PANEL_WIDTH = 420; // px, can use % if preferred
   const BAR_WIDTH = 54; // px
   const BAR_HEIGHT = 200; // px
@@ -34,6 +46,12 @@ export default function ChatPanel({ open, onOpen, onClose }) {
     selectedAgentId !== null
       ? agents.find(a => a.id === selectedAgentId)
       : null;
+
+  useEffect(() => {
+    if (!open) return;
+    if (defaultAgentId !== null) setSelectedAgentId(defaultAgentId);
+    if (defaultInput) setInput(defaultInput);
+  }, [open, defaultAgentId, defaultInput]);
 
   useEffect(() => {
     if (selectedAgentId === null) return;

--- a/frontend/src/app/worlds/[worldID]/concept/[conceptID]/page/[pageID]/page.tsx
+++ b/frontend/src/app/worlds/[worldID]/concept/[conceptID]/page/[pageID]/page.tsx
@@ -82,6 +82,7 @@ export default function PageView() {
   const { characteristics, isLoading: charsLoading } = useCharacteristicsForConcept(page?.concept_id);
 
   const { agents } = useAgents(page?.gameworld_id);
+  const chatAgent = agents?.find(a => a.task === "conversational");
 
   const loading = pageLoading || conceptLoading || worldLoading || worldsLoading || conceptsLoading || charsLoading;
 
@@ -109,6 +110,15 @@ export default function PageView() {
 
   const groups = [...new Set(concepts.filter(c => !!c.group).map(c => c.group))];
   const agent = agents?.find(a => a.id === page?.updated_by_agent_id);
+
+  function openChatWithAgent() {
+    if (!chatAgent) return;
+    const detail = {
+      agentId: chatAgent.id,
+      input: `I have the following questions about the page ${page?.name}: `,
+    };
+    window.dispatchEvent(new CustomEvent("openChatPanel", { detail }));
+  }
 
   if (!hasRole(user?.role, "player")) {
     return (
@@ -361,6 +371,21 @@ const bodySectionValues = filterNonEmptySectionValues(getSectionValues("body"));
             </ModalContainer>
           )}
         </div>
+        {chatAgent && (
+          <button
+            onClick={openChatWithAgent}
+            className="fixed bottom-6 left-6 z-40 flex flex-col items-center group"
+          >
+            <img
+              src={chatAgent.logo || "/images/default/avatars/logo.png"}
+              alt={chatAgent.name}
+              className="w-16 h-16 rounded-full border-2 border-[var(--primary)] shadow-lg group-hover:scale-110 transition-transform object-cover"
+            />
+            <span className="mt-1 px-2 py-0.5 rounded-full bg-[var(--primary)] text-[var(--primary-foreground)] text-xs font-semibold shadow group-hover:bg-[var(--accent)]">
+              Ask {chatAgent.name}
+            </span>
+          </button>
+        )}
       </DashboardLayout>
     </AuthGuard>
   );


### PR DESCRIPTION
## Summary
- show sticky avatar on world pages that opens chat for the world's conversational agent
- support setting default agent and input via new `openChatPanel` event
- update `ChatPanel` to accept `defaultAgentId` and `defaultInput` props
- make `DashboardLayout` listen for `openChatPanel`

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6859acc0dac88322a283ff2a2d508d1d