### PR TITLE
Fix missing date-fns dependency

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -41,6 +41,7 @@
         "@tiptap/starter-kit": "^2.12.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "date-fns": "^4.1.0",
         "formidable": "^3.5.4",
         "framer-motion": "^12.15.0",
         "html-react-parser": "^5.2.5",
@@ -4733,6 +4734,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,7 @@
     "@tiptap/starter-kit": "^2.12.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
     "formidable": "^3.5.4",
     "framer-motion": "^12.15.0",
     "html-react-parser": "^5.2.5",


### PR DESCRIPTION
## Summary
- add `date-fns` to the frontend dependencies

## Testing
- `npm run build` *(fails: useSearchParams should be wrapped in a suspense boundary)*

------
https://chatgpt.com/codex/tasks/task_e_687eb92ee658832291301aa1d5dfa326