### PR TITLE
Add Library management

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,4 +1,4 @@
-from . import api_characteristic, api_concept, api_page, api_user, api_gameworld, api_import_export, api_vectordb, api_agent, api_specialist, api_backup
+from . import api_characteristic, api_concept, api_page, api_user, api_gameworld, api_import_export, api_vectordb, api_agent, api_specialist, api_backup, api_library
 
 __all__ = [
     "api_characteristic",
@@ -11,4 +11,5 @@ __all__ = [
     "api_agent",
     "api_specialist",
     "api_backup",
+    "api_library",
 ]

--- a/backend/app/api/api_library.py
+++ b/backend/app/api/api_library.py
@@ -1,0 +1,82 @@
+from fastapi import APIRouter, Depends, UploadFile, File, Form, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from pathlib import Path
+
+from app.database import get_session
+from app.models.model_user import User, UserRole
+from app.models.model_library_item import LibraryItem
+from app.schemas.schema_library_item import LibraryItemRead, LibraryItemUpdate
+from app.crud.crud_library_item import (
+    create_item,
+    get_items,
+    get_item,
+    update_item,
+    delete_item,
+)
+from app.dependencies import get_current_user, require_role
+
+LibraryItemRead.model_rebuild()
+
+router = APIRouter(prefix="/library", tags=["Library"], dependencies=[Depends(get_current_user)])
+
+@router.post("/", response_model=LibraryItemRead)
+async def create_library_item(
+    name: str = Form(...),
+    system: str = Form(...),
+    description: str = Form(None),
+    file: UploadFile = File(...),
+    user: User = Depends(require_role(UserRole.system_admin)),
+    session: AsyncSession = Depends(get_session),
+):
+    dest_dir = Path("data") / "library" / "system" / system
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    ext = Path(file.filename).suffix
+    safe_name = Path(name).stem or "item"
+    dest_path = dest_dir / f"{safe_name}{ext}"
+    with open(dest_path, "wb") as out:
+        out.write(await file.read())
+    item = LibraryItem(
+        name=name,
+        system=system,
+        description=description,
+        path=str(dest_path),
+    )
+    return await create_item(session, item)
+
+@router.get("/", response_model=list[LibraryItemRead])
+async def list_library_items(
+    system: str | None = None,
+    session: AsyncSession = Depends(get_session),
+):
+    return await get_items(session, system)
+
+@router.get("/{item_id}", response_model=LibraryItemRead)
+async def read_library_item(item_id: int, session: AsyncSession = Depends(get_session)):
+    item = await get_item(session, item_id)
+    if not item:
+        raise HTTPException(status_code=404, detail="Item not found")
+    return item
+
+@router.patch("/{item_id}", response_model=LibraryItemRead)
+async def update_library_item_endpoint(
+    item_id: int,
+    updates: LibraryItemUpdate,
+    user: User = Depends(require_role(UserRole.system_admin)),
+    session: AsyncSession = Depends(get_session),
+):
+    update_dict = updates.model_dump(exclude_unset=True)
+    item = await update_item(session, item_id, update_dict)
+    if not item:
+        raise HTTPException(status_code=404, detail="Item not found")
+    return item
+
+@router.delete("/{item_id}")
+async def delete_library_item_endpoint(
+    item_id: int,
+    user: User = Depends(require_role(UserRole.system_admin)),
+    session: AsyncSession = Depends(get_session),
+):
+    ok = await delete_item(session, item_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Item not found")
+    return {"ok": True}

--- a/backend/app/crud/__init__.py
+++ b/backend/app/crud/__init__.py
@@ -10,6 +10,7 @@ from . import crud_chat_history
 from . import crud_specialist_source
 from . import crud_specialist_vectordb
 from . import crud_specialist_agent
+from . import crud_library_item
 try:
     from . import crud_vectordb
 except Exception:  # pragma: no cover - optional dependency
@@ -32,6 +33,7 @@ __all__ = [
     "crud_specialist_source",
     "crud_specialist_vectordb",
     "crud_specialist_agent",
+    "crud_library_item",
 ]
 if crud_vectordb:
     __all__.append("crud_vectordb")

--- a/backend/app/crud/crud_library_item.py
+++ b/backend/app/crud/crud_library_item.py
@@ -1,0 +1,45 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+from typing import List, Optional
+import os
+
+from app.models.model_library_item import LibraryItem
+
+async def create_item(session: AsyncSession, item: LibraryItem) -> LibraryItem:
+    session.add(item)
+    await session.commit()
+    await session.refresh(item)
+    return item
+
+async def get_items(session: AsyncSession, system: Optional[str] = None) -> List[LibraryItem]:
+    stmt = select(LibraryItem)
+    if system:
+        stmt = stmt.where(LibraryItem.system == system)
+    result = await session.execute(stmt)
+    return result.scalars().all()
+
+async def get_item(session: AsyncSession, item_id: int) -> Optional[LibraryItem]:
+    return await session.get(LibraryItem, item_id)
+
+async def update_item(session: AsyncSession, item_id: int, updates: dict) -> Optional[LibraryItem]:
+    item = await session.get(LibraryItem, item_id)
+    if not item:
+        return None
+    for k, v in updates.items():
+        setattr(item, k, v)
+    await session.commit()
+    await session.refresh(item)
+    return item
+
+async def delete_item(session: AsyncSession, item_id: int) -> bool:
+    item = await session.get(LibraryItem, item_id)
+    if not item:
+        return False
+    if item.path and os.path.isfile(item.path):
+        try:
+            os.remove(item.path)
+        except Exception:
+            pass
+    await session.delete(item)
+    await session.commit()
+    return True

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -47,6 +47,12 @@ def _migrate(conn):
         if "name" not in columns:
             conn.execute(text("ALTER TABLE specialistsource ADD COLUMN name TEXT"))
 
+    # -- LibraryItem table --
+    if "libraryitem" not in inspector.get_table_names():
+        conn.execute(text(
+            "CREATE TABLE libraryitem (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, system TEXT, description TEXT, path TEXT, added_at DATETIME NOT NULL)"
+        ))
+
 async def get_session() -> AsyncSession:
     async with async_session_maker() as session:
         yield session

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,7 @@ from .api import (
     api_agent,
     api_specialist,
     api_backup,
+    api_library,
 )
 from contextlib import asynccontextmanager
 
@@ -93,6 +94,7 @@ app.include_router(api_vectordb.router)
 app.include_router(api_agent.router)
 app.include_router(api_specialist.router)
 app.include_router(api_backup.router)
+app.include_router(api_library.router)
 
 
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,4 +1,4 @@
-from . import model_agent, model_characteristic, model_concept, model_gameworld, model_page, model_user, model_specialist_source
+from . import model_agent, model_characteristic, model_concept, model_gameworld, model_page, model_user, model_specialist_source, model_library_item
 
 __all__ = [
     "model_agent",
@@ -8,4 +8,5 @@ __all__ = [
     "model_page",
     "model_user",
     "model_specialist_source",
+    "model_library_item",
 ]

--- a/backend/app/models/model_library_item.py
+++ b/backend/app/models/model_library_item.py
@@ -1,0 +1,11 @@
+from typing import Optional
+from sqlmodel import SQLModel, Field
+from datetime import datetime, timezone
+
+class LibraryItem(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+    system: str
+    description: Optional[str] = None
+    path: str
+    added_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/backend/app/schemas/schema_library_item.py
+++ b/backend/app/schemas/schema_library_item.py
@@ -1,0 +1,24 @@
+from typing import Optional
+from sqlmodel import SQLModel
+from datetime import datetime
+
+class LibraryItemBase(SQLModel):
+    name: str
+    system: str
+    description: Optional[str] = None
+
+class LibraryItemCreate(LibraryItemBase):
+    pass
+
+class LibraryItemUpdate(SQLModel):
+    name: Optional[str] = None
+    system: Optional[str] = None
+    description: Optional[str] = None
+
+class LibraryItemRead(LibraryItemBase):
+    id: int
+    path: str
+    added_at: datetime
+
+    class Config:
+        orm_mode = True

--- a/backend/tests/test_library.py
+++ b/backend/tests/test_library.py
@@ -1,0 +1,81 @@
+import pytest
+from pathlib import Path
+
+SYSTEM_ADMIN = {
+    "nickname": "sysadmin",
+    "email": "lib_admin@example.com",
+    "password": "secret123",
+    "role": "system admin",
+    "image_url": "no image",
+}
+PLAYER = {
+    "nickname": "player",
+    "email": "lib_player@example.com",
+    "password": "secret123",
+    "role": "player",
+    "image_url": "no image",
+}
+
+@pytest.mark.anyio
+async def register_and_login(async_client, user_data):
+    resp = await async_client.post("/user/", json=user_data)
+    assert resp.status_code == 200, resp.text
+    resp = await async_client.post(
+        "/user/login",
+        data={"username": user_data["email"], "password": user_data["password"]},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["access_token"]
+
+@pytest.mark.anyio
+async def test_library_crud(async_client, tmp_path):
+    admin_token = await register_and_login(async_client, SYSTEM_ADMIN)
+    player_token = await register_and_login(async_client, PLAYER)
+
+    file_path = tmp_path / "doc.txt"
+    file_path.write_text("hello")
+
+    with open(file_path, "rb") as f:
+        resp = await async_client.post(
+            "/library/",
+            data={"name": "Doc", "system": "dnd", "description": "desc"},
+            files={"file": ("doc.txt", f, "text/plain")},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+    assert resp.status_code == 200
+    item_id = resp.json()["id"]
+    stored = Path(resp.json()["path"])
+    assert stored.is_file()
+
+    # player cannot create
+    with open(file_path, "rb") as f:
+        resp = await async_client.post(
+            "/library/",
+            data={"name": "P", "system": "dnd"},
+            files={"file": ("p.txt", f, "text/plain")},
+            headers={"Authorization": f"Bearer {player_token}"},
+        )
+    assert resp.status_code == 403
+
+    # list
+    resp = await async_client.get("/library/", headers={"Authorization": f"Bearer {admin_token}"})
+    assert resp.status_code == 200
+    assert any(it["id"] == item_id for it in resp.json())
+
+    # update
+    resp = await async_client.patch(
+        f"/library/{item_id}",
+        json={"description": "new"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["description"] == "new"
+
+    # delete
+    resp = await async_client.delete(
+        f"/library/{item_id}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+    assert not stored.exists()

--- a/frontend/src/app/components/library/LibraryGrid.tsx
+++ b/frontend/src/app/components/library/LibraryGrid.tsx
@@ -1,0 +1,29 @@
+export default function LibraryGrid({ items, onItemClick }) {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-7">
+      {items.map((it) => (
+        <button
+          key={it.id}
+          className="group relative w-full bg-[var(--card-bg)]/90 rounded-2xl shadow-xl border border-[var(--primary)]/30 flex flex-col items-center px-6 py-7 cursor-pointer hover:shadow-2xl hover:border-[var(--accent)]/80 hover:scale-[1.025] active:scale-100 transition outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)]"
+          style={{ minHeight: 180 }}
+          onClick={() => onItemClick(it)}
+          tabIndex={0}
+          aria-label={`Edit item ${it.name}`}
+        >
+          <div className="text-lg font-bold text-[var(--primary)] text-center truncate w-full mb-1">
+            {it.name}
+          </div>
+          <div className="text-xs text-[var(--foreground)]/60 text-center truncate w-full mb-2">
+            {it.system}
+          </div>
+          <div className="text-sm text-[var(--foreground)]/80 text-center line-clamp-3">
+            {it.description}
+          </div>
+          <div className="absolute top-2 left-4 text-[10px] text-[var(--foreground)]/30 select-none font-mono">
+            ID: {it.id}
+          </div>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/app/components/library/LibraryModal.tsx
+++ b/frontend/src/app/components/library/LibraryModal.tsx
@@ -1,0 +1,118 @@
+"use client";
+import { useState } from "react";
+import ModalContainer from "../template/modalContainer";
+import { M3FloatingInput } from "../template/M3FloatingInput";
+import { createLibraryItem, updateLibraryItem, deleteLibraryItem } from "../../lib/libraryAPI";
+import { useAuth } from "../auth/AuthProvider";
+
+export default function LibraryModal({ item, onClose, onSave, onDelete }) {
+  const isEdit = !!item;
+  const [form, setForm] = useState({
+    name: item?.name || "",
+    system: item?.system || "",
+    description: item?.description || "",
+  });
+  const [file, setFile] = useState<File | null>(null);
+  const { token } = useAuth();
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setSaving(true);
+    setError("");
+    try {
+      if (isEdit) {
+        await updateLibraryItem(item.id, form, token);
+      } else {
+        const fd = new FormData();
+        fd.append("name", form.name);
+        fd.append("system", form.system);
+        fd.append("description", form.description);
+        if (file) fd.append("file", file);
+        await createLibraryItem(fd, token);
+      }
+      onSave?.();
+      onClose();
+    } catch (err: any) {
+      setError(err?.detail || err?.message || String(err));
+    }
+    setSaving(false);
+  }
+
+  async function handleDelete() {
+    if (!isEdit) return;
+    setSaving(true);
+    try {
+      await deleteLibraryItem(item.id, token);
+      onDelete?.();
+      onClose();
+    } catch (err: any) {
+      setError(err?.detail || err?.message || String(err));
+    }
+    setSaving(false);
+  }
+
+  return (
+    <ModalContainer title={isEdit ? "Edit Item" : "Add Item"} onClose={onClose}>
+      {error && (
+        <div className="bg-red-100 text-red-700 rounded-lg px-3 py-2 mb-3 text-sm">
+          {error}
+        </div>
+      )}
+      <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
+        <M3FloatingInput
+          label="Name"
+          value={form.name}
+          onChange={(e) => setForm({ ...form, name: e.target.value })}
+          required
+        />
+        <M3FloatingInput
+          label="System"
+          value={form.system}
+          onChange={(e) => setForm({ ...form, system: e.target.value })}
+          required
+        />
+        <M3FloatingInput
+          label="Description"
+          value={form.description}
+          onChange={(e) => setForm({ ...form, description: e.target.value })}
+        />
+        {!isEdit && (
+          <input
+            type="file"
+            required
+            onChange={(e) => setFile(e.target.files?.[0] || null)}
+          />
+        )}
+        <div className="flex flex-row-reverse gap-3 mt-3">
+          <button
+            type="submit"
+            className="px-7 py-2 rounded-xl font-bold bg-[var(--primary)] text-[var(--primary-foreground)] shadow-md hover:bg-[var(--accent)] hover:text-[var(--primary)] border border-[var(--primary)]/30 transition-all"
+            disabled={saving}
+          >
+            {saving ? "Saving..." : "Save"}
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={saving}
+            className="px-6 py-2 rounded-xl font-semibold bg-transparent border border-[var(--border)] text-[var(--primary)] hover:bg-[var(--surface-variant)] transition-all"
+          >
+            Cancel
+          </button>
+          {isEdit && (
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={saving}
+              className="px-6 py-2 rounded-xl font-semibold bg-red-600 text-white hover:bg-red-700 transition-all"
+            >
+              Delete
+            </button>
+          )}
+        </div>
+      </form>
+    </ModalContainer>
+  );
+}

--- a/frontend/src/app/components/template/Sidebar.tsx
+++ b/frontend/src/app/components/template/Sidebar.tsx
@@ -95,6 +95,14 @@ export default function Sidebar({ mobileOpen = false, setMobileOpen = () => {} }
       external: false,
       show: user && ["world builder", "system admin"].includes(user.role),
     },
+
+    {
+      label: t("library"),
+      icon: <BookOpenText fontSize="medium" />,
+      href: "/library",
+      external: false,
+      show: user && user.role === "system admin",
+    },
  
   
     {

--- a/frontend/src/app/lib/libraryAPI.ts
+++ b/frontend/src/app/lib/libraryAPI.ts
@@ -1,0 +1,41 @@
+import { API_URL } from "./config";
+
+export async function getLibraryItems(token: string) {
+  const res = await fetch(`${API_URL}/library/`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) throw await res.text();
+  return await res.json();
+}
+
+export async function createLibraryItem(form: FormData, token: string) {
+  const res = await fetch(`${API_URL}/library/`, {
+    method: "POST",
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+    body: form,
+  });
+  if (!res.ok) throw await res.text();
+  return await res.json();
+}
+
+export async function updateLibraryItem(id: number, data: any, token: string) {
+  const res = await fetch(`${API_URL}/library/${id}`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw await res.text();
+  return await res.json();
+}
+
+export async function deleteLibraryItem(id: number, token: string) {
+  const res = await fetch(`${API_URL}/library/${id}`, {
+    method: "DELETE",
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) throw await res.text();
+  return await res.json();
+}

--- a/frontend/src/app/lib/useLibraryItems.ts
+++ b/frontend/src/app/lib/useLibraryItems.ts
@@ -1,0 +1,21 @@
+import useSWR from "swr";
+import { getLibraryItems } from "./libraryAPI";
+import { useAuth } from "../components/auth/AuthProvider";
+
+export function useLibraryItems() {
+  const { token } = useAuth();
+
+  const fetcher = (t: string) => getLibraryItems(t);
+
+  const { data, error, mutate, isLoading } = useSWR(
+    token ? ["library", token] : null,
+    () => fetcher(token)
+  );
+
+  return {
+    items: data || [],
+    error,
+    mutate,
+    isLoading,
+  };
+}

--- a/frontend/src/app/library/page.tsx
+++ b/frontend/src/app/library/page.tsx
@@ -1,0 +1,74 @@
+"use client";
+import AuthGuard from "../components/auth/AuthGuard";
+import DashboardLayout from "../components/DashboardLayout";
+import { hasRole } from "../lib/roles";
+import { useAuth } from "../components/auth/AuthProvider";
+import { useLibraryItems } from "../lib/useLibraryItems";
+import { useState } from "react";
+import LibraryGrid from "../components/library/LibraryGrid";
+import LibraryModal from "../components/library/LibraryModal";
+import { PlusCircle } from "lucide-react";
+
+export default function LibraryPage() {
+  const { user } = useAuth();
+  const { items, isLoading, mutate } = useLibraryItems();
+  const [modalOpen, setModalOpen] = useState(false);
+  const [selected, setSelected] = useState(null);
+
+  if (!hasRole(user?.role, "system admin")) {
+    return (
+      <DashboardLayout>
+        <div className="p-10 text-2xl text-red-600 font-bold">Not authorized</div>
+      </DashboardLayout>
+    );
+  }
+
+  function handleEdit(item) {
+    setSelected(item);
+    setModalOpen(true);
+  }
+
+  function handleNew() {
+    setSelected(null);
+    setModalOpen(true);
+  }
+
+  function handleSaved() {
+    mutate();
+  }
+
+  return (
+    <AuthGuard>
+      <DashboardLayout>
+        <div className="min-h-screen w-full bg-[var(--background)] text-[var(--foreground)] transition-colors duration-300 px-2 sm:px-6 py-8">
+          <div className="mx-auto max-w-5xl w-full flex flex-col gap-8">
+            <div className="flex items-center justify-between mb-3">
+              <h1 className="text-2xl font-serif font-bold text-[var(--primary)] tracking-tight">
+                Library
+              </h1>
+              <button
+                className="flex items-center gap-2 px-4 py-2 rounded-xl font-bold bg-[var(--primary)] text-[var(--primary-foreground)] shadow hover:bg-[var(--accent)] hover:text-[var(--background)] transition"
+                onClick={handleNew}
+              >
+                <PlusCircle className="w-5 h-5" /> Add
+              </button>
+            </div>
+            {isLoading ? (
+              <div>Loading...</div>
+            ) : (
+              <LibraryGrid items={items} onItemClick={handleEdit} />
+            )}
+          </div>
+          {modalOpen && (
+            <LibraryModal
+              item={selected}
+              onClose={() => setModalOpen(false)}
+              onSave={handleSaved}
+              onDelete={handleSaved}
+            />
+          )}
+        </div>
+      </DashboardLayout>
+    </AuthGuard>
+  );
+}

--- a/frontend/src/app/locales/en.json
+++ b/frontend/src/app/locales/en.json
@@ -37,6 +37,7 @@
   "ai_adventure_novelists": "AI Adventure Novelists",
   "world_builder": "World Builder",
   "system_settings": "System Settings",
+  "library": "Library",
   "worlds": "Worlds",
   "hi": "Hi!",
   "personalize": "Personalize",

--- a/frontend/src/app/locales/it.json
+++ b/frontend/src/app/locales/it.json
@@ -37,6 +37,7 @@
   "ai_adventure_novelists": "Romanzieri di Avventure AI",
   "world_builder": "Costruttore di Mondi",
   "system_settings": "Impostazioni di Sistema",
+  "library": "Libreria",
   "worlds": "Mondi",
   "hi": "Ciao!",
   "personalize": "Personalizza",

--- a/frontend/src/app/locales/pt.json
+++ b/frontend/src/app/locales/pt.json
@@ -37,6 +37,7 @@
   "ai_adventure_novelists": "Romancistas de Aventuras IA",
   "world_builder": "Construtor de Mundos",
   "system_settings": "Configurações do Sistema",
+  "library": "Biblioteca",
   "worlds": "Mundos",
   "hi": "Olá!",
   "personalize": "Personalizar",


### PR DESCRIPTION
## Summary
- add LibraryItem model, CRUD and API endpoints
- expose new admin Library page in frontend with translation
- add components and hooks for library management
- update sidebar menu
- include tests for library API

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ProxyError when downloading huggingface model)*

------
https://chatgpt.com/codex/tasks/task_e_687d3b75a0b08322900ee470bac9de65