### PR TITLE
Add MD3 language switcher

### DIFF
--- a/frontend/src/app/components/LanguageSwitcher.tsx
+++ b/frontend/src/app/components/LanguageSwitcher.tsx
@@ -1,17 +1,26 @@
 "use client";
 import { useTranslation } from "../hooks/useTranslation";
+import { MdTranslate } from "react-icons/md";
 
-export default function LanguageSwitcher() {
+export default function LanguageSwitcher({ className = "" }) {
   const { locale, setLocale } = useTranslation();
+
   return (
-    <select
-      className="absolute top-2 right-2 z-50 px-2 py-1 rounded-md text-black"
-      value={locale}
-      onChange={(e) => setLocale(e.target.value as any)}
-    >
-      <option value="en">English</option>
-      <option value="pt">Português</option>
-      <option value="it">Italiano</option>
-    </select>
+    <div className={`relative ${className}`}>
+      <MdTranslate
+        className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--primary)]/80 pointer-events-none"
+        size={20}
+      />
+      <select
+        className="appearance-none pl-9 pr-3 py-2 rounded-xl bg-[var(--surface-variant)] text-[var(--foreground)] border border-[var(--primary)]/70 focus:ring-1 focus:ring-[var(--primary)] focus:border-[var(--primary)] font-semibold text-sm"
+        value={locale}
+        onChange={(e) => setLocale(e.target.value as any)}
+        aria-label="Select language"
+      >
+        <option value="en">EN</option>
+        <option value="pt">PT</option>
+        <option value="it">IT</option>
+      </select>
+    </div>
   );
 }

--- a/frontend/src/app/components/template/Sidebar.tsx
+++ b/frontend/src/app/components/template/Sidebar.tsx
@@ -5,6 +5,7 @@ import { useAuth } from "../auth/AuthProvider";
 import UserModal from "../user_management/User_Modal";
 import Image from "next/image";
 import Link from "next/link";
+import { useTranslation } from "../../hooks/useTranslation";
 
 // Material Symbols
 import PublicIcon from "@mui/icons-material/Public";
