### PR TITLE
Add cover images for library items

### DIFF
--- a/backend/app/api/api_library.py
+++ b/backend/app/api/api_library.py
@@ -40,11 +40,27 @@ async def create_library_item(
     dest_path = dest_dir / f"{safe_name}{ext}"
     with open(dest_path, "wb") as out:
         out.write(await file.read())
+
+    cover_url = None
+    if ext.lower() == ".pdf":
+        try:
+            from pdf2image import convert_from_path
+
+            cover_dir = Path("uploads") / "library" / safe_name
+            cover_dir.mkdir(parents=True, exist_ok=True)
+            cover_path = cover_dir / "cover.png"
+            images = convert_from_path(str(dest_path), first_page=1, last_page=1)
+            if images:
+                images[0].save(cover_path, "PNG")
+                cover_url = str(cover_path)
+        except Exception:
+            cover_url = None
     item = LibraryItem(
         name=name,
         system=system,
         description=description,
         path=str(dest_path),
+        cover_url=cover_url,
     )
     return await create_item(session, item)
 

--- a/backend/app/crud/crud_library_item.py
+++ b/backend/app/crud/crud_library_item.py
@@ -40,6 +40,19 @@ async def delete_item(session: AsyncSession, item_id: int) -> bool:
             os.remove(item.path)
         except Exception:
             pass
+    if item.cover_url:
+        folder = os.path.dirname(item.cover_url)
+        if os.path.isdir(folder):
+            try:
+                import shutil
+                shutil.rmtree(folder)
+            except Exception:
+                pass
+    try:
+        from app.crud import crud_library_vectordb
+        crud_library_vectordb.delete_item_vectors(item_id)
+    except Exception:
+        pass
     await session.delete(item)
     await session.commit()
     return True

--- a/backend/app/crud/crud_library_vectordb.py
+++ b/backend/app/crud/crud_library_vectordb.py
@@ -83,3 +83,9 @@ async def rebuild_item_with_progress(
     item.vector_db_update_date = datetime.now(timezone.utc)
     await session.commit()
     return len(docs)
+
+
+def delete_item_vectors(item_id: int) -> None:
+    """Remove the vector DB collection for a library item."""
+    collection = _get_collection(item_id)
+    _delete_collection(f"library_{item_id}", collection)

--- a/backend/app/crud/crud_vectordb.py
+++ b/backend/app/crud/crud_vectordb.py
@@ -14,11 +14,22 @@ from langchain.docstore.document import Document
 from langchain_huggingface import HuggingFaceEmbeddings
 
 
+class _DummyEmbeddings:
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        return [[float(hash(t) % 1000)] for t in texts]
 
-_embedding_fn = HuggingFaceEmbeddings(
-    model_name="sentence-transformers/all-mpnet-base-v2",
-      model_kwargs={"device": "cpu"}
-)
+    def embed_query(self, text: str) -> List[float]:
+        return [float(hash(text) % 1000)]
+
+
+
+if os.getenv("USE_DUMMY_EMBEDDINGS", "false").lower() == "true":
+    _embedding_fn = _DummyEmbeddings()
+else:
+    _embedding_fn = HuggingFaceEmbeddings(
+        model_name="sentence-transformers/all-mpnet-base-v2",
+        model_kwargs={"device": "cpu"},
+    )
 
 
 _text_splitter = RecursiveCharacterTextSplitter(

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -56,6 +56,8 @@ def _migrate(conn):
         columns = [c["name"] for c in inspector.get_columns("libraryitem")]
         if "vector_db_update_date" not in columns:
             conn.execute(text("ALTER TABLE libraryitem ADD COLUMN vector_db_update_date DATETIME"))
+        if "cover_url" not in columns:
+            conn.execute(text("ALTER TABLE libraryitem ADD COLUMN cover_url TEXT"))
 
 async def get_session() -> AsyncSession:
     async with async_session_maker() as session:

--- a/backend/app/models/model_library_item.py
+++ b/backend/app/models/model_library_item.py
@@ -8,5 +8,6 @@ class LibraryItem(SQLModel, table=True):
     system: str
     description: Optional[str] = None
     path: str
+    cover_url: Optional[str] = None
     added_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     vector_db_update_date: Optional[datetime] = None

--- a/backend/app/schemas/schema_library_item.py
+++ b/backend/app/schemas/schema_library_item.py
@@ -14,10 +14,12 @@ class LibraryItemUpdate(SQLModel):
     name: Optional[str] = None
     system: Optional[str] = None
     description: Optional[str] = None
+    cover_url: Optional[str] = None
 
 class LibraryItemRead(LibraryItemBase):
     id: int
     path: str
+    cover_url: Optional[str] = None
     added_at: datetime
     vector_db_update_date: Optional[datetime] = None
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -28,3 +28,5 @@ email-validator==2.1.1
 torchvision
 pillow
 pdfminer.six
+pdf2image
+reportlab

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -12,6 +12,7 @@ from httpx import AsyncClient, ASGITransport
 
 os.environ.setdefault("CELERY_BROKER_URL", "memory://")
 os.environ.setdefault("CELERY_RESULT_BACKEND", "cache+memory://")
+os.environ.setdefault("USE_DUMMY_EMBEDDINGS", "true")
 # Configure chat history location for tests
 from pathlib import Path
 from app.config import settings

--- a/backend/tests/test_library.py
+++ b/backend/tests/test_library.py
@@ -32,20 +32,26 @@ async def test_library_crud(async_client, tmp_path):
     admin_token = await register_and_login(async_client, SYSTEM_ADMIN)
     player_token = await register_and_login(async_client, PLAYER)
 
-    file_path = tmp_path / "doc.txt"
-    file_path.write_text("hello")
+    file_path = tmp_path / "doc.pdf"
+    from reportlab.pdfgen import canvas
+    c = canvas.Canvas(str(file_path))
+    c.drawString(100, 750, "hello")
+    c.showPage()
+    c.save()
 
     with open(file_path, "rb") as f:
         resp = await async_client.post(
             "/library/",
             data={"name": "Doc", "system": "dnd", "description": "desc"},
-            files={"file": ("doc.txt", f, "text/plain")},
+            files={"file": ("doc.pdf", f, "application/pdf")},
             headers={"Authorization": f"Bearer {admin_token}"},
         )
     assert resp.status_code == 200
     item_id = resp.json()["id"]
     stored = Path(resp.json()["path"])
+    cover = Path(resp.json()["cover_url"])
     assert stored.is_file()
+    assert cover.is_file()
 
     # player cannot create
     with open(file_path, "rb") as f:
@@ -68,7 +74,7 @@ async def test_library_crud(async_client, tmp_path):
         headers={"Authorization": f"Bearer {admin_token}"},
     )
     assert resp.status_code == 200
-    assert resp.text == "hello"
+    assert resp.headers.get("content-type", "").startswith("application/pdf")
 
     # update
     resp = await async_client.patch(
@@ -87,3 +93,4 @@ async def test_library_crud(async_client, tmp_path):
     assert resp.status_code == 200
     assert resp.json()["ok"] is True
     assert not stored.exists()
+    assert not cover.parent.exists()

--- a/frontend/src/app/components/library/LibraryGrid.tsx
+++ b/frontend/src/app/components/library/LibraryGrid.tsx
@@ -15,6 +15,13 @@ export default function LibraryGrid({ items, onItemClick, onEmbed, jobsByItem, e
           <div className="text-lg font-bold text-[var(--primary)] text-center truncate w-full mb-1 pointer-events-none">
             {it.name}
           </div>
+          {it.cover_url && (
+            <img
+              src={it.cover_url.startsWith("/") ? it.cover_url : `/${it.cover_url}`}
+              alt="cover"
+              className="w-full h-40 object-cover rounded-lg mb-2 pointer-events-none"
+            />
+          )}
           <div className="text-xs text-[var(--foreground)]/60 text-center truncate w-full mb-2 pointer-events-none">
             {it.system}
           </div>


### PR DESCRIPTION
## Summary
- allow optional `cover_url` on library items
- generate cover image from uploaded PDF first page
- expose `cover_url` in library API
- remove cover directory and vectors when deleting an item
- support dummy embeddings for tests
- display book covers in LibraryGrid
- adjust library CRUD test for new cover images

## Testing
- `pytest backend/tests/test_library.py::test_library_crud -q`

------
https://chatgpt.com/codex/tasks/task_e_687e7a7dcd6083229683590bcf7e0994