### PR TITLE
Fix ForceGraph load

### DIFF
--- a/frontend/src/app/components/see_page/RelationshipGraph.tsx
+++ b/frontend/src/app/components/see_page/RelationshipGraph.tsx
@@ -1,6 +1,15 @@
 "use client";
-import { ForceGraph2D } from "react-force-graph";
+import dynamic from "next/dynamic";
 import Link from "next/link";
+
+// ForceGraph2D requires browser globals like AFRAME which are
+// not available during server side rendering. Dynamically load
+// the component with SSR disabled to avoid "AFRAME is not defined"
+// errors when Next.js builds the server bundle.
+const ForceGraph2D = dynamic(
+  () => import("react-force-graph").then((mod) => mod.ForceGraph2D),
+  { ssr: false },
+);
 
 interface Node {
   id: number;


### PR DESCRIPTION
## Summary
- dynamically load `react-force-graph` to avoid `AFRAME` reference error in SSR

## Testing
- `npm run lint` *(fails: token unused and other errors)*
- `npm run build` *(fails to compile due to missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6880002c3cd883228521b6a2b6786c5f