### PR TITLE
Implement bidirectional page reference syncing

### DIFF
--- a/backend/app/api/api_page.py
+++ b/backend/app/api/api_page.py
@@ -84,9 +84,9 @@ async def create_page_endpoint(
 
      # Schedule background crosslink update only if this page allows
     if not db_page.ignore_crosslink:
-        from app.task_queue import task_auto_crosslink_batch
+        from app.task_queue import task_auto_crosslink_batch, task_sync_page_ref_attributes
         task_auto_crosslink_batch.delay(db_page.id)
-
+        task_sync_page_ref_attributes.delay(db_page.id)
     return response
 
     # values = await get_page_characteristic_values(session, db_page.id)
@@ -166,8 +166,9 @@ async def update_page_endpoint(
     response = PageRead.model_validate({**db_page.model_dump(), "values": values})
 
     print ("Page was updated with the right values, now going into auto_crosslink!")
-    from app.task_queue import task_auto_crosslink_page_content
+    from app.task_queue import task_auto_crosslink_page_content, task_sync_page_ref_attributes
     task_auto_crosslink_page_content.delay(db_page.id)
+    task_sync_page_ref_attributes.delay(db_page.id)
 
     return response
 

--- a/backend/app/task_queue.py
+++ b/backend/app/task_queue.py
@@ -28,6 +28,7 @@ from app.crud.crud_page_links_update import (
     auto_crosslink_batch,
     remove_crosslinks_to_page,
     remove_page_refs_from_characteristics,
+    sync_page_ref_attributes,
 )
 
 # Ensure all models are imported so SQLModel can resolve relationships
@@ -57,6 +58,10 @@ def task_remove_crosslinks_to_page(page_id: int):
 @celery_app.task
 def task_remove_page_refs_from_characteristics(page_id: int):
     asyncio.run(remove_page_refs_from_characteristics(page_id))
+
+@celery_app.task
+def task_sync_page_ref_attributes(page_id: int):
+    asyncio.run(sync_page_ref_attributes(page_id))
 
 from app.crud.crud_page_analysis import analyze_pages_bulk
 from app.api.api_agent import get_agent


### PR DESCRIPTION
## Summary
- ensure page reference characteristics sync bidirectionally
- add background task to mirror references
- trigger sync when creating or updating pages

## Testing
- `python -m py_compile backend/app/api/api_page.py`
- `python -m py_compile backend/app/crud/crud_page_links_update.py`
- `python -m py_compile backend/app/task_queue.py`
- `pytest -q` *(fails: ProxyError to huggingface.co)*

------
https://chatgpt.com/codex/tasks/task_e_6866d1078b7483228195cc8ba48da49d