### PR TITLE
Add main dashboard with role-based cards

### DIFF
--- a/frontend/src/app/agent_writer/page.tsx
+++ b/frontend/src/app/agent_writer/page.tsx
@@ -5,7 +5,7 @@ import { useSearchParams } from "next/navigation";
 import AuthGuard from "../components/auth/AuthGuard";
 import DashboardLayout from "../components/DashboardLayout";
 import { useAuth } from "../components/auth/AuthProvider";
-import { hasRole } from "../lib/roles";
+import useRoleRedirect from "../hooks/useRoleRedirect";
 import { useAgents } from "../lib/useAgents";
 import { useWorlds } from "../lib/userWorlds";
 import { usePages } from "../lib/usePage";
@@ -74,13 +74,8 @@ function AgentWriterPageContent() {
     return () => clearInterval(interval);
   }, [jobs, token]);
 
-  if (!hasRole(user?.role, "writer")) {
-    return (
-      <DashboardLayout>
-        <div className="p-10 text-2xl text-red-600 font-bold">{t('not_authorized')}</div>
-      </DashboardLayout>
-    );
-  }
+  const allowed = useRoleRedirect("writer");
+  if (!allowed) return null;
 
   const writerAgents = agents.filter(a => a.task === "page writer");
   const worldsMap = Object.fromEntries(worlds.map(w => [w.id, w]));

--- a/frontend/src/app/agents_settings/agent_conversational/page.tsx
+++ b/frontend/src/app/agents_settings/agent_conversational/page.tsx
@@ -3,8 +3,8 @@ import { useState } from "react";
 import { Bot, Sparkles, Wand2, Search } from "lucide-react";
 import AuthGuard from "../../components/auth/AuthGuard";
 import DashboardLayout from "../../components/DashboardLayout";
-import { hasRole } from "../../lib/roles";
 import { useAuth } from "../../components/auth/AuthProvider";
+import useRoleRedirect from "../../hooks/useRoleRedirect";
 import { useAgents } from "../../lib/useAgents";
 import { useWorlds } from "../../lib/userWorlds";
 import AgentModal from "../../components/agents/AgentModal";
@@ -283,13 +283,8 @@ export default function AgentsGuildhallPage() {
     npcQuotes[Math.floor(Math.random() * npcQuotes.length)]
   );
 
