### PR TITLE
Implement relationship map UI with direction

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -46,8 +46,12 @@ def _migrate(conn):
     # -- PageRelationship table --
     if "pagerelationship" not in inspector.get_table_names():
         conn.execute(text(
-            "CREATE TABLE pagerelationship (id INTEGER PRIMARY KEY AUTOINCREMENT, page_id INTEGER NOT NULL REFERENCES page(id), target_page_id INTEGER NOT NULL REFERENCES page(id), relationship_type TEXT NOT NULL, source_page_id INTEGER REFERENCES page(id), description TEXT, author_type TEXT NOT NULL, author_id INTEGER NOT NULL, added_at DATETIME NOT NULL)"
+            "CREATE TABLE pagerelationship (id INTEGER PRIMARY KEY AUTOINCREMENT, page_id INTEGER NOT NULL REFERENCES page(id), target_page_id INTEGER NOT NULL REFERENCES page(id), relationship_type TEXT NOT NULL, direction TEXT NOT NULL, source_page_id INTEGER REFERENCES page(id), description TEXT, author_type TEXT NOT NULL, author_id INTEGER NOT NULL, added_at DATETIME NOT NULL)"
         ))
+    else:
+        columns = [c["name"] for c in inspector.get_columns("pagerelationship")]
+        if "direction" not in columns:
+            conn.execute(text("ALTER TABLE pagerelationship ADD COLUMN direction TEXT DEFAULT 'outgoing'"))
 
     # -- PageChange table --
     if "pagechange" not in inspector.get_table_names():

--- a/backend/app/models/model_page.py
+++ b/backend/app/models/model_page.py
@@ -32,6 +32,7 @@ class PageRelationship(SQLModel, table=True):
     page_id: int = Field(foreign_key="page.id")
     target_page_id: int = Field(foreign_key="page.id")
     relationship_type: str
+    direction: str = "outgoing"
     source_page_id: Optional[int] = Field(default=None, foreign_key="page.id")
     description: Optional[str] = None
     author_type: str

--- a/backend/app/schemas/schema_page_relationship.py
+++ b/backend/app/schemas/schema_page_relationship.py
@@ -5,6 +5,7 @@ from datetime import datetime
 class PageRelationshipBase(SQLModel):
     target_page_id: int
     relationship_type: str
+    direction: str = "outgoing"
     source_page_id: Optional[int] = None
     description: Optional[str] = None
     author_type: str

--- a/frontend/src/app/components/see_page/AddRelationshipModal.tsx
+++ b/frontend/src/app/components/see_page/AddRelationshipModal.tsx
@@ -1,0 +1,94 @@
+"use client";
+import { useState } from "react";
+import { Combobox } from "@headlessui/react";
+import ModalContainer from "../template/modalContainer";
+
+interface PageInfo {
+  id: number;
+  name: string;
+  logo?: string;
+}
+
+interface RelationshipInput {
+  target_page_id: number;
+  relationship_type: string;
+  description?: string;
+  source_page_id?: number | null;
+  direction: string;
+}
+
+export default function AddRelationshipModal({ pages, onAdd, onClose }: { pages: PageInfo[]; onAdd: (r: RelationshipInput) => void; onClose: () => void }) {
+  const [target, setTarget] = useState<string>(""
+  );
+  const [filter, setFilter] = useState("");
+  const [type, setType] = useState("friend");
+  const [description, setDescription] = useState("");
+  const [source, setSource] = useState<string>("");
+  const [direction, setDirection] = useState("outgoing");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!target) return;
+    onAdd({
+      target_page_id: Number(target),
+      relationship_type: type,
+      description,
+      source_page_id: source ? Number(source) : undefined,
+      direction,
+    });
+    onClose();
+  };
+
+  return (
+    <ModalContainer title="Add Relationship" onClose={onClose}>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="font-semibold text-sm">Target Page</label>
+          <Combobox value={target} onChange={setTarget}>
+            <Combobox.Input
+              className="border w-full rounded px-2 py-1 bg-[var(--surface)]"
+              displayValue={() => pages.find((p) => p.id.toString() === target)?.name || ""}
+              onChange={(e) => setFilter(e.target.value)}
+            />
+            <Combobox.Options className="absolute bg-[var(--surface)] border w-full max-h-60 overflow-auto z-20">
+              {pages
+                .filter((p) => p.name.toLowerCase().includes(filter.toLowerCase()))
+                .map((p) => (
+                  <Combobox.Option key={p.id} value={p.id.toString()} className="px-2 py-1 cursor-pointer hover:bg-[var(--accent)]/20">
+                    {p.name}
+                  </Combobox.Option>
+                ))}
+            </Combobox.Options>
+          </Combobox>
+        </div>
+        <div className="flex flex-col gap-1">
+          <label className="font-semibold text-sm">Relationship Type</label>
+          <input value={type} onChange={(e) => setType(e.target.value)} className="border rounded px-2 py-1 bg-[var(--surface)]" />
+        </div>
+        <div className="flex flex-col gap-1">
+          <label className="font-semibold text-sm">Description</label>
+          <textarea value={description} onChange={(e) => setDescription(e.target.value)} className="border rounded px-2 py-1 bg-[var(--surface)]" />
+        </div>
+        <div className="flex flex-col gap-1">
+          <label className="font-semibold text-sm">Source Page</label>
+          <select value={source} onChange={(e) => setSource(e.target.value)} className="border rounded px-2 py-1 bg-[var(--surface)]">
+            <option value="">None</option>
+            {pages.map((p) => (
+              <option key={p.id} value={p.id.toString()}>{p.name}</option>
+            ))}
+          </select>
+        </div>
+        <div className="flex flex-col gap-1">
+          <label className="font-semibold text-sm">Direction</label>
+          <select value={direction} onChange={(e) => setDirection(e.target.value)} className="border rounded px-2 py-1 bg-[var(--surface)]">
+            <option value="outgoing">From this page</option>
+            <option value="incoming">To this page</option>
+          </select>
+        </div>
+        <button type="submit" className="px-3 py-1 bg-[var(--primary)] text-white rounded">
+          Add
+        </button>
+      </form>
+    </ModalContainer>
+  );
+}

