### PR TITLE
Add user notes section

### DIFF
--- a/frontend/src/app/components/notes/NoteList.tsx
+++ b/frontend/src/app/components/notes/NoteList.tsx
@@ -1,0 +1,22 @@
+"use client";
+import { format } from "date-fns";
+
+export default function NoteList({ notes, onEdit }) {
+  if (!notes?.length) return <div className="text-center py-10 opacity-60">No notes.</div>;
+  return (
+    <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+      {notes.map((n) => (
+        <button
+          key={n.id}
+          className="flex flex-col items-start gap-1 p-4 rounded-xl border border-[var(--border)] bg-[var(--surface)] hover:bg-[var(--surface-variant)] text-left"
+          onClick={() => onEdit(n)}
+        >
+          <span className="font-bold text-[var(--primary)]">{n.title}</span>
+          <span className="text-xs text-[var(--foreground)]/70">
+            {n.note_date ? format(new Date(n.note_date), "PPpp") : ""}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/app/components/notes/NoteModal.tsx
+++ b/frontend/src/app/components/notes/NoteModal.tsx
@@ -1,0 +1,103 @@
+"use client";
+import { useState } from "react";
+import ModalContainer from "../template/modalContainer";
+import { M3FloatingInput } from "../template/M3FloatingInput";
+import { useAuth } from "../auth/AuthProvider";
+import { createUserNote, updateUserNote, deleteUserNote } from "../../lib/userNotesAPI";
+import EditableContent from "../editor/EditableContent";
+import { getPages } from "../../lib/pagesAPI";
+import { autoLinkWikiContent } from "../editor/autoLinkWikiContent";
+
+export default function NoteModal({ note, onClose, onSave }) {
+  const isEdit = !!note;
+  const [form, setForm] = useState({
+    title: note?.title || "",
+    content: note?.content || "",
+  });
+  const { token, user } = useAuth();
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setSaving(true);
+    setError("");
+    try {
+      const pages = await getPages(token || "");
+      const linkedContent = autoLinkWikiContent(form.content, pages, null, true);
+      const payload = { ...form, content: linkedContent };
+      if (isEdit) {
+        await updateUserNote(note.id, payload, token || "");
+      } else {
+        await createUserNote(payload, token || "");
+      }
+      onSave?.();
+      onClose();
+    } catch (err: any) {
+      setError(err?.detail || err?.message || String(err));
+    }
+    setSaving(false);
+  }
+
+  async function handleDelete() {
+    if (!isEdit) return;
+    setSaving(true);
+    try {
+      await deleteUserNote(note.id, token || "");
+      onSave?.();
+      onClose();
+    } catch (err: any) {
+      setError(err?.detail || err?.message || String(err));
+    }
+    setSaving(false);
+  }
+
+  return (
+    <ModalContainer title={isEdit ? "Edit Note" : "New Note"} onClose={onClose}>
+      {error && <div className="bg-red-100 text-red-700 rounded-lg px-3 py-2 mb-3 text-sm">{error}</div>}
+      <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
+        <M3FloatingInput
+          label="Title"
+          value={form.title}
+          onChange={(e) => setForm({ ...form, title: e.target.value })}
+          required
+        />
+        <EditableContent
+          content={form.content}
+          canEdit
+          onSaveContent={(html) => setForm({ ...form, content: html })}
+          pageType={`users/${user?.id}`}
+          pageName={note?.id ? `${note.id}` : "temp"}
+          className="max-h-[400px] overflow-y-auto"
+        />
+        <div className="flex flex-row-reverse gap-3 mt-3">
+          <button
+            type="submit"
+            className="px-7 py-2 rounded-xl font-bold bg-[var(--primary)] text-[var(--primary-foreground)] shadow-md hover:bg-[var(--accent)] hover:text-[var(--primary)] border border-[var(--primary)]/30 transition-all"
+            disabled={saving}
+          >
+            {saving ? "Saving..." : "Save"}
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={saving}
+            className="px-6 py-2 rounded-xl font-semibold bg-transparent border border-[var(--border)] text-[var(--primary)] hover:bg-[var(--surface-variant)] transition-all"
+          >
+            Cancel
+          </button>
+          {isEdit && (
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={saving}
+              className="px-6 py-2 rounded-xl font-semibold bg-red-600 text-white hover:bg-red-700 transition-all"
+            >
+              Delete
+            </button>
+          )}
+        </div>
+      </form>
+    </ModalContainer>
+  );
+}

--- a/frontend/src/app/components/template/Sidebar.tsx
+++ b/frontend/src/app/components/template/Sidebar.tsx
@@ -69,6 +69,13 @@ export default function Sidebar({ mobileOpen = false, setMobileOpen = () => {} }
       show: true,
     },
     {
+      label: t("notes"),
+      icon: <FileText fontSize="medium" />,
+      href: "/user_notes",
+      external: false,
+      show: true,
+    },
+    {
       label: t("see_all_pages"),
       icon: <FileText fontSize="medium" />,
       href: "/all_pages",

--- a/frontend/src/app/lib/useUserNote.ts
+++ b/frontend/src/app/lib/useUserNote.ts
@@ -1,0 +1,10 @@
+import useSWR from "swr";
+import { getUserNote } from "./userNotesAPI";
+import { useAuth } from "../components/auth/AuthProvider";
+
+export function useUserNote(noteId?: number) {
+  const { token } = useAuth();
+  const fetcher = () => getUserNote(noteId!, token || "");
+  const { data, error, mutate, isLoading } = useSWR(noteId && token ? ["user_note", noteId, token] : null, fetcher);
+  return { note: data || null, error, mutate, isLoading };
+}

--- a/frontend/src/app/lib/useUserNotes.ts
+++ b/frontend/src/app/lib/useUserNotes.ts
@@ -1,0 +1,10 @@
+import useSWR from "swr";
+import { getUserNotes } from "./userNotesAPI";
+import { useAuth } from "../components/auth/AuthProvider";
+
+export function useUserNotes() {
+  const { token } = useAuth();
+  const fetcher = () => getUserNotes(token || "");
+  const { data, error, mutate, isLoading } = useSWR(token ? ["user_notes", token] : null, fetcher);
+  return { notes: data || [], error, mutate, isLoading };
+}

--- a/frontend/src/app/lib/userNotesAPI.ts
+++ b/frontend/src/app/lib/userNotesAPI.ts
@@ -1,0 +1,46 @@
+import { API_URL } from "./config";
+
+export async function getUserNotes(token: string) {
+  const res = await fetch(`${API_URL}/user_notes/`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) throw await res.json();
+  return await res.json();
+}
+
+export async function getUserNote(id: number, token: string) {
+  const res = await fetch(`${API_URL}/user_notes/${id}`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) throw await res.json();
+  return await res.json();
+}
+
+export async function createUserNote(data: any, token: string) {
+  const res = await fetch(`${API_URL}/user_notes/`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw await res.json();
+  return await res.json();
+}
+
+export async function updateUserNote(id: number, data: any, token: string) {
+  const res = await fetch(`${API_URL}/user_notes/${id}`, {
+    method: "PATCH",
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw await res.json();
+  return await res.json();
+}
+
+export async function deleteUserNote(id: number, token: string) {
+  const res = await fetch(`${API_URL}/user_notes/${id}`, {
+    method: "DELETE",
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) throw await res.json();
+  return await res.json();
+}

--- a/frontend/src/app/locales/en.json
+++ b/frontend/src/app/locales/en.json
@@ -39,6 +39,7 @@
   "world_builder": "World Builder",
   "system_settings": "System Settings",
   "library": "Library",
+  "notes": "Notes",
   "worlds": "Worlds",
   "hi": "Hi!",
   "personalize": "Personalize",

--- a/frontend/src/app/locales/it.json
+++ b/frontend/src/app/locales/it.json
@@ -39,6 +39,7 @@
   "world_builder": "Costruttore di Mondi",
   "system_settings": "Impostazioni di Sistema",
   "library": "Libreria",
+  "notes": "Note",
   "worlds": "Mondi",
   "hi": "Ciao!",
   "personalize": "Personalizza",

--- a/frontend/src/app/locales/pt.json
+++ b/frontend/src/app/locales/pt.json
@@ -39,6 +39,7 @@
   "world_builder": "Construtor de Mundos",
   "system_settings": "Configurações do Sistema",
   "library": "Biblioteca",
+  "notes": "Notas",
   "worlds": "Mundos",
   "hi": "Olá!",
   "personalize": "Personalizar",

--- a/frontend/src/app/user_notes/page.tsx
+++ b/frontend/src/app/user_notes/page.tsx
@@ -1,0 +1,56 @@
+"use client";
+import { useState } from "react";
+import AuthGuard from "../components/auth/AuthGuard";
+import DashboardLayout from "../components/DashboardLayout";
+import { useUserNotes } from "../lib/useUserNotes";
+import NoteModal from "../components/notes/NoteModal";
+import NoteList from "../components/notes/NoteList";
+import { PlusCircle } from "lucide-react";
+
+export default function UserNotesPage() {
+  const { notes, mutate, isLoading } = useUserNotes();
+  const [modalOpen, setModalOpen] = useState(false);
+  const [selected, setSelected] = useState(null);
+
+  function handleEdit(note) {
+    setSelected(note);
+    setModalOpen(true);
+  }
+
+  function handleNew() {
+    setSelected(null);
+    setModalOpen(true);
+  }
+
+  function handleSaved() {
+    mutate();
+  }
+
+  return (
+    <AuthGuard>
+      <DashboardLayout>
+        <div className="min-h-screen w-full bg-[var(--background)] text-[var(--foreground)] transition-colors duration-300 px-2 sm:px-6 py-8">
+          <div className="mx-auto max-w-5xl w-full flex flex-col gap-6">
+            <div className="flex items-center justify-between mb-4">
+              <h1 className="text-2xl font-serif font-bold text-[var(--primary)] tracking-tight">My Notes</h1>
+              <button
+                className="flex items-center gap-2 px-4 py-2 rounded-xl font-bold bg-[var(--primary)] text-[var(--primary-foreground)] shadow hover:bg-[var(--accent)] hover:text-[var(--background)] transition"
+                onClick={handleNew}
+              >
+                <PlusCircle className="w-5 h-5" /> Add
+              </button>
+            </div>
+            {isLoading ? (
+              <div>Loading...</div>
+            ) : (
+              <NoteList notes={notes} onEdit={handleEdit} />
+            )}
+          </div>
+          {modalOpen && (
+            <NoteModal note={selected} onClose={() => setModalOpen(false)} onSave={handleSaved} />
+          )}
+        </div>
+      </DashboardLayout>
+    </AuthGuard>
+  );
+}


### PR DESCRIPTION
## Summary
- add user notes frontend API and hooks
- create NoteModal and NoteList components
- implement new `/user_notes` page
- show Notes in sidebar menu
- update locale files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_687eb509c54c8322b336ab2c754f22a2