-  if (!hasRole(user?.role, "world builder") && !hasRole(user?.role, "system admin")) {
-    return (
-      <DashboardLayout>
-        <div className="p-10 text-2xl text-red-600 font-bold">Not authorized</div>
-      </DashboardLayout>
-    );
-  }
+  const allowed = useRoleRedirect("world builder");
+  if (!allowed) return null;
 // Filter/search logic
 const filtered = agents.filter((a) =>
   a.name?.toLowerCase().includes(search.toLowerCase())

--- a/frontend/src/app/agents_settings/agent_novelist/page.tsx
+++ b/frontend/src/app/agents_settings/agent_novelist/page.tsx
@@ -3,8 +3,8 @@ import { useState } from "react";
 import { Sparkles, Wand2, Book, Search } from "lucide-react";
 import AuthGuard from "../../components/auth/AuthGuard";
 import DashboardLayout from "../../components/DashboardLayout";
-import { hasRole } from "../../lib/roles";
 import { useAuth } from "../../components/auth/AuthProvider";
+import useRoleRedirect from "../../hooks/useRoleRedirect";
 import { useAgents } from "../../lib/useAgents";
 import { useWorlds } from "../../lib/userWorlds";
 import AgentModal from "../../components/agents/AgentModal";
@@ -283,13 +283,8 @@ export default function AgentsGuildhallPage() {
     npcQuotes[Math.floor(Math.random() * npcQuotes.length)]
   );
 
-  if (!hasRole(user?.role, "world builder") && !hasRole(user?.role, "system admin")) {
-    return (
-      <DashboardLayout>
-        <div className="p-10 text-2xl text-red-600 font-bold">Not authorized</div>
-      </DashboardLayout>
-    );
-  }
+  const allowed = useRoleRedirect("world builder");
+  if (!allowed) return null;
 // Filter/search logic
 const filtered = agents.filter((a) =>
   a.name?.toLowerCase().includes(search.toLowerCase())

--- a/frontend/src/app/agents_settings/agent_specialist/page.tsx
+++ b/frontend/src/app/agents_settings/agent_specialist/page.tsx
@@ -4,7 +4,7 @@ import { Bot, Sparkles, Search, Database, CheckCircle2, XCircle } from "lucide-r
 import AuthGuard from "../../components/auth/AuthGuard";
 import DashboardLayout from "../../components/DashboardLayout";
 import { useAuth } from "../../components/auth/AuthProvider";
-import { hasRole } from "../../lib/roles";
+import useRoleRedirect from "../../hooks/useRoleRedirect";
 import { useAgents } from "../../lib/useAgents";
 import { useWorlds } from "../../lib/userWorlds";
 import { useAgentLibraryItems } from "../../lib/useAgentLibraryItems";
@@ -238,13 +238,8 @@ export default function SpecialistSettingsPage() {
   const [npcFlavor, setNpcFlavor] = useState("Manage your specialist agents and their library items here.");
   const [npcQuote] = useState(npcQuotes[Math.floor(Math.random()*npcQuotes.length)]);
 
-  if (!hasRole(user?.role, "world builder") && !hasRole(user?.role, "system admin")) {
-    return (
-      <DashboardLayout>
-        <div className="p-10 text-2xl text-red-600 font-bold">Not authorized</div>
-      </DashboardLayout>
-    );
-  }
+  const allowed = useRoleRedirect("world builder");
+  if (!allowed) return null;
 
   const specialists = agents.filter(a => a.task === "specialist");
 

--- a/frontend/src/app/agents_settings/agent_writer/page.tsx
+++ b/frontend/src/app/agents_settings/agent_writer/page.tsx
@@ -3,8 +3,8 @@ import { useState } from "react";
 import { Sparkles, Wand2, BookOpenText, Search } from "lucide-react";
 import AuthGuard from "../../components/auth/AuthGuard";
 import DashboardLayout from "../../components/DashboardLayout";
-import { hasRole } from "../../lib/roles";
 import { useAuth } from "../../components/auth/AuthProvider";
+import useRoleRedirect from "../../hooks/useRoleRedirect";
 import { useAgents } from "../../lib/useAgents";
 import { useWorlds } from "../../lib/userWorlds";
 import AgentModal from "../../components/agents/AgentModal";
@@ -283,13 +283,8 @@ export default function AgentsGuildhallPage() {
     npcQuotes[Math.floor(Math.random() * npcQuotes.length)]
   );
 
-  if (!hasRole(user?.role, "world builder") && !hasRole(user?.role, "system admin")) {
-    return (
-      <DashboardLayout>
-        <div className="p-10 text-2xl text-red-600 font-bold">Not authorized</div>
-      </DashboardLayout>
-    );
-  }
+  const allowed = useRoleRedirect("world builder");
+  if (!allowed) return null;
 // Filter/search logic
 const filtered = agents.filter((a) =>
   a.name?.toLowerCase().includes(search.toLowerCase())

--- a/frontend/src/app/ai_novelist/create_novel/page.tsx
+++ b/frontend/src/app/ai_novelist/create_novel/page.tsx
@@ -3,7 +3,7 @@ export const dynamic = "force-dynamic";
 import DashboardLayout from "../../components/DashboardLayout";
 import AuthGuard from "../../components/auth/AuthGuard";
 import { useAuth } from "../../components/auth/AuthProvider";
-import { hasRole } from "../../lib/roles";
+import useRoleRedirect from "../../hooks/useRoleRedirect";
 import { useSearchParams, useRouter } from "next/navigation";
 import { Suspense, useEffect, useState, useMemo, useRef } from "react";
 import { useAgentById } from "../../lib/useAgentById";
@@ -541,15 +541,8 @@ function CreateNovelPageContent() {
     router.push(`/ai_novelist/create_novel?agent= ${agentId}`);
   }
 
-  if (!hasRole(user?.role, "writer")) {
-    return (
-      <DashboardLayout>
-        <div className="p-10 text-2xl text-red-600 font-bold">
-          Not authorized
-        </div>
-      </DashboardLayout>
-    );
-  }
+  const allowed = useRoleRedirect("writer");
+  if (!allowed) return null;
 
   return (
     <AuthGuard>

--- a/frontend/src/app/ai_novelist/page.tsx
+++ b/frontend/src/app/ai_novelist/page.tsx
@@ -2,7 +2,7 @@
 import AuthGuard from "../components/auth/AuthGuard";
 import DashboardLayout from "../components/DashboardLayout";
 import { useAuth } from "../components/auth/AuthProvider";
-import { hasRole } from "../lib/roles";
+import useRoleRedirect from "../hooks/useRoleRedirect";
 import { useAgents } from "../lib/useAgents";
 import { useWorlds } from "../lib/userWorlds";
 import Image from "next/image";
@@ -15,13 +15,8 @@ export default function AINovelistPage() {
   const { worlds } = useWorlds();
   const router = useRouter();
 
-  if (!hasRole(user?.role, "writer")) {
-    return (
-      <DashboardLayout>
-        <div className="p-10 text-2xl text-red-600 font-bold">Not authorized</div>
-      </DashboardLayout>
-    );
-  }
+  const allowed = useRoleRedirect("writer");
+  if (!allowed) return null;
 
   const novelists = agents.filter(a => a.task === "story novelist");
   const worldName = (id: number) => worlds.find(w => w.id === id)?.name || "";

--- a/frontend/src/app/all_pages/page.tsx
+++ b/frontend/src/app/all_pages/page.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import AuthGuard from "../components/auth/AuthGuard";
 import DashboardLayout from "../components/DashboardLayout";
 import { useAuth } from "../components/auth/AuthProvider";
-import { hasRole } from "../lib/roles";
+import useRoleRedirect from "../hooks/useRoleRedirect";
 import { useWorlds } from "../lib/userWorlds";
 import { useConcepts } from "../lib/useConcept";
 import { usePages } from "../lib/usePage";
@@ -26,13 +26,8 @@ export default function AllPagesPage() {
   const [search, setSearch] = useState("");
   const [selectedPages, setSelectedPages] = useState<number[]>([]);
 
-  if (!hasRole(user?.role, "writer") && !hasRole(user?.role, "system admin")) {
-    return (
-      <DashboardLayout>
-        <div className="p-10 text-2xl text-red-600 font-bold">Not authorized</div>
-      </DashboardLayout>
-    );
-  }
+  const allowed = useRoleRedirect("writer");
+  if (!allowed) return null;
 
   const worldMap: Record<number, any> = {};
   worlds.forEach((w) => {

--- a/frontend/src/app/background_jobs/page.tsx
+++ b/frontend/src/app/background_jobs/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 import AuthGuard from "../components/auth/AuthGuard";
 import DashboardLayout from "../components/DashboardLayout";
-import { hasRole } from "../lib/roles";
 import { useAuth } from "../components/auth/AuthProvider";
+import useRoleRedirect from "../hooks/useRoleRedirect";
 import { useJobs } from "../lib/useJobs";
 import { deleteJobs } from "../lib/jobsAPI";
 import { useState } from "react";
@@ -17,13 +17,8 @@ export default function BackgroundJobsPage() {
   const [selected, setSelected] = useState<string[]>([]);
   const [message, setMessage] = useState(" ");
 
-  if (!hasRole(user?.role, "system admin")) {
-    return (
-      <DashboardLayout>
-        <div className="p-10 text-2xl text-red-600 font-bold">Not authorized</div>
-      </DashboardLayout>
-    );
-  }
+  const allowed = useRoleRedirect("system admin");
+  if (!allowed) return null;
 
   const activeStatuses = ["queued", "running", "processing"];
 

--- a/frontend/src/app/chat_test/page.tsx
+++ b/frontend/src/app/chat_test/page.tsx
@@ -3,7 +3,7 @@ import { useState, useRef, FormEvent } from "react";
 import AuthGuard from "../components/auth/AuthGuard";
 import DashboardLayout from "../components/DashboardLayout";
 import { useAuth } from "../components/auth/AuthProvider";
-import { hasRole } from "../lib/roles";
+import useRoleRedirect from "../hooks/useRoleRedirect";
 import { useAgents } from "../lib/useAgents";
 import { ChatMessage, chatTest } from "../lib/agentAPI";
 import Image from "next/image";
@@ -17,13 +17,8 @@ export default function ChatTestPage() {
   const [loading, setLoading] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
-  if (!hasRole(user?.role, "system admin")) {
-    return (
-      <DashboardLayout>
-        <div className="p-10 text-2xl text-red-600 font-bold">Not authorized</div>
-      </DashboardLayout>
-    );
-  }
+  const allowed = useRoleRedirect("system admin");
+  if (!allowed) return null;
 
   const availableAgents = agents.filter(a => a.vector_db_update_date);
 

--- a/frontend/src/app/components/template/Sidebar.tsx
+++ b/frontend/src/app/components/template/Sidebar.tsx
@@ -13,6 +13,7 @@ import GroupRoundedIcon from "@mui/icons-material/GroupRounded";
 import CasinoRoundedIcon from "@mui/icons-material/CasinoRounded";
 import BuildRoundedIcon from "@mui/icons-material/BuildRounded";
 import SettingsRoundedIcon from "@mui/icons-material/SettingsRounded";
+import HomeIcon from "@mui/icons-material/HomeRounded";
 import PersonEditAlt1RoundedIcon from "@mui/icons-material/EditRounded";
 import { Bot, BookOpenText, FileText, PenLine, Sparkles } from "lucide-react";
 
@@ -43,6 +44,13 @@ export default function Sidebar({ mobileOpen = false, setMobileOpen = () => {} }
       icon: <CasinoRoundedIcon fontSize="medium" />,
       href: "https://foundry.shrecknet.club",
       external: true,
+      show: true,
+    },
+    {
+      label: t("home"),
+      icon: <HomeIcon fontSize="medium" />,
+      href: "/main",
+      external: false,
       show: true,
     },
     {

--- a/frontend/src/app/hooks/useRoleRedirect.tsx
+++ b/frontend/src/app/hooks/useRoleRedirect.tsx
@@ -1,0 +1,19 @@
+"use client";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "../components/auth/AuthProvider";
+import { hasRole, UserRole } from "../lib/roles";
+
+export default function useRoleRedirect(required: UserRole) {
+  const { user } = useAuth();
+  const router = useRouter();
+  const allowed = hasRole(user?.role, required);
+
+  useEffect(() => {
+    if (user && !allowed) {
+      router.replace("/main?error=unauthorized");
+    }
+  }, [user, allowed, router]);
+
+  return allowed;
+}

--- a/frontend/src/app/library_admin/page.tsx
+++ b/frontend/src/app/library_admin/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 import AuthGuard from "../components/auth/AuthGuard";
 import DashboardLayout from "../components/DashboardLayout";
-import { hasRole } from "../lib/roles";
 import { useAuth } from "../components/auth/AuthProvider";
+import useRoleRedirect from "../hooks/useRoleRedirect";
 import { useLibraryItems } from "../lib/useLibraryItems";
 import { useState } from "react";
 import { startLibraryVectorJob } from "../lib/libraryAPI";
@@ -23,13 +23,8 @@ export default function LibraryPage() {
   const [embeddingId, setEmbeddingId] = useState<number | null>(null);
   const [toastMsg, setToastMsg] = useState("");
 
-  if (!hasRole(user?.role, "system admin")) {
-    return (
-      <DashboardLayout>
-        <div className="p-10 text-2xl text-red-600 font-bold">Not authorized</div>
-      </DashboardLayout>
-    );
-  }
+  const allowed = useRoleRedirect("system admin");
+  if (!allowed) return null;
 
   function handleEdit(item) {
     setSelected(item);

--- a/frontend/src/app/locales/en.json
+++ b/frontend/src/app/locales/en.json
@@ -31,6 +31,7 @@
   "create_page": "Create Page",
   "logout": "Logout",
   "see_all_pages": "All Pages",
+  "home": "Home",
   "ai_world_elders": "Elders",
   "ai_system_specialists": "Specialists",
   "ai_page_writers": "Writers",

--- a/frontend/src/app/locales/it.json
+++ b/frontend/src/app/locales/it.json
@@ -31,6 +31,7 @@
   "create_page": "Crea Pagina",
   "logout": "Esci",
   "see_all_pages": "Tutte le Pagine",
+  "home": "Home",
   "ai_world_elders": "Anziani",
   "ai_system_specialists": "Specialisti",
   "ai_page_writers": "Scrittori",

--- a/frontend/src/app/locales/pt.json
+++ b/frontend/src/app/locales/pt.json
@@ -31,6 +31,7 @@
   "create_page": "Criar Página",
   "logout": "Sair",
   "see_all_pages": "Todas as Páginas",
+  "home": "Início",
   "ai_world_elders": "Anciões",
   "ai_system_specialists": "Especialistas",
   "ai_page_writers": "Escritores",

--- a/frontend/src/app/main/page.tsx
+++ b/frontend/src/app/main/page.tsx
@@ -1,0 +1,120 @@
+"use client";
+import AuthGuard from "../components/auth/AuthGuard";
+import DashboardLayout from "../components/DashboardLayout";
+import { useAuth } from "../components/auth/AuthProvider";
+import { useTranslation } from "../hooks/useTranslation";
+import { useSearchParams } from "next/navigation";
+import Link from "next/link";
+import {
+  Globe,
+  BookOpenText,
+  Users,
+  Sparkles,
+  Bot,
+  PenLine,
+  Hammer,
+  Settings,
+} from "lucide-react";
+
+function HomeCard({ href, icon, title, description }) {
+  return (
+    <Link
+      href={href}
+      className="group relative overflow-hidden rounded-3xl border border-[var(--border)] bg-[var(--surface)] p-6 shadow-md hover:shadow-xl transition"
+    >
+      <div className="relative z-10 flex items-center gap-3 mb-3">
+        <div className="w-10 h-10 rounded-xl flex items-center justify-center bg-[var(--primary)]/10 text-[var(--primary)]">
+          {icon}
+        </div>
+        <h2 className="text-lg font-bold text-[var(--primary)]">{title}</h2>
+      </div>
+      <p className="text-sm text-[var(--foreground)]/80">{description}</p>
+    </Link>
+  );
+}
+
+export default function MainPage() {
+  const { user } = useAuth();
+  const { t } = useTranslation();
+  const params = useSearchParams();
+  const error = params.get("error");
+
+  const cards = [
+    {
+      title: t("worlds"),
+      description: t("explore_worlds_desc"),
+      icon: <Globe className="w-6 h-6" />,
+      href: "/worlds",
+      show: true,
+    },
+    {
+      title: t("library"),
+      description: t("library_desc"),
+      icon: <BookOpenText className="w-6 h-6" />,
+      href: "/library",
+      show: true,
+    },
+    {
+      title: t("ai_world_elders"),
+      description: t("desc_agent_conversational"),
+      icon: <Users className="w-6 h-6" />,
+      href: "/elders",
+      show: true,
+    },
+    {
+      title: t("ai_system_specialists"),
+      description: t("desc_agent_specialist"),
+      icon: <Sparkles className="w-6 h-6" />,
+      href: "/ai_specialist",
+      show: true,
+    },
+    {
+      title: t("ai_page_writers"),
+      description: t("desc_agent_writer"),
+      icon: <Bot className="w-6 h-6" />,
+      href: "/agent_writer",
+      show: user && ["writer", "system admin"].includes(user.role),
+    },
+    {
+      title: t("ai_adventure_novelists"),
+      description: t("desc_agent_novelist"),
+      icon: <PenLine className="w-6 h-6" />,
+      href: "/ai_novelist",
+      show: user && ["writer", "system admin"].includes(user.role),
+    },
+    {
+      title: t("world_builder"),
+      description: "Forge new worlds and adventures.",
+      icon: <Hammer className="w-6 h-6" />,
+      href: "/world_builder",
+      show: user && ["world builder", "system admin"].includes(user.role),
+    },
+    {
+      title: t("system_settings"),
+      description: "Manage users and system configuration.",
+      icon: <Settings className="w-6 h-6" />,
+      href: "/system_settings",
+      show: user && user.role === "system admin",
+    },
+  ];
+
+  return (
+    <AuthGuard>
+      <DashboardLayout>
+        <div className="min-h-screen w-full px-2 sm:px-6 py-8 flex flex-col gap-6">
+          {error === "unauthorized" && (
+            <div className="text-center bg-red-100 text-red-700 border border-red-300 px-4 py-2 rounded">
+              {t("not_authorized")}
+            </div>
+          )}
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {cards.filter((c) => c.show).map((c) => (
+              <HomeCard key={c.title} {...c} />
+            ))}
+          </div>
+        </div>
+      </DashboardLayout>
+    </AuthGuard>
+  );
+}
+

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -19,7 +19,7 @@ function LoginPageContent() {
 
   useEffect(() => {
     if (!loading && user) {
-      router.replace("/worlds");
+      router.replace("/main");
     }
   }, [loading, user, router]);
 

--- a/frontend/src/app/system_settings/page.tsx
+++ b/frontend/src/app/system_settings/page.tsx
@@ -4,7 +4,7 @@ import DashboardLayout from "../components/DashboardLayout";
 import { useAuth } from "../components/auth/AuthProvider";
 import { useState } from "react";
 import { useTranslation } from "@/app/hooks/useTranslation";
-import { hasRole } from "../lib/roles";
+import useRoleRedirect from "../hooks/useRoleRedirect";
 import ImportWorldModal from "../components/importexport/ImportWorldModal";
 import ExportWorldModal from "../components/importexport/ExportWorldModal";
 import ImportBackupModal from "../components/importexport/ImportBackupModal";
@@ -46,13 +46,8 @@ export default function AdminDashboardPage() {
     }
   }
 
-  if (!hasRole(user?.role, "system admin")) {
-    return (
-      <DashboardLayout>
-        <div className="p-10 text-2xl text-red-600 font-bold">Not authorized</div>
-      </DashboardLayout>
-    );
-  }
+  const allowed = useRoleRedirect("system admin");
+  if (!allowed) return null;
 
   return (
     <AuthGuard>

--- a/frontend/src/app/user_management/page.tsx
+++ b/frontend/src/app/user_management/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 import AuthGuard from "../components/auth/AuthGuard";
 import DashboardLayout from "../components/DashboardLayout";
-import { hasRole } from "../lib/roles";
 import { useAuth } from "../components/auth/AuthProvider";
+import useRoleRedirect from "../hooks/useRoleRedirect";
 import UserGrid from "../components/user_management/User_Grid";
 import UserModal from "../components/user_management/User_Modal";
 import { useUsers } from "../lib/useUsers";
@@ -17,13 +17,8 @@ export default function UserManagementPage() {
   const [modalOpen, setModalOpen] = useState(false);
   const [success, setSuccess] = useState(""); 
 
-  if (!hasRole(user?.role, "system admin")) {
-    return (
-      <DashboardLayout>
-        <div className="p-10 text-2xl text-red-600 font-bold">Not authorized</div>
-      </DashboardLayout>
-    );
-  }
+  const allowed = useRoleRedirect("system admin");
+  if (!allowed) return null;
 
   // Filtering logic
   const filteredUsers = (users || []).filter(u =>

--- a/frontend/src/app/world_builder/[id]/page.tsx
+++ b/frontend/src/app/world_builder/[id]/page.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { useParams } from "next/navigation";
 import DashboardLayout from "@/app/components/DashboardLayout";
 import { useAuth } from "@/app/components/auth/AuthProvider";
-import { hasRole } from "@/app/lib/roles";
+import useRoleRedirect from "@/app/hooks/useRoleRedirect";
 import { useWorlds } from "@/app/lib/userWorlds";
 import { useConcepts } from "@/app/lib/useConcept";
 import { useCharacteristics } from "@/app/lib/userCharacteristic";
@@ -69,13 +69,8 @@ export default function WorldBuilderAdminPage() {
 
   console.log(enrichedConcept);
 
-  if (!hasRole(user?.role, "world builder") && !hasRole(user?.role, "system admin")) {
-    return (
-      <DashboardLayout>
-        <div className="p-10 text-2xl text-red-600 font-bold">Not authorized</div>
-      </DashboardLayout>
-    );
-  }
+  const allowed = useRoleRedirect("world builder");
+  if (!allowed) return null;
 
   if (worldsLoading) {
     return (

--- a/frontend/src/app/world_builder/page.tsx
+++ b/frontend/src/app/world_builder/page.tsx
@@ -2,8 +2,8 @@
 import AuthGuard from "../components/auth/AuthGuard";
 import DashboardLayout from "../components/DashboardLayout";
 import DashboardWorlds from "../components/worlds/DashboardWorlds";
-import { hasRole } from "../lib/roles";
 import { useAuth } from "../components/auth/AuthProvider";
+import useRoleRedirect from "../hooks/useRoleRedirect";
 import { useWorlds } from "../lib/userWorlds";
 
 export default function WorldBuilderPage() {
@@ -11,13 +11,8 @@ export default function WorldBuilderPage() {
   const { user } = useAuth();
 
   // Only "world builder" and "system admin" can access
-  if (!hasRole(user?.role, "world builder") && !hasRole(user?.role, "system admin")) {
-    return (
-      <DashboardLayout>
-        <div className="p-10 text-2xl text-red-600 font-bold">Not authorized</div>
-      </DashboardLayout>
-    );
-  }
+  const allowed = useRoleRedirect("world builder");
+  if (!allowed) return null;
 
   return (
     <AuthGuard>

--- a/frontend/src/app/worlds/[worldID]/concept/[conceptID]/page/[pageID]/page.tsx
+++ b/frontend/src/app/worlds/[worldID]/concept/[conceptID]/page/[pageID]/page.tsx
@@ -18,6 +18,7 @@ import HeaderSection from "@/app/components/see_page/HeaderSection";
 import BodySection from "@/app/components/see_page/BodySection";
 import EditableContent from "@/app/components/editor/EditableContent";
 import WorldBreadcrumb from "@/app/components/worlds/WorldBreadCrump";
+import useRoleRedirect from "@/app/hooks/useRoleRedirect";
 import { useTranslation } from "@/app/hooks/useTranslation";
 import { hasRole } from "@/app/lib/roles";
 import ModalContainer from "@/app/components/template/modalContainer";
@@ -122,13 +123,8 @@ export default function PageView() {
     window.dispatchEvent(new CustomEvent("openChatPanel", { detail }));
   }
 
-  if (!hasRole(user?.role, "player")) {
-    return (
-      <DashboardLayout>
-        <div className="p-10 text-2xl text-red-600 font-bold">Not authorized</div>
-      </DashboardLayout>
-    );
-  }
+  const allowed = useRoleRedirect("player");
+  if (!allowed) return null;
 
   async function handleSaveContent(newContent) {
     if (!pageId || !token) return;


### PR DESCRIPTION
## Summary
- add new `/main` landing page with cards for worlds, library, agents, builder and system settings
- implement `useRoleRedirect` hook to send users lacking permission back to `/main`
- update sidebar with Home link
- redirect login success to new main page
- apply role redirect across pages

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q` *(fails: 10 failed, 9 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687eac5c5dac8322ac29513217fc4499