--- a/frontend/src/app/components/see_page/RelationshipGraph.tsx
+++ b/frontend/src/app/components/see_page/RelationshipGraph.tsx
@@ -1,0 +1,46 @@
+"use client";
+import { ForceGraph2D } from "react-force-graph";
+import Link from "next/link";
+
+interface Node {
+  id: number;
+  name: string;
+  logo?: string;
+}
+
+interface LinkInfo {
+  id: number;
+  source: number;
+  target: number;
+  type: string;
+  direction: string;
+  description?: string;
+}
+
+export default function RelationshipGraph({ nodes, links }: { nodes: Node[]; links: LinkInfo[] }) {
+  const graphData = {
+    nodes: nodes.map((n) => ({ id: n.id, name: n.name, logo: n.logo })),
+    links: links.map((l) => ({
+      id: l.id,
+      source: l.direction === "incoming" ? l.target : l.source,
+      target: l.direction === "incoming" ? l.source : l.target,
+      type: l.type,
+      description: l.description,
+    })),
+  };
+  return (
+    <div className="h-96 w-full">
+      {/* ForceGraph2D may be missing if dependencies are not installed */}
+      {/* @ts-ignore */}
+      <ForceGraph2D
+        graphData={graphData}
+        nodeLabel={(node: any) => node.name}
+        linkDirectionalArrowLength={6}
+        linkLabel={(link: any) => link.type}
+        onNodeClick={(node: any) => {
+          window.location.href = `/pages/${node.id}`;
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/app/components/see_page/RelationshipMap.tsx
+++ b/frontend/src/app/components/see_page/RelationshipMap.tsx
@@ -1,8 +1,0 @@
-"use client";
-export default function RelationshipMap() {
-  return (
-    <div className="p-4 rounded-xl border border-dashed border-[var(--primary)]/40 bg-[var(--surface)] text-center text-sm text-[var(--foreground)]/80">
-      Relationship map will appear here.
-    </div>
-  );
-}

--- a/frontend/src/app/components/see_page/RelationshipMapTab.tsx
+++ b/frontend/src/app/components/see_page/RelationshipMapTab.tsx
@@ -1,0 +1,66 @@
+"use client";
+import { useState, useEffect } from "react";
+import RelationshipGraph from "./RelationshipGraph";
+import RelationshipTable from "./RelationshipTable";
+import AddRelationshipModal from "./AddRelationshipModal";
+
+interface Relationship {
+  id: number;
+  page_id: number;
+  target_page_id: number;
+  relationship_type: string;
+  description?: string;
+  source_page_id?: number | null;
+  author_type: string;
+  author_id: number;
+  added_at?: string;
+  direction: string;
+}
+
+interface PageInfo {
+  id: number;
+  name: string;
+  logo?: string;
+}
+
+export default function RelationshipMapTab({ page, pages }: { page: { relationship_map: Relationship[]; id: number }; pages: PageInfo[] }) {
+  const [relationships, setRelationships] = useState<Relationship[]>([]);
+  const [showModal, setShowModal] = useState(false);
+
+  useEffect(() => {
+    setRelationships(page.relationship_map || []);
+  }, [page]);
+
+  const handleAdd = (rel: Omit<Relationship, "id" | "page_id" | "author_type" | "author_id" | "added_at">) => {
+    const newRel: Relationship = {
+      id: Date.now(),
+      page_id: page.id,
+      author_type: "user",
+      author_id: 0,
+      added_at: new Date().toISOString(),
+      ...rel,
+    };
+    setRelationships((r) => [...r, newRel]);
+  };
+
+  return (
+    <div className="space-y-4">
+      <RelationshipGraph
+        nodes={pages.map((p) => ({ id: p.id, name: p.name, logo: p.logo }))}
+        links={relationships.map((r) => ({
+          id: r.id,
+          source: page.id,
+          target: r.target_page_id,
+          type: r.relationship_type,
+          direction: r.direction,
+          description: r.description,
+        }))}
+      />
+      <RelationshipTable relationships={relationships} pages={pages} />
+      <button className="px-3 py-1 bg-[var(--primary)] text-white rounded" onClick={() => setShowModal(true)}>
+        Add Relationship
+      </button>
+      {showModal && <AddRelationshipModal pages={pages} onAdd={handleAdd} onClose={() => setShowModal(false)} />}
+    </div>
+  );
+}

--- a/frontend/src/app/components/see_page/RelationshipTable.tsx
+++ b/frontend/src/app/components/see_page/RelationshipTable.tsx
@@ -1,0 +1,54 @@
+"use client";
+import Link from "next/link";
+
+interface Relationship {
+  id: number;
+  target_page_id: number;
+  relationship_type: string;
+  description?: string;
+  source_page_id?: number | null;
+  author_type: string;
+  author_id: number;
+  added_at?: string;
+  direction: string;
+}
+
+interface PageInfo {
+  id: number;
+  name: string;
+  logo?: string;
+}
+
+export default function RelationshipTable({ relationships, pages }: { relationships: Relationship[]; pages: PageInfo[] }) {
+  const getPage = (id: number) => pages.find((p) => p.id === id);
+  return (
+    <table className="w-full text-sm mt-4 border">
+      <thead className="bg-[var(--surface)]">
+        <tr>
+          <th className="px-2 py-1 text-left">Target</th>
+          <th className="px-2 py-1 text-left">Type</th>
+          <th className="px-2 py-1 text-left">Description</th>
+          <th className="px-2 py-1 text-left">Source</th>
+        </tr>
+      </thead>
+      <tbody>
+        {relationships.map((rel) => {
+          const target = getPage(rel.target_page_id);
+          const source = rel.source_page_id ? getPage(rel.source_page_id) : null;
+          return (
+            <tr key={rel.id} className="even:bg-[var(--surface)]/50">
+              <td className="px-2 py-1">
+                {target ? <Link href={`/pages/${target.id}`}>{target.name}</Link> : rel.target_page_id}
+              </td>
+              <td className="px-2 py-1">{rel.relationship_type}</td>
+              <td className="px-2 py-1">{rel.description}</td>
+              <td className="px-2 py-1">
+                {source ? <Link href={`/pages/${source.id}`}>{source.name}</Link> : "-"}
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}

--- a/frontend/src/app/worlds/[worldID]/concept/[conceptID]/page/[pageID]/page.tsx
+++ b/frontend/src/app/worlds/[worldID]/concept/[conceptID]/page/[pageID]/page.tsx
@@ -36,7 +36,7 @@ import {
 import CreatePageForm from "../../../../../../components/create_page/CreatePageForm";
 import PageTabMenu from "@/app/components/see_page/PageTabMenu";
 import EventTimeline from "@/app/components/see_page/EventTimeline";
-import RelationshipMap from "@/app/components/see_page/RelationshipMap";
+import RelationshipMapTab from "@/app/components/see_page/RelationshipMapTab";
 import Changelog from "@/app/components/see_page/Changelog";
 import Image from "next/image";
 import { useAgents } from "@/app/lib/useAgents";
@@ -348,7 +348,7 @@ const bodySectionValues = filterNonEmptySectionValues(getSectionValues("body"));
                       onUpdated={mutatePage}
                     />
                   ) : activeTab === "relationships" ? (
-                    <RelationshipMap />
+                    <RelationshipMapTab page={page} pages={worldPages} />
                   ) : (
                     <Changelog />
                   )}


### PR DESCRIPTION
## Summary
- add `direction` field to page relationships models and schema
- migrate database to add the new column
- replace old `RelationshipMap` with new `RelationshipMapTab`
- implement `RelationshipGraph`, `RelationshipTable`, and `AddRelationshipModal`
- update page view to render the new relationship map tab

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ffa2ee1b88322831c9241deaca0e5