### PR TITLE
Fix circular import preventing Celery startup

### DIFF
--- a/backend/app/api/api_library.py
+++ b/backend/app/api/api_library.py
@@ -18,7 +18,6 @@ from app.crud.crud_library_item import (
     delete_item,
 )
 from app.dependencies import get_current_user, require_role
-from app.task_queue import task_rebuild_library_vectors
 from app.config import settings
 
 LibraryItemRead.model_rebuild()
@@ -107,6 +106,7 @@ async def embed_library_item_async(
     item_id: int,
     user: User = Depends(require_role(UserRole.system_admin)),
 ):
+    from app.task_queue import task_rebuild_library_vectors
     job_id = uuid4().hex
     job_dir = Path(settings.library_job_dir)
     job_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- fix circular import in `api_library` by lazily importing Celery task

## Testing
- `pytest -q` *(fails: unable to download model due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687e557ebe5483228e26dd1d4d81ea63