### PR TITLE
Add system-wide backup utilities

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,4 +1,4 @@
-from . import api_characteristic, api_concept, api_page, api_user, api_gameworld, api_import_export, api_vectordb, api_agent, api_specialist
+from . import api_characteristic, api_concept, api_page, api_user, api_gameworld, api_import_export, api_vectordb, api_agent, api_specialist, api_backup
 
 __all__ = [
     "api_characteristic",
@@ -10,4 +10,5 @@ __all__ = [
     "api_vectordb",
     "api_agent",
     "api_specialist",
+    "api_backup",
 ]

--- a/backend/app/api/api_backup.py
+++ b/backend/app/api/api_backup.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter, Depends, UploadFile, Response
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.database import get_session
+from app.crud.crud_backup import export_backup_zip, import_backup_zip
+from app.models.model_user import User, UserRole
+from app.dependencies import get_current_user, require_role
+
+router = APIRouter(prefix="/backup", tags=["Backup"], dependencies=[Depends(get_current_user)])
+
+@router.get("/export")
+async def export_backup(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_role(UserRole.system_admin)),
+):
+    data = await export_backup_zip(session)
+    return Response(
+        content=data,
+        media_type="application/zip",
+        headers={"Content-Disposition": 'attachment; filename="backup.zip"'}
+    )
+
+@router.post("/import")
+async def import_backup(
+    file: UploadFile,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_role(UserRole.system_admin)),
+):
+    await import_backup_zip(session, file)
+    return {"ok": True}

--- a/backend/app/crud/crud_backup.py
+++ b/backend/app/crud/crud_backup.py
@@ -1,0 +1,61 @@
+import os, json, io, zipfile, shutil, tempfile
+from sqlmodel import SQLModel, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import model_agent, model_characteristic, model_concept, model_gameworld, model_page, model_specialist_source, model_user
+
+MODELS = [
+    model_user.User,
+    model_gameworld.GameWorld,
+    model_concept.Concept,
+    model_characteristic.Characteristic,
+    model_characteristic.ConceptCharacteristicLink,
+    model_page.Page,
+    model_page.PageCharacteristicValue,
+    model_agent.Agent,
+    model_specialist_source.SpecialistSource,
+]
+
+def _model_name(model):
+    return model.__name__.lower() + 's'
+
+async def export_backup_zip(session: AsyncSession, uploads_dir: str = 'uploads'):
+    data = {}
+    for model in MODELS:
+        result = await session.execute(select(model))
+        rows = result.scalars().all()
+        data[_model_name(model)] = [r.dict() for r in rows]
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, 'w', zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr('data.json', json.dumps(data, default=str))
+        if os.path.isdir(uploads_dir):
+            for root, _, files in os.walk(uploads_dir):
+                for f in files:
+                    full = os.path.join(root, f)
+                    arcname = os.path.relpath(full, uploads_dir)
+                    zf.write(full, os.path.join('uploads', arcname))
+    buffer.seek(0)
+    return buffer.read()
+
+async def import_backup_zip(session: AsyncSession, file, uploads_dir: str = 'uploads'):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        data_path = os.path.join(tmpdir, 'data.json')
+        with zipfile.ZipFile(io.BytesIO(await file.read()), 'r') as zf:
+            zf.extractall(tmpdir)
+        with open(data_path, 'r') as f:
+            data = json.load(f)
+        extracted_uploads = os.path.join(tmpdir, 'uploads')
+        if os.path.exists(uploads_dir):
+            shutil.rmtree(uploads_dir)
+        if os.path.exists(extracted_uploads):
+            shutil.move(extracted_uploads, uploads_dir)
+        # clear tables
+        for model in MODELS[::-1]:
+            await session.execute(model.__table__.delete())
+        # insert rows
+        for model in MODELS:
+            entries = data.get(_model_name(model), [])
+            for row in entries:
+                obj = model(**row)
+                session.add(obj)
+        await session.commit()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,6 +11,7 @@ from .api import (
     api_vectordb,
     api_agent,
     api_specialist,
+    api_backup,
 )
 from contextlib import asynccontextmanager
 
@@ -91,6 +92,7 @@ app.include_router(api_import_export.router)
 app.include_router(api_vectordb.router)
 app.include_router(api_agent.router)
 app.include_router(api_specialist.router)
+app.include_router(api_backup.router)
 
 
 

