### PR TITLE
Display agent name in chat bubbles

### DIFF
--- a/frontend/src/app/ai_specialist/specialist_chat/page.tsx
+++ b/frontend/src/app/ai_specialist/specialist_chat/page.tsx
@@ -434,6 +434,11 @@ function SpecialistChatPageContent() {
                       animate={{ scale: 1, y: 0, opacity: 1 }}
                       transition={{ type: "spring", stiffness: 260, damping: 18 }}
                     >
+                      {m.role === "assistant" && (
+                        <div className="text-xs font-semibold text-fuchsia-700 mb-1">
+                          {agent?.name}
+                        </div>
+                      )}
                       {renderMessageContent(m, idx, m.role === "assistant")}
                     </motion.div>
                     {m.role === "user" && user?.image_url && (

--- a/frontend/src/app/elders/[id]/page.tsx
+++ b/frontend/src/app/elders/[id]/page.tsx
@@ -161,6 +161,11 @@ export default function ElderChatPage() {
                     <Image src={agent?.logo || "/images/default/avatars/logo.png"} alt="" width={32} height={32} className="w-8 h-8 rounded-full object-cover mr-2 self-end" />
                   )}
                   <div className={`${m.role === "user" ? "bg-[var(--primary)] text-[var(--primary-foreground)]" : "bg-[var(--surface-variant)]"} rounded-xl px-3 py-2 shadow max-w-[80%] whitespace-pre-wrap`}>
+                    {m.role === "assistant" && (
+                      <div className="text-xs font-semibold text-[var(--primary)] mb-1">
+                        {agent?.name}
+                      </div>
+                    )}
                     {loading && idx === messages.length - 1 && m.role === "assistant" && m.content === "" ? (
                       <span className="flex items-center gap-2"><Loader2 className="animate-spin w-4 h-4" /> Thinking...</span>
                     ) : (


### PR DESCRIPTION
## Summary
- show agent name at top of assistant messages in specialist chat
- show agent name at top of assistant messages in elder chat

## Testing
- `pytest -q` *(fails: ProxyError when trying to download Hugging Face model)*

------
https://chatgpt.com/codex/tasks/task_e_6859b55a94c883229d02039665239a95