### PR TITLE
Localize elders pages

### DIFF
--- a/frontend/src/app/elders/[id]/page.tsx
+++ b/frontend/src/app/elders/[id]/page.tsx
@@ -13,6 +13,7 @@ import Image from "next/image";
 import WikiLinkHoverCard from "../../components/editor/WikiLinkHoverCard";
 import { Loader2 } from "lucide-react";
 import { BookOpen } from "lucide-react";
+import { useTranslation } from "../../hooks/useTranslation";
 
 interface Message extends ChatMessage { time: Date }
 interface SourceInfo { title: string; url: string; logo?: string }
@@ -22,6 +23,7 @@ export default function ElderChatPage() {
   const id = Number(params?.id);
   const { user, token } = useAuth();
   const { agent } = useAgentById(id);
+  const { t } = useTranslation();
 
   const [messages, setMessages] = useState<Message[]>([]);
   const [sourceInfos, setSourceInfos] = useState<SourceInfo[]>([]);
@@ -95,7 +97,7 @@ export default function ElderChatPage() {
     } catch {
       setMessages(m => {
         const arr = [...m];
-        arr[arr.length - 1] = { role: "assistant", content: "Sorry, something went wrong.", time: new Date() };
+        arr[arr.length - 1] = { role: "assistant", content: t("generic_error"), time: new Date() };
         return arr;
       });
       updateSourceInfos([]);
@@ -107,7 +109,7 @@ export default function ElderChatPage() {
   async function clearMessages() {
     if (!id) return;
     const confirmed = window.confirm(
-      "This will permanently delete your chat history with this Elder. Continue?"
+      t("delete_chat_confirm")
     );
     if (!confirmed) return;
     try {
@@ -150,7 +152,7 @@ export default function ElderChatPage() {
                 onClick={clearMessages}
                 className="ml-auto px-3 py-1 text-sm rounded-lg bg-red-600 text-white hover:bg-red-700"
               >
-                Clear chat
+                {t("clear_chat")}
               </button>
             </div>
             
@@ -167,7 +169,7 @@ export default function ElderChatPage() {
                       </div>
                     )}
                     {loading && idx === messages.length - 1 && m.role === "assistant" && m.content === "" ? (
-                      <span className="flex items-center gap-2"><Loader2 className="animate-spin w-4 h-4" /> Thinking...</span>
+                      <span className="flex items-center gap-2"><Loader2 className="animate-spin w-4 h-4" /> {t("thinking")}</span>
                     ) : (
                       renderMessageContent(m)
                     )}
@@ -192,8 +194,7 @@ export default function ElderChatPage() {
       </svg>
       <BookOpen className="w-5 h-5 text-fuchsia-600" />
       <span className="font-semibold text-fuchsia-700 text-base">
-      
-        Relevant Sources
+        {t("relevant_sources")}
       </span>
     </div>
           {/* Source suggestions */}
@@ -229,7 +230,7 @@ export default function ElderChatPage() {
                 className="flex-1 rounded-xl border border-[var(--primary)] p-2 bg-[var(--surface)] text-[var(--foreground)] placeholder-[var(--primary)]/70 focus:outline-none"
                 value={input}
                 onChange={e => setInput(e.target.value)}
-                placeholder="Type your message..."
+                placeholder={t("type_message")}
                 disabled={loading}
               />
               <button
@@ -237,7 +238,7 @@ export default function ElderChatPage() {
                 className="px-4 py-2 rounded-xl bg-[var(--primary)] text-[var(--primary-foreground)] disabled:opacity-50"
                 disabled={loading || !input.trim()}
               >
-                Send
+                {t("send")}
               </button>
             </form>
           </div>

--- a/frontend/src/app/elders/page.tsx
+++ b/frontend/src/app/elders/page.tsx
@@ -2,12 +2,14 @@
 import DashboardLayout from "../components/DashboardLayout";
 import { useAgents } from "../lib/useAgents";
 import { useWorlds } from "../lib/userWorlds";
+import { useTranslation } from "../hooks/useTranslation";
 import Image from "next/image";
 import Link from "next/link";
 
 export default function EldersPage() {
   const { agents, isLoading } = useAgents();
   const { worlds } = useWorlds();
+  const { t } = useTranslation();
 
   const conversational = agents.filter(a => a.task === "conversational");
   const worldName = (id: number) => worlds.find(w => w.id === id)?.name || "";
@@ -17,14 +19,14 @@ export default function EldersPage() {
       <div className="w-full max-w-7xl mx-auto px-2 sm:px-6 py-10">
         <div className="flex flex-col items-center mb-8 text-center">
           <h1 className="font-serif text-3xl md:text-5xl font-bold text-[var(--primary)] mb-2 tracking-tight">
-            The Elders
+            {t("elders_title")}
           </h1>
           <p className="text-base md:text-lg text-[var(--foreground)]/70 max-w-2xl">
-            Step into the council chamber of Shrecknet and meet its wisest beings. Each Elder guards the lore of a unique world and is eager to share their knowledge with you.
+            {t("elders_description")}
           </p>
         </div>
         {isLoading ? (
-          <div className="text-center text-lg text-[var(--primary)]">Loading elders...</div>
+          <div className="text-center text-lg text-[var(--primary)]">{t("loading_elders")}</div>
         ) : (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 justify-items-center">
             {conversational.map(agent => (
@@ -47,7 +49,7 @@ export default function EldersPage() {
                   {worldName(agent.world_id)}
                 </p>
                 <p className="text-xs text-center text-[var(--foreground)]/60 group-hover:text-[var(--primary)]">
-                  Speak with this Elder
+                  {t("speak_with_elder")}
                 </p>
               </Link>
             ))}

--- a/frontend/src/app/locales/en.json
+++ b/frontend/src/app/locales/en.json
@@ -79,5 +79,16 @@
   "desc_agent_conversational": "Chat with your world’s rules, lore, and personalities.",
   "desc_agent_writer": "Automate and review page creation, linking, and summaries.",
   "desc_agent_novelist": "Generate adventure hooks, session logs, and dramatic retellings.",
-  "desc_agent_specialist": "Niche agents for specific game mechanics or moderation."
+  "desc_agent_specialist": "Niche agents for specific game mechanics or moderation.",
+  "elders_title": "The Elders",
+  "elders_description": "Step into the council chamber of Shrecknet and meet its wisest beings. Each Elder guards the lore of a unique world and is eager to share their knowledge with you.",
+  "loading_elders": "Loading elders...",
+  "speak_with_elder": "Speak with this Elder",
+  "clear_chat": "Clear chat",
+  "thinking": "Thinking...",
+  "relevant_sources": "Relevant Sources",
+  "type_message": "Type your message...",
+  "send": "Send",
+  "delete_chat_confirm": "This will permanently delete your chat history with this Elder. Continue?",
+  "generic_error": "Sorry, something went wrong."
 }

--- a/frontend/src/app/locales/it.json
+++ b/frontend/src/app/locales/it.json
@@ -79,5 +79,16 @@
   "desc_agent_conversational": "Parla con le regole, il lore e le personalità del tuo mondo.",
   "desc_agent_writer": "Automatizza e revisiona la creazione di pagine, i collegamenti e i riassunti.",
   "desc_agent_novelist": "Genera spunti di avventura, resoconti di sessione e racconti drammatici.",
-  "desc_agent_specialist": "Agenti specializzati per meccaniche specifiche o moderazione."
+  "desc_agent_specialist": "Agenti specializzati per meccaniche specifiche o moderazione.",
+  "elders_title": "Gli Anziani",
+  "elders_description": "Entra nella sala del consiglio di Shrecknet e incontra i suoi esseri più saggi. Ogni Anziano custodisce il sapere di un mondo unico ed è pronto a condividere la sua conoscenza con te.",
+  "loading_elders": "Caricamento anziani...",
+  "speak_with_elder": "Parla con questo Anziano",
+  "clear_chat": "Cancella chat",
+  "thinking": "Sto pensando...",
+  "relevant_sources": "Fonti Rilevanti",
+  "type_message": "Digita il tuo messaggio...",
+  "send": "Invia",
+  "delete_chat_confirm": "Questo eliminerà definitivamente la tua cronologia con questo Anziano. Continuare?",
+  "generic_error": "Spiacente, qualcosa è andato storto."
 }

--- a/frontend/src/app/locales/pt.json
+++ b/frontend/src/app/locales/pt.json
@@ -79,5 +79,16 @@
   "desc_agent_conversational": "Converse com as regras, o lore e as personalidades do seu mundo.",
   "desc_agent_writer": "Automatize e revise a criação de páginas, links e resumos.",
   "desc_agent_novelist": "Gere ganchos de aventura, registros de sessão e recontos dramáticos.",
-  "desc_agent_specialist": "Agentes específicos para mecânicas ou moderação."
+  "desc_agent_specialist": "Agentes específicos para mecânicas ou moderação.",
+  "elders_title": "Os Anciões",
+  "elders_description": "Adentre a câmara do conselho da Shrecknet e conheça seus seres mais sábios. Cada Ancião guarda o lore de um mundo único e está ansioso para compartilhar seu conhecimento com você.",
+  "loading_elders": "Carregando anciões...",
+  "speak_with_elder": "Falar com este Ancião",
+  "clear_chat": "Limpar conversa",
+  "thinking": "Pensando...",
+  "relevant_sources": "Fontes Relevantes",
+  "type_message": "Digite sua mensagem...",
+  "send": "Enviar",
+  "delete_chat_confirm": "Isso apagará permanentemente seu histórico de conversa com este Ancião. Continuar?",
+  "generic_error": "Desculpe, algo deu errado."
 }


### PR DESCRIPTION
## Summary
- integrate translation hook in Elders pages
- add i18n strings for elders chat
- update locale files for EN/PT/IT

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `pytest` *(fails: cannot download model due to network policy)*

------
https://chatgpt.com/codex/tasks/task_e_6859c2be8fd08322aaddce0b8b85acd2