### PR TITLE
Add background job management

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,4 +1,17 @@
-from . import api_characteristic, api_concept, api_page, api_user, api_gameworld, api_import_export, api_vectordb, api_agent, api_specialist, api_backup, api_library
+from . import (
+    api_characteristic,
+    api_concept,
+    api_page,
+    api_user,
+    api_gameworld,
+    api_import_export,
+    api_vectordb,
+    api_agent,
+    api_specialist,
+    api_backup,
+    api_library,
+    api_jobs,
+)
 
 __all__ = [
     "api_characteristic",
@@ -12,4 +25,5 @@ __all__ = [
     "api_specialist",
     "api_backup",
     "api_library",
+    "api_jobs",
 ]

--- a/backend/app/api/api_jobs.py
+++ b/backend/app/api/api_jobs.py
@@ -1,0 +1,63 @@
+from fastapi import APIRouter, Depends, HTTPException
+from app.dependencies import get_current_user, require_role
+from app.models.model_user import User, UserRole
+from app.config import settings
+from pathlib import Path
+from typing import List
+import json
+from pydantic import BaseModel
+
+router = APIRouter(prefix="/jobs", tags=["Jobs"], dependencies=[Depends(get_current_user)])
+
+JOB_DIRS = {
+    "vectordb": settings.vectordb_job_dir,
+    "writer": settings.writer_job_dir,
+    "specialist": settings.specialist_job_dir,
+    "novelist": settings.novelist_job_dir,
+    "library": settings.library_job_dir,
+}
+
+class JobRef(BaseModel):
+    kind: str
+    job_id: str
+
+class DeleteJobsRequest(BaseModel):
+    jobs: List[JobRef]
+
+
+def _load_jobs():
+    jobs = []
+    for kind, dir_path in JOB_DIRS.items():
+        p = Path(dir_path)
+        p.mkdir(parents=True, exist_ok=True)
+        for f in p.glob("*.json"):
+            with open(f) as fh:
+                data = json.load(fh)
+            data["job_id"] = f.stem
+            data["kind"] = kind
+            jobs.append(data)
+    return jobs
+
+@router.get("/")
+async def list_jobs():
+    jobs = _load_jobs()
+    jobs.sort(key=lambda j: j.get("start_time", ""), reverse=True)
+    return jobs
+
+@router.delete("/")
+async def delete_jobs(payload: DeleteJobsRequest, user: User = Depends(require_role(UserRole.system_admin))):
+    deleted = []
+    for ref in payload.jobs:
+        dir_path = JOB_DIRS.get(ref.kind)
+        if not dir_path:
+            continue
+        job_path = Path(dir_path) / f"{ref.job_id}.json"
+        if not job_path.is_file():
+            continue
+        with open(job_path) as f:
+            data = json.load(f)
+        if data.get("status") in {"running", "processing", "queued"}:
+            continue
+        job_path.unlink()
+        deleted.append({"kind": ref.kind, "job_id": ref.job_id})
+    return {"deleted": deleted}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,6 +13,7 @@ from .api import (
     api_specialist,
     api_backup,
     api_library,
+    api_jobs,
 )
 from contextlib import asynccontextmanager
 
@@ -95,6 +96,7 @@ app.include_router(api_agent.router)
 app.include_router(api_specialist.router)
 app.include_router(api_backup.router)
 app.include_router(api_library.router)
+app.include_router(api_jobs.router)
 
 
 

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -1,0 +1,59 @@
+import json
+from pathlib import Path
+import pytest
+
+@pytest.mark.anyio
+async def test_list_and_delete_jobs(async_client, create_user, login_and_get_token, tmp_path, monkeypatch):
+    from app.config import settings
+
+    settings.vectordb_job_dir = str(tmp_path / "vector")
+    settings.writer_job_dir = str(tmp_path / "writer")
+    settings.specialist_job_dir = str(tmp_path / "specialist")
+    settings.novelist_job_dir = str(tmp_path / "novelist")
+    settings.library_job_dir = str(tmp_path / "library")
+
+    for p in [settings.vectordb_job_dir, settings.writer_job_dir, settings.specialist_job_dir, settings.novelist_job_dir, settings.library_job_dir]:
+        Path(p).mkdir(parents=True, exist_ok=True)
+
+    # create sample job files
+    vec_job = Path(settings.vectordb_job_dir) / "v1.json"
+    vec_job.write_text(json.dumps({"status": "done", "start_time": "2024"}))
+
+    writer_job = Path(settings.writer_job_dir) / "w1.json"
+    writer_job.write_text(json.dumps({"status": "running", "start_time": "2024"}))
+
+    novel_job = Path(settings.novelist_job_dir) / "n1.json"
+    novel_job.write_text(json.dumps({"status": "error", "start_time": "2024"}))
+
+    await create_user("admin@test.com", "pass", "system admin")
+    token = await login_and_get_token("admin@test.com", "pass", "system admin")
+
+    resp = await async_client.get("/jobs", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert any(j["job_id"] == "v1" and j["kind"] == "vectordb" for j in data)
+    assert any(j["job_id"] == "w1" for j in data)
+
+    # attempt delete (should remove done and error but not running)
+    delete_payload = {
+        "jobs": [
+            {"kind": "vectordb", "job_id": "v1"},
+            {"kind": "novelist", "job_id": "n1"},
+            {"kind": "writer", "job_id": "w1"},
+        ]
+    }
+    del_resp = await async_client.delete(
+        "/jobs",
+        json=delete_payload,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert del_resp.status_code == 200
+    res = del_resp.json()
+    assert {"kind": "vectordb", "job_id": "v1"} in res["deleted"]
+    assert {"kind": "novelist", "job_id": "n1"} in res["deleted"]
+    assert {"kind": "writer", "job_id": "w1"} not in res["deleted"]
+
+    # ensure files deleted appropriately
+    assert not vec_job.exists()
+    assert not novel_job.exists()
+    assert writer_job.exists()

--- a/frontend/src/app/background_jobs/page.tsx
+++ b/frontend/src/app/background_jobs/page.tsx
@@ -1,0 +1,150 @@
+"use client";
+import AuthGuard from "../components/auth/AuthGuard";
+import DashboardLayout from "../components/DashboardLayout";
+import { hasRole } from "../lib/roles";
+import { useAuth } from "../components/auth/AuthProvider";
+import { useJobs } from "../lib/useJobs";
+import { deleteJobs } from "../lib/jobsAPI";
+import { useState } from "react";
+import { Trash2 } from "lucide-react";
+
+export default function BackgroundJobsPage() {
+  const { user, token } = useAuth();
+  const { jobs, mutate } = useJobs();
+  const [typeFilter, setTypeFilter] = useState("");
+  const [statusFilter, setStatusFilter] = useState("");
+  const [sortDesc, setSortDesc] = useState(true);
+  const [selected, setSelected] = useState<string[]>([]);
+  const [message, setMessage] = useState(" ");
+
+  if (!hasRole(user?.role, "system admin")) {
+    return (
+      <DashboardLayout>
+        <div className="p-10 text-2xl text-red-600 font-bold">Not authorized</div>
+      </DashboardLayout>
+    );
+  }
+
+  const activeStatuses = ["queued", "running", "processing"];
+
+  const filtered = jobs.filter((j: any) =>
+    (!typeFilter || j.kind === typeFilter) &&
+    (!statusFilter || j.status === statusFilter)
+  );
+
+  const sorted = [...filtered].sort((a, b) => {
+    const av = a.start_time || "";
+    const bv = b.start_time || "";
+    if (av < bv) return sortDesc ? 1 : -1;
+    if (av > bv) return sortDesc ? -1 : 1;
+    return 0;
+  });
+
+  const types = Array.from(new Set(jobs.map((j: any) => j.kind)));
+  const statuses = Array.from(new Set(jobs.map((j: any) => j.status)));
+
+  function toggle(id: string) {
+    setSelected(sel => sel.includes(id) ? sel.filter(x => x !== id) : [...sel, id]);
+  }
+
+  async function handleDelete() {
+    const toDelete = sorted
+      .filter(j => selected.includes(j.kind + j.job_id) && !activeStatuses.includes(j.status))
+      .map(j => ({ kind: j.kind, job_id: j.job_id }));
+    if (toDelete.length === 0) return;
+    await deleteJobs(toDelete, token || "");
+    setMessage("Jobs removed");
+    setTimeout(() => setMessage(""), 2000);
+    setSelected([]);
+    mutate();
+  }
+
+  return (
+    <AuthGuard>
+      <DashboardLayout>
+        <div className="min-h-screen w-full bg-[var(--background)] text-[var(--foreground)] transition-colors duration-300 px-2 sm:px-6 py-8">
+          <div className="mx-auto max-w-5xl w-full flex flex-col gap-6">
+            <div className="flex items-center justify-between mb-3">
+              <h1 className="text-2xl font-serif font-bold text-[var(--primary)]">Background Jobs</h1>
+              {message && (
+                <div className="bg-[var(--primary)] text-[var(--primary-foreground)] px-4 py-2 rounded-xl shadow text-sm animate-fade-in-out">
+                  {message}
+                </div>
+              )}
+            </div>
+            <div className="flex flex-wrap gap-4 items-center bg-[var(--surface-variant)]/60 rounded-xl p-3">
+              <select
+                className="px-3 py-2 rounded-xl border border-[var(--primary)] bg-[var(--card-bg)] text-[var(--foreground)] focus:outline-none text-base"
+                value={typeFilter}
+                onChange={e => setTypeFilter(e.target.value)}
+              >
+                <option value="">All types</option>
+                {types.map(t => <option key={t} value={t}>{t}</option>)}
+              </select>
+              <select
+                className="px-3 py-2 rounded-xl border border-[var(--primary)] bg-[var(--card-bg)] text-[var(--foreground)] focus:outline-none text-base"
+                value={statusFilter}
+                onChange={e => setStatusFilter(e.target.value)}
+              >
+                <option value="">All status</option>
+                {statuses.map(s => <option key={s} value={s}>{s}</option>)}
+              </select>
+              <button
+                className="ml-auto flex items-center gap-2 px-4 py-2 rounded-xl font-bold bg-rose-600 text-white shadow hover:bg-rose-800 transition"
+                onClick={handleDelete}
+              >
+                <Trash2 className="w-4 h-4" /> Remove Selected
+              </button>
+            </div>
+            <div className="overflow-x-auto">
+              <table className="min-w-full border border-[var(--border)] text-sm">
+                <thead className="bg-[var(--surface)]">
+                  <tr>
+                    <th className="border px-2 py-1"></th>
+                    <th className="border px-2 py-1">Type</th>
+                    <th className="border px-2 py-1">Job ID</th>
+                    <th className="border px-2 py-1 cursor-pointer" onClick={() => setSortDesc(!sortDesc)}>
+                      Start {sortDesc ? '▼' : '▲'}
+                    </th>
+                    <th className="border px-2 py-1">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sorted.map(j => (
+                    <JobRow key={j.kind + j.job_id} job={j} selected={selected.includes(j.kind + j.job_id)} toggle={toggle} disable={activeStatuses.includes(j.status)} />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </DashboardLayout>
+    </AuthGuard>
+  );
+}
+
+function JobRow({ job, selected, toggle, disable }: any) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <tr className="hover:bg-[var(--surface)]/40">
+        <td className="border px-2 py-1 text-center">
+          <input type="checkbox" disabled={disable} checked={selected} onChange={() => toggle(job.kind + job.job_id)} />
+        </td>
+        <td className="border px-2 py-1">{job.kind}</td>
+        <td className="border px-2 py-1 font-mono underline cursor-pointer" onClick={() => setOpen(o => !o)}>
+          {job.job_id}
+        </td>
+        <td className="border px-2 py-1">{job.start_time ? new Date(job.start_time).toLocaleString() : '-'}</td>
+        <td className="border px-2 py-1">{job.status}</td>
+      </tr>
+      {open && (
+        <tr>
+          <td colSpan={5} className="border px-2 py-2 bg-[var(--surface)] text-xs whitespace-pre-wrap">
+            {JSON.stringify(job, null, 2)}
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}

--- a/frontend/src/app/lib/jobsAPI.ts
+++ b/frontend/src/app/lib/jobsAPI.ts
@@ -1,0 +1,22 @@
+import { API_URL } from "./config";
+
+export async function listJobs(token: string) {
+  const res = await fetch(`${API_URL}/jobs`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) throw await res.text();
+  return await res.json();
+}
+
+export async function deleteJobs(jobs: { kind: string; job_id: string }[], token: string) {
+  const res = await fetch(`${API_URL}/jobs`, {
+    method: "DELETE",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify({ jobs }),
+  });
+  if (!res.ok) throw await res.text();
+  return await res.json();
+}

--- a/frontend/src/app/lib/useJobs.ts
+++ b/frontend/src/app/lib/useJobs.ts
@@ -1,0 +1,14 @@
+import useSWR from "swr";
+import { listJobs } from "./jobsAPI";
+import { useAuth } from "../components/auth/AuthProvider";
+
+export function useJobs() {
+  const { token } = useAuth();
+  const fetcher = () => listJobs(token || "");
+  const { data, error, mutate } = useSWR(
+    token ? ["jobs", token] : null,
+    fetcher,
+    { refreshInterval: 2000 }
+  );
+  return { jobs: data || [], error, mutate };
+}

--- a/frontend/src/app/system_settings/page.tsx
+++ b/frontend/src/app/system_settings/page.tsx
@@ -7,6 +7,7 @@ import { useState } from "react";
 import { useTranslation } from "@/app/hooks/useTranslation";
 import ImportWorldModal from "../components/importexport/ImportWorldModal";
 import { Download, Upload, Users2, Bot, PenLine, FileDown, FileUp, BookOpenText } from "lucide-react";
+import { History } from "lucide-react";
 import Link from "next/link";
 import ExportWorldModal from "../components/importexport/ExportWorldModal";
 import ImportBackupModal from "../components/importexport/ImportBackupModal";
@@ -177,6 +178,24 @@ export default function UserManagementPage() {
               >
                 <Bot className="w-5 h-5" />
                 Go to Agent Settings
+              </Link>
+            </div>
+
+            {/* Background Jobs Area */}
+            <div className="bg-[var(--surface)] border border-[var(--border)] rounded-2xl shadow-sm p-6 w-full flex flex-col gap-2">
+              <div className="flex items-center gap-2 mb-2">
+                <History className="w-6 h-6 text-[var(--primary)]" />
+                <div className="text-[var(--primary)] font-bold text-lg">Background Jobs</div>
+              </div>
+              <div className="text-[var(--foreground)]/80 text-sm mb-3">
+                View and manage background job history.
+              </div>
+              <Link
+                href="/background_jobs"
+                className="inline-flex items-center gap-2 px-5 py-2 rounded-xl font-bold bg-[var(--primary)] text-[var(--primary-foreground)] shadow hover:bg-[var(--accent)] hover:text-[var(--background)] border border-[var(--primary)] transition w-fit"
+              >
+                <History className="w-5 h-5" />
+                Open Background Jobs
               </Link>
             </div>
 


### PR DESCRIPTION
## Summary
- add new API endpoint for listing and deleting job files
- expose background jobs page in system settings
- implement background job viewer with filters and bulk delete
- add helper APIs and hooks for jobs
- include basic tests for the jobs API

## Testing
- `pytest backend/tests/test_jobs.py -q` *(fails: ImportError langchain_openai)*

------
https://chatgpt.com/codex/tasks/task_e_687ea4bc40188322bf42431b54e01363