### PR TITLE
Fix duplicate icon import

### DIFF
--- a/frontend/src/app/ai_specialist/specialist_chat/page.tsx
+++ b/frontend/src/app/ai_specialist/specialist_chat/page.tsx
@@ -15,7 +15,6 @@ import type { ChatMessage } from "../../lib/specialistAPI";
 import { useAgentLibraryItems } from "../../lib/useAgentLibraryItems";
 import { downloadBlob } from "../../lib/importExportAPI";
 import { motion } from "framer-motion";
-import { Download, File } from "lucide-react";
 import ModalContainer from "../../components/template/modalContainer";
 import { clearSpecialistHistory } from "../../lib/specialistAPI";
 import { getPage } from "../../lib/pagesAPI";


### PR DESCRIPTION
## Summary
- deduplicate lucide-react icons in specialist chat page

## Testing
- `npm run lint` *(fails: multiple lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_687e9d934e348322aa6a8a1103198053