### PR TITLE
Update note creation workflow

### DIFF
--- a/frontend/src/app/user_notes/[noteID]/page.tsx
+++ b/frontend/src/app/user_notes/[noteID]/page.tsx
@@ -78,7 +78,7 @@ export default function NoteDetailPage() {
   return (
     <AuthGuard>
       <div className="min-h-screen w-full bg-[var(--background)] text-[var(--foreground)] px-2 sm:px-6 py-8">
-        <div className="mx-auto max-w-2xl flex flex-col gap-4">
+        <div className="w-full flex flex-col gap-4">
           <button
             className="self-start px-4 py-2 rounded-xl font-bold bg-[var(--primary)] text-[var(--primary-foreground)] shadow hover:bg-[var(--accent)] hover:text-[var(--background)] transition"
             onClick={() => router.push('/user_notes')}

--- a/frontend/src/app/user_notes/new/page.tsx
+++ b/frontend/src/app/user_notes/new/page.tsx
@@ -1,0 +1,84 @@
+"use client";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import AuthGuard from "../components/auth/AuthGuard";
+import { createUserNote } from "../lib/userNotesAPI";
+import EditableContent from "../components/editor/EditableContent";
+import { M3FloatingInput } from "../components/template/M3FloatingInput";
+import { useAuth } from "../components/auth/AuthProvider";
+import { getPages } from "../lib/pagesAPI";
+import { autoLinkWikiContent } from "../components/editor/autoLinkWikiContent";
+
+export default function NewNotePage() {
+  const router = useRouter();
+  const { token, user } = useAuth();
+  const [form, setForm] = useState({ title: "", content: "" });
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleSave(e: any) {
+    e.preventDefault();
+    setSaving(true);
+    setError("");
+    try {
+      const pages = await getPages(token || "");
+      const linkedContent = autoLinkWikiContent(form.content, pages, null, true);
+      const newNote = await createUserNote({ title: form.title, content: linkedContent }, token || "");
+      router.push(`/user_notes/${newNote.id}`);
+    } catch (err: any) {
+      setError(err?.detail || err?.message || String(err));
+    }
+    setSaving(false);
+  }
+
+  return (
+    <AuthGuard>
+      <div className="min-h-screen w-full bg-[var(--background)] text-[var(--foreground)] px-2 sm:px-6 py-8">
+        <div className="w-full flex flex-col gap-4">
+          <button
+            className="self-start px-4 py-2 rounded-xl font-bold bg-[var(--primary)] text-[var(--primary-foreground)] shadow hover:bg-[var(--accent)] hover:text-[var(--background)] transition"
+            onClick={() => router.push('/user_notes')}
+          >
+            Back to Notes
+          </button>
+          <form className="flex flex-col gap-4" onSubmit={handleSave}>
+            {error && (
+              <div className="bg-red-100 text-red-700 rounded-lg px-3 py-2 text-sm">{error}</div>
+            )}
+            <M3FloatingInput
+              label="Title"
+              value={form.title}
+              onChange={e => setForm({ ...form, title: e.target.value })}
+              required
+            />
+            <EditableContent
+              content={form.content}
+              canEdit
+              onSaveContent={html => setForm({ ...form, content: html })}
+              pageType={`users/${user?.id}`}
+              pageName="temp"
+              className="max-h-[400px] overflow-y-auto"
+            />
+            <div className="flex flex-row-reverse gap-3">
+              <button
+                type="submit"
+                className="px-7 py-2 rounded-xl font-bold bg-[var(--primary)] text-[var(--primary-foreground)] shadow-md hover:bg-[var(--accent)] hover:text-[var(--primary)] border border-[var(--primary)]/30 transition-all"
+                disabled={saving}
+              >
+                {saving ? 'Saving...' : 'Save'}
+              </button>
+              <button
+                type="button"
+                onClick={() => router.push('/user_notes')}
+                className="px-6 py-2 rounded-xl font-semibold bg-transparent border border-[var(--border)] text-[var(--primary)] hover:bg-[var(--surface-variant)] transition-all"
+                disabled={saving}
+              >
+                Cancel
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </AuthGuard>
+  );
+}

--- a/frontend/src/app/user_notes/page.tsx
+++ b/frontend/src/app/user_notes/page.tsx
@@ -1,25 +1,14 @@
 "use client";
-import { useState } from "react";
 import AuthGuard from "../components/auth/AuthGuard";
 import DashboardLayout from "../components/DashboardLayout";
 import { useUserNotes } from "../lib/useUserNotes";
-import NoteModal from "../components/notes/NoteModal";
 import NoteList from "../components/notes/NoteList";
 import { PlusCircle } from "lucide-react";
 import { useAuth } from "../components/auth/AuthProvider";
 
 export default function UserNotesPage() {
-  const { notes, mutate, isLoading } = useUserNotes();
+  const { notes, isLoading } = useUserNotes();
   const { user } = useAuth();
-  const [modalOpen, setModalOpen] = useState(false);
-
-  function handleNew() {
-    setModalOpen(true);
-  }
-
-  function handleSaved() {
-    mutate();
-  }
 
   return (
     <AuthGuard>
@@ -28,12 +17,14 @@ export default function UserNotesPage() {
           <div className="mx-auto max-w-5xl w-full flex flex-col gap-6">
             <div className="flex items-center justify-between mb-4">
               <h1 className="text-2xl font-serif font-bold text-[var(--primary)] tracking-tight">My Notes</h1>
-              <button
+              <a
+                href="/user_notes/new"
+                target="_blank"
+                rel="noopener noreferrer"
                 className="flex items-center gap-2 px-4 py-2 rounded-xl font-bold bg-[var(--primary)] text-[var(--primary-foreground)] shadow hover:bg-[var(--accent)] hover:text-[var(--background)] transition"
-                onClick={handleNew}
               >
                 <PlusCircle className="w-5 h-5" /> Add
-              </button>
+              </a>
             </div>
             {isLoading ? (
               <div>Loading...</div>
@@ -52,9 +43,6 @@ export default function UserNotesPage() {
               </>
             )}
           </div>
-          {modalOpen && (
-            <NoteModal note={null} onClose={() => setModalOpen(false)} onSave={handleSaved} />
-          )}
         </div>
       </DashboardLayout>
     </AuthGuard>


### PR DESCRIPTION
## Summary
- allow creating notes on a dedicated page
- open note creation page in a new tab from notes list
- widen note edit and creation pages

## Testing
- `npm run lint` *(fails: next not found / lint errors)*
- `pytest -q` *(fails: multiple tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_687fdf8daa008322bf9bdc20bd4dd8f6