### PR TITLE
Add manual job close buttons

### DIFF
--- a/frontend/src/app/agent_writer/page.tsx
+++ b/frontend/src/app/agent_writer/page.tsx
@@ -10,7 +10,7 @@ import { useAgents } from "../lib/useAgents";
 import { useWorlds } from "../lib/userWorlds";
 import { usePages } from "../lib/usePage";
 import { useConcepts } from "../lib/useConcept";
-import { startAnalyzeJob, getWriterJob } from "../lib/agentAPI";
+import { startAnalyzeJob, getWriterJob, updateWriterJob } from "../lib/agentAPI";
 import { useWriterJobs } from "../lib/useWriterJobs";
 import Image from "next/image";
 import Link from "next/link";
@@ -46,7 +46,7 @@ function AgentWriterPageContent() {
   const PAGE_SIZE = 10;
   const [selectedPages, setSelectedPages] = useState<number[]>([]);
   const [jobs, setJobs] = useState<any[]>([]);
-  const { jobs: writerJobs } = useWriterJobs();
+  const { jobs: writerJobs, mutate: mutateWriterJobs } = useWriterJobs();
   const [jobFeedback, setJobFeedback] = useState<string | null>(null);
 
   useEffect(() => {
@@ -244,6 +244,15 @@ function AgentWriterPageContent() {
                           ) : (
                             <Link className="text-fuchsia-700 underline font-bold" href={`/agent_writer/${selectedAgent.id}/review/${job.job_id}`}>{t('review')}</Link>
                           )}
+                          <button
+                            className="text-red-600 underline"
+                            onClick={async () => {
+                              await updateWriterJob(job.job_id, { action_needed: 'done' }, token || '');
+                              mutateWriterJobs();
+                            }}
+                          >
+                            {t('close_job')}
+                          </button>
                         </td>
                       </tr>
                     ))}

--- a/frontend/src/app/locales/en.json
+++ b/frontend/src/app/locales/en.json
@@ -68,6 +68,7 @@
   "running": "Running",
   "done": "Done",
   "review": "Review",
+  "close_job": "Close",
   "processing_selected_pages": "Processing selected pages...",
   "no_lore_found": "No lore found. Try a different search.",
   "agent_settings": "Agent Settings",

--- a/frontend/src/app/locales/it.json
+++ b/frontend/src/app/locales/it.json
@@ -68,6 +68,7 @@
   "running": "In corso",
   "done": "Completato",
   "review": "Revisiona",
+  "close_job": "Chiudi",
   "processing_selected_pages": "Elaborazione delle pagine selezionate...",
   "no_lore_found": "Nessun lore trovato. Prova un'altra ricerca.",
   "agent_settings": "Impostazioni Agenti",

--- a/frontend/src/app/locales/pt.json
+++ b/frontend/src/app/locales/pt.json
@@ -68,6 +68,7 @@
   "running": "Executando",
   "done": "Concluído",
   "review": "Revisar",
+  "close_job": "Fechar",
   "processing_selected_pages": "Processando páginas selecionadas...",
   "no_lore_found": "Nenhum lore encontrado. Tente outra busca.",
   "agent_settings": "Configurações dos Agentes",


### PR DESCRIPTION
## Summary
- add new i18n key `close_job`
- let novelist and writer job lists close jobs without review

## Testing
- `pytest -q` *(fails: ProxyError to huggingface.co)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6866d48d8fec83228e11ba281cfc7975