@@ -16,6 +17,7 @@ import { Bot, BookOpenText, PenLine, Sparkles } from "lucide-react";
 
 export default function Sidebar({ mobileOpen = false, setMobileOpen = () => {} }) {
   const { user, token, isLoading: authLoading, refreshUser } = useAuth();
+  const { t } = useTranslation();
   const [profileModalOpen, setProfileModalOpen] = useState(false);
   const [profileSuccess, setProfileSuccess] = useState("");
   const [profileError, setProfileError] = useState("");
@@ -25,7 +27,7 @@ export default function Sidebar({ mobileOpen = false, setMobileOpen = () => {} }
   async function handleProfileSave() {
     if (typeof refreshUser === "function") await refreshUser();
     setProfileModalOpen(false);
-    setProfileSuccess("Profile updated with success!");
+    setProfileSuccess(t("profile_updated_success"));
     setTimeout(() => setProfileSuccess(""), 2000);
   }
   function handleProfileError(msg) {
@@ -36,50 +38,50 @@ export default function Sidebar({ mobileOpen = false, setMobileOpen = () => {} }
   // Menu Items
   const menu = [
     {
-      label: "Virtual Table",
+      label: t("virtual_table"),
       icon: <CasinoRoundedIcon fontSize="medium" />,
       href: "https://foundry.shrecknet.club",
       external: true,
       show: true,
     },
     {
-      label: "Worlds",
+      label: t("worlds"),
       icon: <PublicIcon fontSize="medium" />,
       href: "/worlds",
       external: false,
       show: true,
     },
     {
-      label: "See All Pages",
+      label: t("see_all_pages"),
       icon: <BookOpenText fontSize="medium" />,
       href: "/all_pages",
       external: false,
       show: user && ["writer", "system admin"].includes(user.role),
     },
     {
-      label: "AI World Elders",
+      label: t("ai_world_elders"),
       icon: <GroupRoundedIcon fontSize="medium" />,
       href: "/elders",
       external: false,
       show: true,
     },
     {
-      label: "AI System Specialists",
+      label: t("ai_system_specialists"),
       icon: <Sparkles fontSize="medium" />,
       href: "/ai_specialist",
       external: false,
       show: true,
-    },    
+    },
 
     {
-      label: "AI Page Writers",
+      label: t("ai_page_writers"),
       icon: <Bot fontSize="medium" />,
       href: "/agent_writer",
       external: false,
       show: user && ["writer", "system admin"].includes(user.role),
     },
     {
-      label: "AI Adventure Novelists",
+      label: t("ai_adventure_novelists"),
       icon: <PenLine fontSize="medium" />,
       href: "/ai_novelist",
       external: false,
@@ -87,21 +89,21 @@ export default function Sidebar({ mobileOpen = false, setMobileOpen = () => {} }
     },
 
     {
-      label: "World Builder",
+      label: t("world_builder"),
       icon: <BuildRoundedIcon fontSize="medium" />,
       href: "/world_builder",
       external: false,
       show: user && ["world builder", "system admin"].includes(user.role),
-    },    
+    },
  
   
     {
-      label: "System Settings",
+      label: t("system_settings"),
       icon: <GroupRoundedIcon fontSize="medium" />,
       href: "/system_settings",
       external: false,
       show: user && user.role === "system admin",
-    },    
+    },
   ];
 
   // Don't render if not logged in
@@ -210,10 +212,10 @@ export default function Sidebar({ mobileOpen = false, setMobileOpen = () => {} }
             />
           </div>
           <div className="font-bold text-[var(--primary)] text-lg capitalize flex items-center gap-2">
-            {user?.nickname || "Hi!"}
+            {user?.nickname || t("hi")}
             <button
               className="ml-1 p-1 text-[var(--primary)]/80 hover:text-[var(--primary)] transition"
-              title="Personalize"
+              title={t("personalize")}
               onClick={() => setProfileModalOpen(true)}
             >
               <PersonEditAlt1RoundedIcon style={{ fontSize: 20 }} />

--- a/frontend/src/app/components/template/TopBar.tsx
+++ b/frontend/src/app/components/template/TopBar.tsx
@@ -10,9 +10,12 @@ import { getGameWorlds } from "@/app/lib/gameworldsAPI";
 import { MdPublic } from "react-icons/md";
 import { RiFile3Line } from "react-icons/ri";
 import { useRouter } from "next/navigation";
+import LanguageSwitcher from "../LanguageSwitcher";
+import { useTranslation } from "../../hooks/useTranslation";
 
 export default function TopBar() {
   const { user, logout, token } = useAuth();
+  const { t } = useTranslation();
   const showCreatePage =
     user &&
     (user.role === "writer" ||
@@ -118,7 +121,7 @@ export default function TopBar() {
               border border-[var(--primary)]/70 shadow-none focus:border-[var(--primary)] focus:ring-1 focus:ring-[var(--primary)] focus:outline-none
               placeholder:text-[var(--primary)]/70 text-base transition
               font-semibold"
-            placeholder="Search for a page…"
+            placeholder={t("search_placeholder")}
             value={searchValue}
             onFocus={() => setSearchOpen(true)}
             onChange={(e) => {
@@ -145,7 +148,7 @@ export default function TopBar() {
               fontWeight: 500,
               letterSpacing: ".01em",
             }}
-            aria-label="Search pages"
+            aria-label={t("search_placeholder")}
           />
           <FaSearch className="absolute left-3 top-1/2 -translate-y-1/2 text-lg text-[var(--primary)]/70" />
           {searchOpen && searchValue.length > 1 && (
@@ -161,9 +164,9 @@ export default function TopBar() {
               }}
             >
               {isLoading ? (
-                <div className="py-4 px-5 text-sm text-[var(--primary)]/80">Loading…</div>
+                <div className="py-4 px-5 text-sm text-[var(--primary)]/80">{t("loading")}</div>
               ) : searchResults.length === 0 ? (
-                <div className="py-4 px-5 text-sm text-[var(--primary)]/70">No results found</div>
+                <div className="py-4 px-5 text-sm text-[var(--primary)]/70">{t("no_results_found")}</div>
               ) : (
                 searchResults.map((page, i) => {
                   const world = worldsMap[page.world_id || page.gameworld_id];
@@ -226,9 +229,10 @@ export default function TopBar() {
             }}
           >
             <FaBookmark className="text-lg" />
-            <span className="hidden sm:inline">Create Page</span>
+            <span className="hidden sm:inline">{t("create_page")}</span>
           </Link>
         )}
+        <LanguageSwitcher className="w-24" />
         <ThemeToggle />
         <button
           onClick={() => {
@@ -238,7 +242,7 @@ export default function TopBar() {
           className="px-3 py-2 rounded-xl bg-transparent hover:bg-[var(--primary)] text-[var(--primary)] hover:text-[var(--primary-foreground)] border border-[var(--primary)] shadow-none font-semibold flex items-center gap-1 transition"
         >
           <FaSignOutAlt className="text-lg" />
-          <span className="hidden sm:inline">Logout</span>
+          <span className="hidden sm:inline">{t("logout")}</span>
         </button>
       </div>
     </header>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -3,7 +3,6 @@ import { AuthProvider } from "./components/auth/AuthProvider";
 import GlobalAuthRedirect from "./components/auth/GlobalAuthRedirect";
 import { ThemeProvider } from "./hooks/useThemes";
 import { TranslationProvider } from "./hooks/useTranslation";
-import LanguageSwitcher from "./components/LanguageSwitcher";
 import Script from "next/script";
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
@@ -25,7 +24,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <TranslationProvider>
           <AuthProvider>
             <ThemeProvider>
-              <LanguageSwitcher />
               <GlobalAuthRedirect />
               {children}
             </ThemeProvider>

--- a/frontend/src/app/locales/en.json
+++ b/frontend/src/app/locales/en.json
@@ -25,5 +25,20 @@
   "talk_elders": "Talk to our Elders",
   "talk_elders_desc": "Talk to our Agentic AI NPCs about the worlds, the game rules or anything you wish.",
   "virtual_table": "Virtual Table",
-  "virtual_table_desc": "Jump into your online table powered by Foundry with a single click."
+  "virtual_table_desc": "Jump into your online table powered by Foundry with a single click.",
+  "search_placeholder": "Search for a page…",
+  "no_results_found": "No results found",
+  "create_page": "Create Page",
+  "logout": "Logout",
+  "see_all_pages": "See All Pages",
+  "ai_world_elders": "AI World Elders",
+  "ai_system_specialists": "AI System Specialists",
+  "ai_page_writers": "AI Page Writers",
+  "ai_adventure_novelists": "AI Adventure Novelists",
+  "world_builder": "World Builder",
+  "system_settings": "System Settings",
+  "worlds": "Worlds",
+  "hi": "Hi!",
+  "personalize": "Personalize",
+  "profile_updated_success": "Profile updated with success!"
 }

--- a/frontend/src/app/locales/it.json
+++ b/frontend/src/app/locales/it.json
@@ -25,5 +25,20 @@
   "talk_elders": "Parla con i nostri Anziani",
   "talk_elders_desc": "Parla con i nostri NPC IA sui mondi, le regole di gioco o qualsiasi cosa desideri.",
   "virtual_table": "Tavolo Virtuale",
-  "virtual_table_desc": "Entra nel tuo tavolo online con Foundry con un solo clic."
+  "virtual_table_desc": "Entra nel tuo tavolo online con Foundry con un solo clic.",
+  "search_placeholder": "Cerca una pagina…",
+  "no_results_found": "Nessun risultato",
+  "create_page": "Crea Pagina",
+  "logout": "Esci",
+  "see_all_pages": "Vedi Tutte le Pagine",
+  "ai_world_elders": "Anziani del Mondo AI",
+  "ai_system_specialists": "Specialisti di Sistema AI",
+  "ai_page_writers": "Scrittori di Pagine AI",
+  "ai_adventure_novelists": "Romanzieri di Avventure AI",
+  "world_builder": "Costruttore di Mondi",
+  "system_settings": "Impostazioni di Sistema",
+  "worlds": "Mondi",
+  "hi": "Ciao!",
+  "personalize": "Personalizza",
+  "profile_updated_success": "Profilo aggiornato con successo!"
 }

--- a/frontend/src/app/locales/pt.json
+++ b/frontend/src/app/locales/pt.json
@@ -25,5 +25,20 @@
   "talk_elders": "Converse com nossos Anciões",
   "talk_elders_desc": "Converse com nossos NPCs de IA sobre os mundos, as regras do jogo ou o que quiser.",
   "virtual_table": "Mesa Virtual",
-  "virtual_table_desc": "Entre na sua mesa online com Foundry em um clique."
+  "virtual_table_desc": "Entre na sua mesa online com Foundry em um clique.",
+  "search_placeholder": "Buscar uma página…",
+  "no_results_found": "Nenhum resultado encontrado",
+  "create_page": "Criar Página",
+  "logout": "Sair",
+  "see_all_pages": "Ver Todas as Páginas",
+  "ai_world_elders": "Anciões do Mundo IA",
+  "ai_system_specialists": "Especialistas do Sistema IA",
+  "ai_page_writers": "Escritores de Páginas IA",
+  "ai_adventure_novelists": "Romancistas de Aventuras IA",
+  "world_builder": "Construtor de Mundos",
+  "system_settings": "Configurações do Sistema",
+  "worlds": "Mundos",
+  "hi": "Olá!",
+  "personalize": "Personalizar",
+  "profile_updated_success": "Perfil atualizado com sucesso!"
 }


### PR DESCRIPTION
## Summary
- move language switcher from layout into TopBar
- restyle language selector with Material icons
- translate TopBar actions and search messages
- translate Sidebar menu and profile section
- extend locale files with new strings for EN/PT/IT

## Testing
- `npm install`
- `npm run lint` *(fails: many pre‑existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6859b98c7780832291df8a26e2aed701