### PR TITLE
Implement key events timeline

### DIFF
--- a/backend/app/api/api_page.py
+++ b/backend/app/api/api_page.py
@@ -1,13 +1,24 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
 from typing import List, Optional
 from fastapi import Query
 from app.database import get_session
 from app.models.model_user import User, UserRole
-from app.models.model_page import Page, PageCharacteristicValue, PageChange
+from app.models.model_page import (
+    Page,
+    PageCharacteristicValue,
+    PageChange,
+    PageKeyEvent,
+)
 from app.schemas.schema_page import PageCreate, PageRead, PageUpdate
 from app.schemas.schema_page_characteristic_value import PageCharacteristicValueUpdate, PageCharacteristicValueRead, PageCharacteristicValueCreate
 from app.schemas.schema_page_change import PageChangeRead
+from app.schemas.schema_page_key_event import (
+    PageKeyEventCreate,
+    PageKeyEventRead,
+    PageKeyEventUpdate,
+)
 from app.crud.crud_page import (
     create_page,
     get_pages,
@@ -24,6 +35,8 @@ from app.crud.crud_page import (
     get_page_changes,
     create_key_event,
     get_key_events,
+    update_key_event,
+    delete_key_event,
     create_relationship,
     get_relationships,
 )
@@ -286,4 +299,71 @@ async def delete_page_value(
     session: AsyncSession = Depends(get_session),
 ):
     await delete_page_characteristic_value(session, page_id, characteristic_id)
+    return {"ok": True}
+
+# -- Key Event endpoints --
+
+@router.post("/{page_id}/events/", response_model=PageKeyEventRead)
+async def add_key_event_endpoint(
+    page_id: int,
+    event: PageKeyEventCreate,
+    user: User = Depends(require_role(UserRole.writer)),
+    session: AsyncSession = Depends(get_session),
+):
+    if event.page_id != page_id:
+        event.page_id = page_id
+    db_event = await create_key_event(session, PageKeyEvent(**event.model_dump()))
+    change = PageChange(
+        page_id=page_id,
+        change_type="key_event_added",
+        author_type="user",
+        author_id=user.id,
+        values=db_event.model_dump(),
+    )
+    await create_page_change(session, change)
+    return db_event
+
+
+@router.patch("/events/{event_id}", response_model=PageKeyEventRead)
+async def update_key_event_endpoint(
+    event_id: int,
+    updates: PageKeyEventUpdate,
+    user: User = Depends(require_role(UserRole.writer)),
+    session: AsyncSession = Depends(get_session),
+):
+    update_dict = updates.model_dump(exclude_unset=True)
+    event = await update_key_event(session, event_id, update_dict)
+    if not event:
+        raise HTTPException(status_code=404, detail="Event not found")
+    change = PageChange(
+        page_id=event.page_id,
+        change_type="key_event_updated",
+        author_type="user",
+        author_id=user.id,
+        values=update_dict,
+    )
+    await create_page_change(session, change)
+    return event
+
+
+@router.delete("/events/{event_id}")
+async def delete_key_event_endpoint(
+    event_id: int,
+    user: User = Depends(require_role(UserRole.writer)),
+    session: AsyncSession = Depends(get_session),
+):
+    result = await session.execute(select(PageKeyEvent).where(PageKeyEvent.id == event_id))
+    event = result.scalar_one_or_none()
+    if not event:
+        raise HTTPException(status_code=404, detail="Event not found")
+    page_id = event.page_id
+    await delete_key_event(session, event_id)
+    change = PageChange(
+        page_id=page_id,
+        change_type="key_event_deleted",
+        author_type="user",
+        author_id=user.id,
+        values={"event_id": event_id},
+    )
+    await create_page_change(session, change)
     return {"ok": True}

--- a/backend/app/crud/crud_page.py
+++ b/backend/app/crud/crud_page.py
@@ -140,6 +140,22 @@ async def get_key_events(session: AsyncSession, page_id: int) -> List[PageKeyEve
     )
     return result.scalars().all()
 
+async def update_key_event(session: AsyncSession, event_id: int, updates: dict) -> Optional[PageKeyEvent]:
+    result = await session.execute(select(PageKeyEvent).where(PageKeyEvent.id == event_id))
+    event = result.scalar_one_or_none()
+    if not event:
+        return None
+    for key, value in updates.items():
+        setattr(event, key, value)
+    await session.commit()
+    await session.flush()
+    return event
+
+async def delete_key_event(session: AsyncSession, event_id: int) -> None:
+    await session.execute(delete(PageKeyEvent).where(PageKeyEvent.id == event_id))
+    await session.commit()
+    await session.flush()
+
 async def create_relationship(session: AsyncSession, rel: PageRelationship) -> PageRelationship:
     session.add(rel)
     await session.commit()

--- a/backend/app/schemas/schema_page_key_event.py
+++ b/backend/app/schemas/schema_page_key_event.py
@@ -18,3 +18,10 @@ class PageKeyEventRead(PageKeyEventBase):
     id: int
     page_id: int
     added_at: datetime
+
+class PageKeyEventUpdate(SQLModel):
+    event_type: Optional[str] = None
+    event_date: Optional[datetime] = None
+    summary: Optional[str] = None
+    source_page_id: Optional[int] = None
+    related_page_ids: Optional[List[int]] = None

--- a/frontend/src/app/components/see_page/EventTimeline.tsx
+++ b/frontend/src/app/components/see_page/EventTimeline.tsx
@@ -1,8 +1,321 @@
 "use client";
-export default function EventTimeline() {
+import { useState, useEffect } from "react";
+import ModalContainer from "../template/modalContainer";
+import { useAuth } from "../auth/AuthProvider";
+import {
+  createKeyEvent,
+  updateKeyEvent,
+  deleteKeyEvent,
+  getPage,
+} from "@/app/lib/pagesAPI";
+import Image from "next/image";
+
+interface Event {
+  id?: number;
+  page_id?: number;
+  event_type: string;
+  event_date?: string;
+  summary?: string;
+  source_page_id?: number | null;
+  related_page_ids?: number[];
+  author_type?: string;
+  author_id?: number;
+  added_at?: string;
+}
+
+interface PageInfo {
+  id: number;
+  name: string;
+  logo?: string;
+}
+
+const EVENT_ICONS: Record<string, string> = {
+  battle: "🗡️",
+  war: "⚔️",
+  lore: "📜",
+  magic: "✨",
+  item: "📦",
+};
+
+function EventForm({
+  initial,
+  pages,
+  onSubmit,
+}: {
+  initial?: Event;
+  pages: PageInfo[];
+  onSubmit: (e: Event) => void;
+}) {
+  const [type, setType] = useState(initial?.event_type || "battle");
+  const [date, setDate] = useState(
+    initial?.event_date ? initial.event_date.substring(0, 10) : ""
+  );
+  const [summary, setSummary] = useState(initial?.summary || "");
+  const [sourcePage, setSourcePage] = useState(
+    initial?.source_page_id?.toString() || ""
+  );
+  const [related, setRelated] = useState<string[]>(
+    (initial?.related_page_ids || []).map(String)
+  );
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onSubmit({
+      ...initial,
+      event_type: type,
+      event_date: date ? new Date(date).toISOString() : undefined,
+      summary,
+      source_page_id: sourcePage ? Number(sourcePage) : undefined,
+      related_page_ids: related.map((r) => Number(r)),
+    });
+  };
+
   return (
-    <div className="p-4 rounded-xl border border-dashed border-[var(--primary)]/40 bg-[var(--surface)] text-center text-sm text-[var(--foreground)]/80">
-      Key events timeline coming soon...
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="flex flex-col gap-1">
+        <label className="font-semibold text-sm">Type</label>
+        <select
+          className="border rounded-md px-3 py-1 bg-[var(--surface)]"
+          value={type}
+          onChange={(e) => setType(e.target.value)}
+        >
+          {Object.keys(EVENT_ICONS).map((k) => (
+            <option key={k} value={k}>
+              {k}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="flex flex-col gap-1">
+        <label className="font-semibold text-sm">Date</label>
+        <input
+          type="date"
+          className="border rounded-md px-3 py-1 bg-[var(--surface)]"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+        />
+      </div>
+      <div className="flex flex-col gap-1">
+        <label className="font-semibold text-sm">Summary</label>
+        <textarea
+          className="border rounded-md px-3 py-1 bg-[var(--surface)]"
+          value={summary}
+          onChange={(e) => setSummary(e.target.value)}
+        />
+      </div>
+      <div className="flex flex-col gap-1">
+        <label className="font-semibold text-sm">Source Page</label>
+        <select
+          className="border rounded-md px-3 py-1 bg-[var(--surface)]"
+          value={sourcePage}
+          onChange={(e) => setSourcePage(e.target.value)}
+        >
+          <option value="">None</option>
+          {pages.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="flex flex-col gap-1">
+        <label className="font-semibold text-sm">Related Pages</label>
+        <select
+          multiple
+          className="border rounded-md px-3 py-1 bg-[var(--surface)] h-32"
+          value={related}
+          onChange={(e) =>
+            setRelated(
+              Array.from(e.target.selectedOptions).map((o) => o.value)
+            )
+          }
+        >
+          {pages.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <button
+        type="submit"
+        className="px-4 py-2 rounded-full bg-[var(--primary)] text-[var(--primary-foreground)] hover:bg-[var(--accent)] transition"
+      >
+        Save
+      </button>
+    </form>
+  );
+}
+
+export default function EventTimeline({
+  pageId,
+  events,
+  pages = [],
+  onUpdated,
+}: {
+  pageId: number;
+  events: Event[];
+  pages: PageInfo[];
+  onUpdated: () => void;
+}) {
+  const { token } = useAuth();
+  const [filter, setFilter] = useState<string>("all");
+  const [query, setQuery] = useState("");
+  const [showForm, setShowForm] = useState(false);
+  const [editEvent, setEditEvent] = useState<Event | null>(null);
+  const [pageMap, setPageMap] = useState<Record<number, PageInfo>>({});
+
+  // Fetch page details if not provided
+  useEffect(() => {
+    const ids = new Set<number>();
+    events.forEach((e) => {
+      e.related_page_ids?.forEach((id) => ids.add(id));
+      if (e.source_page_id) ids.add(e.source_page_id);
+    });
+    ids.forEach((id) => {
+      if (!pageMap[id] && token) {
+        getPage(id, token)
+          .then((p) =>
+            setPageMap((m) => ({ ...m, [id]: { id: p.id, name: p.name, logo: p.logo } }))
+          )
+          .catch(() => {});
+      }
+    });
+  }, [events, token]);
+
+  const allPages = [...pages, ...Object.values(pageMap)];
+
+  const filtered = events
+    .filter((e) => (filter === "all" ? true : e.event_type === filter))
+    .filter((e) => {
+      if (!query) return true;
+      const text = `${e.summary} ${e.event_date}`.toLowerCase();
+      const relatedNames = e.related_page_ids
+        ?.map((id) => pageMap[id]?.name || "")
+        .join(" ")
+        .toLowerCase();
+      const sourceName = e.source_page_id ? pageMap[e.source_page_id]?.name || "" : "";
+      return (
+        text.includes(query.toLowerCase()) ||
+        relatedNames?.includes(query.toLowerCase()) ||
+        sourceName.toLowerCase().includes(query.toLowerCase())
+      );
+    })
+    .sort((a, b) => (a.event_date || "").localeCompare(b.event_date || ""));
+
+  const handleSave = async (ev: Event) => {
+    if (!token) return;
+    try {
+      if (ev.id) {
+        await updateKeyEvent(ev.id, ev, token);
+      } else {
+        await createKeyEvent(pageId, { ...ev, page_id: pageId, author_type: "user", author_id: 0 }, token);
+      }
+      onUpdated();
+      setShowForm(false);
+      setEditEvent(null);
+    } catch (err) {
+      console.error("Failed to save", err);
+    }
+  };
+
+  const handleDelete = async (ev: Event) => {
+    if (!token || !ev.id) return;
+    if (!confirm("Delete this event?")) return;
+    try {
+      await deleteKeyEvent(ev.id, token);
+      onUpdated();
+    } catch (err) {
+      console.error("Failed", err);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2 flex-wrap">
+        <select
+          className="border rounded-md px-3 py-1 bg-[var(--surface)]"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+        >
+          <option value="all">All</option>
+          {Array.from(new Set(events.map((e) => e.event_type))).map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+        <input
+          type="text"
+          placeholder="Search..."
+          className="border rounded-md px-3 py-1 bg-[var(--surface)] flex-1"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        <button
+          className="px-3 py-1 rounded-full bg-[var(--primary)] text-[var(--primary-foreground)] hover:bg-[var(--accent)] transition"
+          onClick={() => setShowForm(true)}
+        >
+          Add Event
+        </button>
+      </div>
+      <div className="relative border-l-2 border-[var(--primary)] ml-4 pl-6 max-h-[60vh] overflow-y-auto">
+        {filtered.map((e) => (
+          <div key={e.id} className="mb-8 relative group">
+            <span className="absolute -left-3 top-2 text-xl">
+              {EVENT_ICONS[e.event_type] || "📜"}
+            </span>
+            <div className="bg-[var(--surface-variant)] border border-[var(--border)] rounded-xl p-4 shadow-md">
+              <div className="flex justify-between items-center mb-2">
+                <div className="font-semibold text-sm flex items-center gap-1">
+                  {EVENT_ICONS[e.event_type] || "📜"} {e.event_type}
+                </div>
+                <div className="text-xs text-[var(--foreground)]/70">
+                  {e.event_date ? new Date(e.event_date).toLocaleDateString() : ""}
+                </div>
+              </div>
+              {e.summary && <p className="mb-2 text-sm">{e.summary}</p>}
+              {e.related_page_ids && e.related_page_ids.length > 0 && (
+                <div className="flex flex-wrap gap-2 mb-2">
+                  {e.related_page_ids.map((id) => {
+                    const p = pageMap[id];
+                    if (!p) return null;
+                    return (
+                      <span key={id} className="flex items-center gap-1 px-2 py-1 rounded-full bg-[var(--surface)] border text-xs">
+                        {p.logo && (
+                          <Image src={p.logo} alt={p.name} width={16} height={16} className="w-4 h-4 rounded-full object-cover" />
+                        )}
+                        {p.name}
+                      </span>
+                    );
+                  })}
+                </div>
+              )}
+              {e.source_page_id && pageMap[e.source_page_id] && (
+                <div className="flex items-center gap-2 text-xs mb-2">
+                  <span className="font-semibold">Source:</span>
+                  {pageMap[e.source_page_id].logo && (
+                    <Image src={pageMap[e.source_page_id].logo!} alt="src" width={16} height={16} className="w-4 h-4 rounded-full object-cover" />
+                  )}
+                  {pageMap[e.source_page_id].name}
+                </div>
+              )}
+              <div className="flex justify-end gap-2 text-xs">
+                <button onClick={() => { setEditEvent(e); setShowForm(true); }} className="text-[var(--primary)] hover:underline">Edit</button>
+                <button onClick={() => handleDelete(e)} className="text-red-600 hover:underline">Delete</button>
+              </div>
+            </div>
+          </div>
+        ))}
+        {filtered.length === 0 && (
+          <div className="text-sm text-center text-[var(--foreground)]/70">No events found.</div>
+        )}
+      </div>
+      {showForm && (
+        <ModalContainer title={editEvent ? "Edit Event" : "Add Event"} onClose={() => { setShowForm(false); setEditEvent(null); }}>
+          <EventForm initial={editEvent || { event_type: "battle" }} pages={allPages} onSubmit={handleSave} />
+        </ModalContainer>
+      )}
     </div>
   );
 }

--- a/frontend/src/app/lib/pagesAPI.ts
+++ b/frontend/src/app/lib/pagesAPI.ts
@@ -69,3 +69,33 @@ export async function getPagesForConcept(concept_id: number, token: string) {
 export async function getPagesForWorld(gameworld_id: number, token: string) {
   return getPages(token, { gameworld_id });
 }
+
+// --- Key Events ---
+export async function createKeyEvent(pageId: number, data: unknown, token: string) {
+  const res = await fetch(`${API_URL}/pages/${pageId}/events/`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw await res.json();
+  return await res.json();
+}
+
+export async function updateKeyEvent(eventId: number, data: unknown, token: string) {
+  const res = await fetch(`${API_URL}/pages/events/${eventId}`, {
+    method: "PATCH",
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw await res.json();
+  return await res.json();
+}
+
+export async function deleteKeyEvent(eventId: number, token: string) {
+  const res = await fetch(`${API_URL}/pages/events/${eventId}`, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw await res.json();
+  return await res.json();
+}

--- a/frontend/src/app/worlds/[worldID]/concept/[conceptID]/page/[pageID]/page.tsx
+++ b/frontend/src/app/worlds/[worldID]/concept/[conceptID]/page/[pageID]/page.tsx
@@ -12,6 +12,7 @@ import { useWorlds } from "@/app/lib/userWorlds";
 import { useConceptById } from "@/app/lib/useConceptById";
 import { useConcepts } from "@/app/lib/useConcept";
 import { useCharacteristicsForConcept } from "@/app/lib/useCharacteristicsForConcept";
+import { usePages } from "@/app/lib/usePage";
 import PageTitleBar from "@/app/components/see_page/PageTitleBar";
 import TitleSection from "@/app/components/see_page/TitleSection";
 import HeaderSection from "@/app/components/see_page/HeaderSection";
@@ -98,6 +99,7 @@ export default function PageView() {
   const { worlds, isLoading: worldsLoading } = useWorlds();
   const { concepts, isLoading: conceptsLoading } = useConcepts(world?.id);
   const { characteristics, isLoading: charsLoading } = useCharacteristicsForConcept(page?.concept_id);
+  const { pages: worldPages } = usePages(world?.id ? { gameworld_id: world.id } : {});
 
   const { agents } = useAgents(page?.gameworld_id);
   const chatAgent = agents?.find(a => a.task === "conversational");
@@ -339,7 +341,12 @@ const bodySectionValues = filterNonEmptySectionValues(getSectionValues("body"));
                       />
                     </div>
                   ) : activeTab === "events" ? (
-                    <EventTimeline />
+                    <EventTimeline
+                      pageId={page.id}
+                      events={page.key_events || []}
+                      pages={worldPages}
+                      onUpdated={mutatePage}
+                    />
                   ) : activeTab === "relationships" ? (
                     <RelationshipMap />
                   ) : (


### PR DESCRIPTION
## Summary
- implement `EventTimeline` UI with add/edit/delete
- CRUD endpoints for page key events and logging
- expose key event API functions in frontend
- show Key Events tab with world pages

## Testing
- `npm run lint` *(fails: many lint errors)*
- `python -m py_compile backend/app/api/api_page.py backend/app/crud/crud_page.py backend/app/schemas/schema_page_key_event.py`

------
https://chatgpt.com/codex/tasks/task_e_687ff0e497d08322a9fa75b33750c2e9