--- a/frontend/src/app/components/importexport/ImportBackupModal.tsx
+++ b/frontend/src/app/components/importexport/ImportBackupModal.tsx
@@ -1,0 +1,69 @@
+"use client";
+import { useState } from "react";
+import ModalContainer from "../template/modalContainer";
+import { importBackup } from "../../lib/backupAPI";
+import { useAuth } from "../auth/AuthProvider";
+import { useTranslation } from "@/app/hooks/useTranslation";
+
+export default function ImportBackupModal({ open, onClose, onImported }) {
+  const { token } = useAuth();
+  const { t } = useTranslation();
+  const [file, setFile] = useState<File | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState(false);
+
+  async function handleImport() {
+    if (!file) return;
+    setLoading(true);
+    setError("");
+    try {
+      await importBackup(token, file);
+      setSuccess(true);
+      setTimeout(() => {
+        setSuccess(false);
+        if (onImported) onImported();
+        onClose();
+      }, 1500);
+    } catch (err) {
+      setError(t("backup_failed"));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (!open) return null;
+
+  return (
+    <ModalContainer title={t("import_backup")} onClose={onClose} className="max-w-md">
+      <div className="flex flex-col gap-4">
+        <input
+          type="file"
+          accept=".zip"
+          onChange={e => setFile(e.target.files?.[0] || null)}
+          className="block w-full rounded-xl border-2 border-[var(--primary)] px-4 py-2 bg-[var(--surface)] text-[var(--foreground)]"
+        />
+        {error && <div className="text-red-700 text-sm">{error}</div>}
+        {success && <div className="text-[var(--primary)] text-sm">{t("backup_imported")}</div>}
+        <div className="flex justify-end gap-3 mt-2">
+          <button
+            type="button"
+            className="px-5 py-2 rounded-xl font-semibold bg-[var(--primary)]/10 text-[var(--primary)]"
+            onClick={onClose}
+            disabled={loading}
+          >
+            {t("cancel")}
+          </button>
+          <button
+            type="button"
+            className="px-5 py-2 rounded-xl font-bold bg-[var(--primary)] text-[var(--primary-foreground)]"
+            onClick={handleImport}
+            disabled={loading || !file}
+          >
+            {loading ? t("backup_importing") : t("confirm_import")}
+          </button>
+        </div>
+      </div>
+    </ModalContainer>
+  );
+}

--- a/frontend/src/app/lib/backupAPI.ts
+++ b/frontend/src/app/lib/backupAPI.ts
@@ -1,0 +1,21 @@
+import { API_URL } from "./config";
+
+export async function createBackup(token: string): Promise<Blob> {
+  const res = await fetch(`${API_URL}/backup/export`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) throw new Error("Failed to create backup");
+  return await res.blob();
+}
+
+export async function importBackup(token: string, file: File): Promise<{ ok: boolean }> {
+  const formData = new FormData();
+  formData.append("file", file);
+  const res = await fetch(`${API_URL}/backup/import`, {
+    method: "POST",
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+    body: formData,
+  });
+  if (!res.ok) throw new Error("Failed to import backup");
+  return await res.json();
+}

--- a/frontend/src/app/locales/en.json
+++ b/frontend/src/app/locales/en.json
@@ -245,5 +245,10 @@
   "confirm_import": "Confirm Import",
   "importing": "Importing...",
   "imported": "Imported!",
-  "world_creator_notice": "World creator and creation date will be set to the importing user/time."
+  "world_creator_notice": "World creator and creation date will be set to the importing user/time.",
+  "create_backup": "Create Backup",
+  "import_backup": "Import Backup",
+  "backup_importing": "Importing backup...",
+  "backup_imported": "Backup imported!",
+  "backup_failed": "Backup failed. Please try again!"
 }

--- a/frontend/src/app/locales/it.json
+++ b/frontend/src/app/locales/it.json
@@ -249,5 +249,10 @@
   "confirm_import": "Conferma Importazione",
   "importing": "Importazione in corso...",
   "imported": "Importato!",
-  "world_creator_notice": "Il creatore del mondo e la data verranno impostati sull'utente che importa."
+  "world_creator_notice": "Il creatore del mondo e la data verranno impostati sull'utente che importa.",
+  "create_backup": "Crea Backup",
+  "import_backup": "Importa Backup",
+  "backup_importing": "Importazione backup...",
+  "backup_imported": "Backup importato!",
+  "backup_failed": "Backup fallito. Riprova!"
 }

--- a/frontend/src/app/locales/pt.json
+++ b/frontend/src/app/locales/pt.json
@@ -246,5 +246,10 @@
   "confirm_import": "Confirmar Importação",
   "importing": "Importando...",
   "imported": "Importado!",
-  "world_creator_notice": "Criador e data serão definidos para o usuário que importou."
+  "world_creator_notice": "Criador e data serão definidos para o usuário que importou.",
+  "create_backup": "Criar Backup",
+  "import_backup": "Importar Backup",
+  "backup_importing": "Importando backup...",
+  "backup_imported": "Backup importado!",
+  "backup_failed": "Falha no backup. Tente novamente!"
 }


### PR DESCRIPTION
## Summary
- add API endpoints to export/import full backup ZIPs
- implement backup CRUD helpers
- integrate backup download and restore in system settings
- add ImportBackupModal component
- add backup API functions and translations

## Testing
- `pytest -q` *(fails: requests to huggingface.co blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685ee3356fb48322aa8459faac2383b1