### PR TITLE
Implement basic changelog tab

### DIFF
--- a/frontend/src/app/components/see_page/ChangeFilterBar.tsx
+++ b/frontend/src/app/components/see_page/ChangeFilterBar.tsx
@@ -1,0 +1,79 @@
+"use client";
+import { format } from "date-fns";
+import { useState } from "react";
+
+export interface ChangeFilter {
+  type: string;
+  author: string;
+  from?: string;
+  to?: string;
+}
+
+export default function ChangeFilterBar({
+  availableTypes,
+  filters,
+  onChange,
+}: {
+  availableTypes: string[];
+  filters: ChangeFilter;
+  onChange: (f: ChangeFilter) => void;
+}) {
+  const [from, setFrom] = useState(filters.from || "");
+  const [to, setTo] = useState(filters.to || "");
+
+  return (
+    <div className="flex flex-wrap items-end gap-2 text-sm">
+      <div>
+        <label className="block font-semibold text-xs">Type</label>
+        <select
+          className="border rounded-md px-2 py-1 bg-[var(--surface)]"
+          value={filters.type}
+          onChange={(e) => onChange({ ...filters, type: e.target.value })}
+        >
+          <option value="all">All</option>
+          {availableTypes.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label className="block font-semibold text-xs">Author</label>
+        <select
+          className="border rounded-md px-2 py-1 bg-[var(--surface)]"
+          value={filters.author}
+          onChange={(e) => onChange({ ...filters, author: e.target.value })}
+        >
+          <option value="all">All</option>
+          <option value="user">User</option>
+          <option value="agent">Agent</option>
+        </select>
+      </div>
+      <div>
+        <label className="block font-semibold text-xs">From</label>
+        <input
+          type="date"
+          className="border rounded-md px-2 py-1 bg-[var(--surface)]"
+          value={from}
+          onChange={(e) => {
+            setFrom(e.target.value);
+            onChange({ ...filters, from: e.target.value });
+          }}
+        />
+      </div>
+      <div>
+        <label className="block font-semibold text-xs">To</label>
+        <input
+          type="date"
+          className="border rounded-md px-2 py-1 bg-[var(--surface)]"
+          value={to}
+          onChange={(e) => {
+            setTo(e.target.value);
+            onChange({ ...filters, to: e.target.value });
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/components/see_page/Changelog.tsx
+++ b/frontend/src/app/components/see_page/Changelog.tsx
@@ -1,8 +1,53 @@
 "use client";
-export default function Changelog() {
+import { useMemo, useState } from "react";
+import ChangelogEntry, { ChangeEntry } from "./ChangelogEntry";
+import ChangeFilterBar, { ChangeFilter } from "./ChangeFilterBar";
+
+export default function Changelog({ changes }: { changes: ChangeEntry[] }) {
+  const [filters, setFilters] = useState<ChangeFilter>({
+    type: "all",
+    author: "all",
+  });
+
+  const availableTypes = useMemo(
+    () => Array.from(new Set(changes.map((c) => c.change_type))),
+    [changes]
+  );
+
+  const filtered = useMemo(() => {
+    return changes
+      .slice()
+      .sort((a, b) => b.date.localeCompare(a.date))
+      .filter((c) =>
+        filters.type === "all" ? true : c.change_type === filters.type
+      )
+      .filter((c) =>
+        filters.author === "all" ? true : c.author_type === filters.author
+      )
+      .filter((c) => {
+        if (filters.from && new Date(c.date) < new Date(filters.from)) return false;
+        if (filters.to && new Date(c.date) > new Date(filters.to)) return false;
+        return true;
+      });
+  }, [changes, filters]);
+
   return (
-    <div className="p-4 rounded-xl border border-dashed border-[var(--primary)]/40 bg-[var(--surface)] text-center text-sm text-[var(--foreground)]/80">
-      Changelog will be displayed here.
+    <div className="space-y-4">
+      <ChangeFilterBar
+        availableTypes={availableTypes}
+        filters={filters}
+        onChange={setFilters}
+      />
+      <div className="max-h-[60vh] overflow-y-auto space-y-4">
+        {filtered.map((c) => (
+          <ChangelogEntry key={c.id} change={c} />
+        ))}
+        {filtered.length === 0 && (
+          <div className="text-sm text-center text-[var(--foreground)]/70">
+            No changes found.
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/app/components/see_page/ChangelogEntry.tsx
+++ b/frontend/src/app/components/see_page/ChangelogEntry.tsx
@@ -1,0 +1,50 @@
+"use client";
+import { format } from "date-fns";
+import { useState } from "react";
+import MarkdownIt from "markdown-it";
+
+const md = new MarkdownIt();
+
+export interface ChangeEntry {
+  id: number;
+  date: string;
+  change_type: string;
+  author_type: string;
+  author_id: number;
+  values?: any;
+}
+
+export default function ChangelogEntry({ change }: { change: ChangeEntry }) {
+  const [open, setOpen] = useState(false);
+  const content = change.values?.content || change.values?.summary || "";
+
+  return (
+    <div className="bg-[var(--surface)] border border-[var(--border)] rounded-xl shadow p-4 space-y-2">
+      <div className="flex justify-between items-center text-sm">
+        <div className="font-semibold flex items-center gap-2">
+          <span>{format(new Date(change.date), "PPpp")}</span>
+          <span className="px-2 py-0.5 rounded-full text-xs bg-[var(--primary)]/20 border border-[var(--primary)]/40">
+            {change.author_type}
+          </span>
+        </div>
+        <div className="text-xs text-[var(--foreground)]/70">{change.change_type}</div>
+      </div>
+      {content && (
+        <div>
+          <button
+            className="text-[var(--primary)] text-xs underline"
+            onClick={() => setOpen((o) => !o)}
+          >
+            {open ? "Hide" : "Show"} Details
+          </button>
+          {open && (
+            <div
+              className="mt-2 prose prose-sm max-w-none text-[var(--foreground)]"
+              dangerouslySetInnerHTML={{ __html: md.render(content) }}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/worlds/[worldID]/concept/[conceptID]/page/[pageID]/page.tsx
+++ b/frontend/src/app/worlds/[worldID]/concept/[conceptID]/page/[pageID]/page.tsx
@@ -350,7 +350,7 @@ const bodySectionValues = filterNonEmptySectionValues(getSectionValues("body"));
                   ) : activeTab === "relationships" ? (
                     <RelationshipMapTab page={page} pages={worldPages} />
                   ) : (
-                    <Changelog />
+                    <Changelog changes={page.changelog || []} />
                   )}
                 </div>
 


### PR DESCRIPTION
## Summary
- add `ChangeFilterBar`, `ChangelogEntry` and expand `Changelog` component
- wire changelog tab on page view to new component

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `pytest -q` *(fails: ModuleNotFoundError: httpx)*

------
https://chatgpt.com/codex/tasks/task_e_687ffc4b24d88322929779bcb33d33aa