### PR TITLE
Update page reference grid

### DIFF
--- a/frontend/src/app/components/see_page/BodySection.tsx
+++ b/frontend/src/app/components/see_page/BodySection.tsx
@@ -47,7 +47,14 @@ export default function BodySection({ values, worldId, conceptid }) {
               >
                 {/* Render lists or single values */}
                 {Array.isArray(value) ? (
-                  <div className="flex flex-wrap  gap-3">
+                  <div
+                    className={
+                      characteristic.type === "page_ref"
+                        ?
+                          "grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4"
+                        : "flex flex-wrap gap-3"
+                    }
+                  >
                     {value.length > 0 ? (
                       value.map((v, i) =>
                         characteristic.type === "page_ref" ? (
@@ -57,12 +64,10 @@ export default function BodySection({ values, worldId, conceptid }) {
                             value={v}
                             worldId={worldId}
                             conceptid={conceptid}
+                            variant="mini"
                           />
                         ) : (
-                          <div
-                            key={i}
-                            className="px-3 py-1 text-sm"
-                          >
+                          <div key={i} className="px-3 py-1 text-sm">
                             {v}
                           </div>
                         )

--- a/frontend/src/app/components/see_page/PageValueRenderer.tsx
+++ b/frontend/src/app/components/see_page/PageValueRenderer.tsx
@@ -234,11 +234,11 @@ export default function PageValueRenderer({
                   : "#"
               }
               className={`
-                flex items-center gap-5 w-full
-                transition                
-                hover:underline
+                flex items-center gap-${isMini ? 2 : 4} w-full
+                rounded-lg border border-[var(--border)] bg-[var(--surface)]
+                px-${isMini ? 2 : 3} py-${isMini ? 2 : 3}
+                shadow-sm transition hover:bg-[var(--surface-variant)]
                 ${isMini ? "text-xs" : ""}
-                justify-left
               `}
               style={{ textDecoration: "none" }}
             >


### PR DESCRIPTION
## Summary
- improve layout of body section to show page references in a responsive grid
- style page reference links as cards

## Testing
- `npm run lint` *(fails: next not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain_openai')*

------
https://chatgpt.com/codex/tasks/task_e_6866d22744788322b9d9c83203690860