### PR TITLE
Improve chat panel

### DIFF
--- a/backend/app/api/api_agent.py
+++ b/backend/app/api/api_agent.py
@@ -205,9 +205,13 @@ async def chat(
 
 
 @router.get("/{agent_id}/history")
-async def chat_history(agent_id: int, user: User = Depends(get_current_user)):
+async def chat_history(
+    agent_id: int,
+    limit: int = 20,
+    user: User = Depends(get_current_user),
+):
     messages = crud_chat_history.load_history(user.id, agent_id)
-    return {"messages": messages[-20:]}
+    return {"messages": messages[-limit:]}
 
 
 @router.delete("/{agent_id}/history")

--- a/backend/app/api/api_specialist.py
+++ b/backend/app/api/api_specialist.py
@@ -249,9 +249,13 @@ async def specialist_chat(
 
 
 @router.get("/{agent_id}/history")
-async def specialist_chat_history(agent_id: int, user: User = Depends(get_current_user)):
+async def specialist_chat_history(
+    agent_id: int,
+    limit: int = 20,
+    user: User = Depends(get_current_user),
+):
     messages = crud_chat_history.load_history(user.id, agent_id)
-    return {"messages": messages[-20:]}
+    return {"messages": messages[-limit:]}
 
 
 @router.delete("/{agent_id}/history")

--- a/frontend/src/app/ai_specialist/specialist_chat/page.tsx
+++ b/frontend/src/app/ai_specialist/specialist_chat/page.tsx
@@ -181,7 +181,7 @@ function SpecialistChatPageContent() {
 
   useEffect(() => {
     if (!agentId) return;
-    getSpecialistHistory(agentId, token || "")
+    getSpecialistHistory(agentId, token || "", 10)
       .then((msgs) => {
         setAllMessages(msgs as ChatMessage[]);
         setMessages((msgs as ChatMessage[]).slice(-10));
@@ -265,6 +265,17 @@ function SpecialistChatPageContent() {
     }
   }
 
+  async function handleOpenHistory() {
+    if (!agentId) return;
+    try {
+      const full = await getSpecialistHistory(agentId, token || "", 1000);
+      setAllMessages(full as ChatMessage[]);
+      setShowHistoryModal(true);
+    } catch {
+      setShowHistoryModal(true);
+    }
+  }
+
   function renderMessageContent(msg: ChatMessage, idx: number, isAssistant: boolean) {
     // If last assistant message and loading, use typewriter
     if (isAssistant && loading && idx === messages.length - 1) {
@@ -330,9 +341,9 @@ function SpecialistChatPageContent() {
             <div className="flex items-center gap-2 mb-2">
               <button
                 className="ml-auto text-xs text-fuchsia-600 underline"
-                onClick={() => setShowHistoryModal(true)}
+                onClick={handleOpenHistory}
               >
-                See whole chat
+                See chat history
               </button>
               <button
                 className="text-xs text-red-600 underline"

--- a/frontend/src/app/elders/[id]/page.tsx
+++ b/frontend/src/app/elders/[id]/page.tsx
@@ -31,7 +31,7 @@ export default function ElderChatPage() {
 
   useEffect(() => {
     if (!id) return;
-    getChatHistory(id, token || "")
+    getChatHistory(id, token || "", 10)
       .then((msgs) => {
         const withTime = (msgs as ChatMessage[]).map(m => ({ ...m, time: new Date() }));
         setMessages(withTime);

--- a/frontend/src/app/lib/agentAPI.ts
+++ b/frontend/src/app/lib/agentAPI.ts
@@ -96,8 +96,12 @@ export async function chatTest(
   return await res.json();
 }
 
-export async function getChatHistory(agentId: number, token: string) {
-  const res = await fetch(`${API_URL}/agents/${agentId}/history`, {
+export async function getChatHistory(
+  agentId: number,
+  token: string,
+  limit = 20,
+) {
+  const res = await fetch(`${API_URL}/agents/${agentId}/history?limit=${limit}`, {
     headers: token ? { Authorization: `Bearer ${token}` } : {},
   });
   if (!res.ok) throw await res.text();

--- a/frontend/src/app/lib/specialistAPI.ts
+++ b/frontend/src/app/lib/specialistAPI.ts
@@ -97,10 +97,17 @@ export async function chatWithSpecialist(
   return (await res.json()) as { answer: string; sources: SourceLink[] };
 }
 
-export async function getSpecialistHistory(agentId: number, token: string) {
-  const res = await fetch(`${API_URL}/specialist_agents/${agentId}/history`, {
-    headers: token ? { Authorization: `Bearer ${token}` } : {},
-  });
+export async function getSpecialistHistory(
+  agentId: number,
+  token: string,
+  limit = 20,
+) {
+  const res = await fetch(
+    `${API_URL}/specialist_agents/${agentId}/history?limit=${limit}`,
+    {
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    },
+  );
   if (!res.ok) throw await res.text();
   const data = await res.json();
   return data.messages || [];


### PR DESCRIPTION
## Summary
- limit chat history queries via new `limit` query parameter in backend APIs
- update specialist and elder chat pages to only fetch recent messages
- redesign ChatPanel with larger textarea, separate sources section, and history modal
- fetch full history on demand for specialist and ChatPanel

## Testing
- `npm run lint` *(fails: numerous lint errors)*
- `pytest -q` *(fails: SyntaxError in backend)*

------
https://chatgpt.com/codex/tasks/task_e_6859b174162483229783ce81ccc7ad90