### PR TITLE
Implement note collaboration and sharing

### DIFF
--- a/backend/alembic/versions/20240607_03_add_contributors_lock.py
+++ b/backend/alembic/versions/20240607_03_add_contributors_lock.py
@@ -1,0 +1,19 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = '20240607_03'
+down_revision = '20240607_02'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('usernote', sa.Column('contributors', sa.JSON(), nullable=True))
+    op.add_column('usernote', sa.Column('locked_by_user_id', sa.Integer(), nullable=True))
+    op.add_column('usernote', sa.Column('locked_at', sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade():
+    op.drop_column('usernote', 'contributors')
+    op.drop_column('usernote', 'locked_by_user_id')
+    op.drop_column('usernote', 'locked_at')

--- a/backend/app/api/api_user_note.py
+++ b/backend/app/api/api_user_note.py
@@ -14,6 +14,7 @@ from app.crud.crud_user_note import (
     update_user_note,
     delete_user_note,
 )
+from app.task_queue import task_auto_crosslink_note_content
 
 UserNoteRead.model_rebuild()
 UserNoteCreate.model_rebuild()
@@ -29,6 +30,7 @@ async def create_note_endpoint(
 ):
     db_note = UserNote(**note.model_dump(), user_id=user.id, created_at=datetime.utcnow())
     db_note = await create_user_note(session, db_note)
+    task_auto_crosslink_note_content.delay(db_note.id)
     return db_note
 
 @router.get("/", response_model=List[UserNoteRead])
@@ -55,7 +57,11 @@ async def update_note(note_id: int, updates: UserNoteUpdate, user: User = Depend
     if not note or note.user_id != user.id:
         raise HTTPException(status_code=404, detail="Note not found")
     update_dict = updates.model_dump(exclude_unset=True)
-    note = await update_user_note(session, note_id, update_dict)
+    try:
+        note = await update_user_note(session, note_id, update_dict, user.id)
+    except PermissionError:
+        raise HTTPException(status_code=409, detail="Note is locked for editing")
+    task_auto_crosslink_note_content.delay(note.id)
     return note
 
 @router.delete("/{note_id}")

--- a/backend/app/crud/crud_page_links_update.py
+++ b/backend/app/crud/crud_page_links_update.py
@@ -4,8 +4,10 @@ from bs4 import BeautifulSoup
 
 from app.database import async_session_maker
 from app.crud.crud_page import get_page
+from app.crud.crud_user_note import get_user_note
 
 from app.models.model_page import Page, PageCharacteristicValue
+from app.models.model_user_note import UserNote
 from app.models.model_characteristic import Characteristic, ConceptCharacteristicLink
 
 
@@ -302,3 +304,68 @@ async def sync_page_ref_attributes(page: Page | int):
 
         await session.commit()
         await session.flush()
+
+
+async def auto_crosslink_note_content(note: UserNote | int):
+    """Add wiki cross-reference links inside a user note."""
+    async with async_session_maker() as session:
+        if isinstance(note, UserNote):
+            note = await get_user_note(session, note.id)
+        else:
+            note = await get_user_note(session, note)
+
+        if not note:
+            return
+
+        if note.gameworld_id:
+            candidate_pages = await session.execute(
+                select(Page)
+                .where(Page.gameworld_id == note.gameworld_id)
+                .where(Page.ignore_crosslink == False)
+            )
+        else:
+            candidate_pages = await session.execute(
+                select(Page).where(Page.ignore_crosslink == False)
+            )
+        candidate_pages = candidate_pages.scalars().all()
+
+        page_name_map = {}
+        for cp in candidate_pages:
+            if cp.name.lower() not in page_name_map:
+                page_name_map[cp.name.lower()] = cp
+
+        soup = BeautifulSoup(note.content or "", "html.parser")
+        content_changed = False
+        for name, target_page in page_name_map.items():
+            already_linked = False
+            for a in soup.find_all("a", href=True):
+                if (
+                    a.get("href")
+                    == f"/worlds/{target_page.gameworld_id}/concept/{target_page.concept_id}/page/{target_page.id}"
+                    or a.get_text(strip=True).lower() == name
+                ):
+                    already_linked = True
+                    break
+            if already_linked:
+                continue
+            pattern = re.compile(rf"\b({re.escape(target_page.name)})\b", re.IGNORECASE)
+            for element in soup.find_all(string=True):
+                if element.find_parent("a"):
+                    continue
+                if pattern.search(element):
+                    def repl(m):
+                        url = f"/worlds/{target_page.gameworld_id}/concept/{target_page.concept_id}/page/{target_page.id}"
+                        return f'<a href="{url}" class="wiki-link" title="{target_page.name}">{m.group(0)}</a>'
+                    new_html = pattern.sub(repl, element, count=1)
+                    new_nodes = BeautifulSoup(new_html, "html.parser")
+                    element.replace_with(new_nodes)
+                    content_changed = True
+                    break
+
+        if content_changed:
+            try:
+                note.content = str(soup)
+                await session.commit()
+                await session.flush()
+            except Exception as e:
+                print("NOTE CROSSLINK ERROR:", repr(e))

--- a/backend/app/crud/crud_user_note.py
+++ b/backend/app/crud/crud_user_note.py
@@ -6,6 +6,8 @@ from sqlalchemy import or_
 from app.models.model_user_note import UserNote
 
 async def create_user_note(session: AsyncSession, note: UserNote) -> UserNote:
+    note.locked_by_user_id = None
+    note.locked_at = None
     session.add(note)
     await session.commit()
     await session.refresh(note)
@@ -36,13 +38,21 @@ async def get_user_notes(
     result = await session.execute(query)
     return result.scalars().all()
 
-async def update_user_note(session: AsyncSession, note_id: int, updates: dict) -> Optional[UserNote]:
+async def update_user_note(session: AsyncSession, note_id: int, updates: dict, editor_id: int) -> Optional[UserNote]:
     note = await get_user_note(session, note_id)
     if not note:
         return None
+    if note.locked_by_user_id and note.locked_by_user_id != editor_id:
+        raise PermissionError("Note is being edited by another user")
     for k, v in updates.items():
         setattr(note, k, v)
+    if editor_id != note.user_id:
+        history = note.contributors or []
+        history.append({"user_id": editor_id, "date": datetime.utcnow().isoformat()})
+        note.contributors = history
     note.updated_at = datetime.utcnow()
+    note.locked_by_user_id = None
+    note.locked_at = None
     await session.commit()
     await session.refresh(note)
     return note

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -68,8 +68,16 @@ def _migrate(conn):
     # -- UserNote table --
     if "usernote" not in inspector.get_table_names():
         conn.execute(text(
-            "CREATE TABLE usernote (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER NOT NULL REFERENCES user(id), title TEXT NOT NULL, content TEXT, note_date DATETIME, tags JSON, gameworld_id INTEGER REFERENCES gameworld(id), shared_with_user_ids JSON, created_at DATETIME NOT NULL, updated_at DATETIME)"
+            "CREATE TABLE usernote (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER NOT NULL REFERENCES user(id), title TEXT NOT NULL, content TEXT, note_date DATETIME, tags JSON, gameworld_id INTEGER REFERENCES gameworld(id), shared_with_user_ids JSON, contributors JSON, locked_by_user_id INTEGER REFERENCES user(id), locked_at DATETIME, created_at DATETIME NOT NULL, updated_at DATETIME)"
         ))
+    else:
+        columns = [c["name"] for c in inspector.get_columns("usernote")]
+        if "contributors" not in columns:
+            conn.execute(text("ALTER TABLE usernote ADD COLUMN contributors JSON"))
+        if "locked_by_user_id" not in columns:
+            conn.execute(text("ALTER TABLE usernote ADD COLUMN locked_by_user_id INTEGER REFERENCES user(id)"))
+        if "locked_at" not in columns:
+            conn.execute(text("ALTER TABLE usernote ADD COLUMN locked_at DATETIME"))
 
 async def get_session() -> AsyncSession:
     async with async_session_maker() as session:

--- a/backend/app/models/model_user_note.py
+++ b/backend/app/models/model_user_note.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import Optional, List, Dict
 from sqlmodel import SQLModel, Field, JSON
 from sqlalchemy import Column
 from datetime import datetime, timezone
@@ -12,5 +12,8 @@ class UserNote(SQLModel, table=True):
     tags: List[str] = Field(default_factory=list, sa_column=Column(JSON))
     gameworld_id: Optional[int] = Field(default=None, foreign_key="gameworld.id")
     shared_with_user_ids: List[int] = Field(default_factory=list, sa_column=Column(JSON))
+    contributors: List[Dict] = Field(default_factory=list, sa_column=Column(JSON))
+    locked_by_user_id: Optional[int] = Field(default=None, foreign_key="user.id")
+    locked_at: Optional[datetime] = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: Optional[datetime] = None

--- a/backend/app/schemas/schema_user_note.py
+++ b/backend/app/schemas/schema_user_note.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import Optional, List, Dict
 from sqlmodel import SQLModel
 from datetime import datetime
 
@@ -9,6 +9,9 @@ class UserNoteBase(SQLModel):
     tags: List[str] = []
     gameworld_id: Optional[int] = None
     shared_with_user_ids: List[int] = []
+    contributors: List[Dict] = []
+    locked_by_user_id: Optional[int] = None
+    locked_at: Optional[datetime] = None
 
 class UserNoteCreate(UserNoteBase):
     pass

--- a/backend/app/task_queue.py
+++ b/backend/app/task_queue.py
@@ -29,6 +29,7 @@ from app.crud.crud_page_links_update import (
     remove_crosslinks_to_page,
     remove_page_refs_from_characteristics,
     sync_page_ref_attributes,
+    auto_crosslink_note_content,
 )
 
 # Ensure all models are imported so SQLModel can resolve relationships
@@ -62,6 +63,10 @@ def task_remove_page_refs_from_characteristics(page_id: int):
 @celery_app.task
 def task_sync_page_ref_attributes(page_id: int):
     asyncio.run(sync_page_ref_attributes(page_id))
+
+@celery_app.task
+def task_auto_crosslink_note_content(note_id: int):
+    asyncio.run(auto_crosslink_note_content(note_id))
 
 from app.crud.crud_page_analysis import analyze_pages_bulk
 from app.crud.crud_agent import get_agent

--- a/frontend/src/app/components/notes/NoteModal.tsx
+++ b/frontend/src/app/components/notes/NoteModal.tsx
@@ -4,6 +4,7 @@ import ModalContainer from "../template/modalContainer";
 import { M3FloatingInput } from "../template/M3FloatingInput";
 import { useAuth } from "../auth/AuthProvider";
 import { createUserNote, updateUserNote, deleteUserNote } from "../../lib/userNotesAPI";
+import { useUsers } from "../../lib/useUsers";
 import EditableContent from "../editor/EditableContent";
 import { getPages } from "../../lib/pagesAPI";
 import { autoLinkWikiContent } from "../editor/autoLinkWikiContent";
@@ -15,6 +16,7 @@ export default function NoteModal({ note, onClose, onSave }) {
     content: note?.content || "",
   });
   const { token, user } = useAuth();
+  const { users } = useUsers();
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
 
@@ -52,8 +54,15 @@ export default function NoteModal({ note, onClose, onSave }) {
     setSaving(false);
   }
 
+  const creator = users.find((u) => u.id === note?.user_id);
+  const sharedUsers = users.filter((u) => note?.shared_with_user_ids?.includes(u.id));
+  const contributors = (note?.contributors || []).map((c) => ({
+    ...c,
+    user: users.find((u) => u.id === c.user_id),
+  }));
+
   return (
-    <ModalContainer title={isEdit ? "Edit Note" : "New Note"} onClose={onClose}>
+    <ModalContainer className="w-[90vw] max-w-[90vw]" title={isEdit ? "Edit Note" : "New Note"} onClose={onClose}>
       {error && <div className="bg-red-100 text-red-700 rounded-lg px-3 py-2 mb-3 text-sm">{error}</div>}
       <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
         <M3FloatingInput
@@ -70,6 +79,20 @@ export default function NoteModal({ note, onClose, onSave }) {
           pageName={note?.id ? `${note.id}` : "temp"}
           className="max-h-[400px] overflow-y-auto"
         />
+        {isEdit && (
+          <div className="text-sm text-[var(--foreground)]/70 flex flex-col gap-1">
+            <div>Creator: {creator?.nickname || note.user_id}</div>
+            {sharedUsers.length > 0 && (
+              <div>Shared with: {sharedUsers.map(u => u.nickname).join(', ')}</div>
+            )}
+            {contributors.length > 0 && (
+              <div>
+                Contributors:
+                {contributors.map(c => ` ${c.user?.nickname || c.user_id} (${new Date(c.date).toLocaleDateString()})`).join(', ')}
+              </div>
+            )}
+          </div>
+        )}
         <div className="flex flex-row-reverse gap-3 mt-3">
           <button
             type="submit"

--- a/frontend/src/app/user_notes/page.tsx
+++ b/frontend/src/app/user_notes/page.tsx
@@ -6,9 +6,11 @@ import { useUserNotes } from "../lib/useUserNotes";
 import NoteModal from "../components/notes/NoteModal";
 import NoteList from "../components/notes/NoteList";
 import { PlusCircle } from "lucide-react";
+import { useAuth } from "../components/auth/AuthProvider";
 
 export default function UserNotesPage() {
   const { notes, mutate, isLoading } = useUserNotes();
+  const { user } = useAuth();
   const [modalOpen, setModalOpen] = useState(false);
   const [selected, setSelected] = useState(null);
 
@@ -43,7 +45,20 @@ export default function UserNotesPage() {
             {isLoading ? (
               <div>Loading...</div>
             ) : (
-              <NoteList notes={notes} onEdit={handleEdit} />
+              <>
+                <h2 className="text-xl font-bold mt-2">My Notes</h2>
+                <NoteList
+                  notes={notes.filter((n) => n.user_id === user?.id)}
+                  onEdit={handleEdit}
+                />
+                <h2 className="text-xl font-bold mt-6">Shared With Me</h2>
+                <NoteList
+                  notes={notes.filter(
+                    (n) => n.user_id !== user?.id && n.shared_with_user_ids?.includes(user?.id)
+                  )}
+                  onEdit={handleEdit}
+                />
+              </>
             )}
           </div>
           {modalOpen && (


### PR DESCRIPTION
## Summary
- extend `UserNote` data model with contributors and lock info
- update CRUD operations and API endpoints for locked edits
- run background crosslink task on note save
- group notes by ownership on the dashboard
- enlarge note edit modal and show sharing details
- add Alembic migration for new fields

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_687ebae24ae08322a0ad572188f2dbc3