### PR TITLE
Fix global THREE initialization for ForceGraph

### DIFF
--- a/frontend/src/app/components/see_page/RelationshipGraph.tsx
+++ b/frontend/src/app/components/see_page/RelationshipGraph.tsx
@@ -6,19 +6,28 @@ import dynamic from "next/dynamic";
 // the component with SSR disabled to avoid "AFRAME is not defined"
 // errors when Next.js builds the server bundle.
 const ForceGraph2D = dynamic(
-  () => {
-    if (typeof window !== "undefined" && !(window as any).AFRAME) {
-      (window as any).AFRAME = {
-        registerComponent: () => {},
-        registerPrimitive: () => {},
-        registerSystem: () => {},
-        components: {},
-        systems: {},
-        primitives: {},
-        utils: { diff: () => ({}) },
-      } as any;
+  async () => {
+    if (typeof window !== "undefined") {
+      if (!(window as any).AFRAME) {
+        (window as any).AFRAME = {
+          registerComponent: () => {},
+          registerPrimitive: () => {},
+          registerSystem: () => {},
+          components: {},
+          systems: {},
+          primitives: {},
+          utils: { diff: () => ({}) },
+        } as any;
+      }
+
+      if (!(window as any).THREE) {
+        const THREE = await import("three");
+        (window as any).THREE = THREE;
+      }
     }
-    return import("react-force-graph").then((mod) => mod.ForceGraph2D);
+
+    const mod = await import("react-force-graph");
+    return mod.ForceGraph2D;
   },
   { ssr: false },
 );


### PR DESCRIPTION
## Summary
- ensure `three` is loaded in RelationshipGraph before importing `react-force-graph`

## Testing
- `npm run lint` *(fails: multiple lint errors)*
- `npm run build` *(fails to compile due to missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_688004958f54832292509ed0b81496cd