### PR TITLE
Add concept badge and delete button to title bar

### DIFF
--- a/frontend/src/app/components/see_page/PageTitleBar.tsx
+++ b/frontend/src/app/components/see_page/PageTitleBar.tsx
@@ -9,20 +9,37 @@ export default function PageTitleBar({
   pageName,
   logo,
   settings, // { allowCrosslinks, ignoreCrosslink, allowCrossworld, onEdit, canEdit }
+  conceptName,
+  conceptLogo,
+  onDelete,
+  canDelete,
+  deleteLabel,
 }) {
   const [zoomOpen, setZoomOpen] = useState(false);
 
   return (
     <div
-  className="    
-    rounded-2xl md:rounded-3xl  -mt-5 mb-10 px-4 py-6 md:px-8
-    shadow-2xl border border-white/20
-    backdrop-blur-[14px]
-     bg-gradient-to-br from-[#29196620] via-[#7b2ff25] to-[#36205a15] bg-white/15
-    flex flex-col md:flex-row items-center gap-8
-  "
-  style={{ boxShadow: "0 6px 40px 0 #7b2ff225, 0 1.5px 8px #2e205933" }}
->
+      className="relative rounded-2xl md:rounded-3xl -mt-5 mb-10 px-4 py-6 md:px-8 shadow-2xl border border-white/20 backdrop-blur-[14px] bg-gradient-to-br from-[#29196620] via-[#7b2ff25] to-[#36205a15] bg-white/15 flex flex-col md:flex-row items-center gap-8"
+      style={{ boxShadow: "0 6px 40px 0 #7b2ff225, 0 1.5px 8px #2e205933" }}
+    >
+  {/* --- Concept badge top right --- */}
+  {conceptName && (
+    <span className="absolute top-3 right-4 flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--primary)]/20 border border-[var(--primary)]/40 shadow-sm">
+      {conceptLogo && (
+        <Image
+          src={conceptLogo}
+          alt={conceptName}
+          width={24}
+          height={24}
+          className="w-6 h-6 rounded-full object-cover border border-[var(--primary)]/50"
+        />
+      )}
+      <span className="text-sm font-semibold text-[var(--primary)] whitespace-nowrap">
+        {conceptName}
+      </span>
+    </span>
+  )}
+
   {/* --- Logo with modal zoom --- */}
   {logo && (
     <div className="flex-shrink-0 flex flex-col items-center justify-center">
@@ -97,6 +114,9 @@ export default function PageTitleBar({
         allowCrossworld={settings.allowCrossworld}
         canEdit={settings.canEdit}
         onEdit={settings.onEdit}
+        canDelete={canDelete}
+        onDelete={onDelete}
+        deleteLabel={deleteLabel}
       />
     </div>
   </div>

--- a/frontend/src/app/components/see_page/SettingsDisplay.tsx
+++ b/frontend/src/app/components/see_page/SettingsDisplay.tsx
@@ -1,7 +1,14 @@
-import { Info } from "lucide-react";
+import { Info, Trash2 } from "lucide-react";
 
-export default function SettingsDisplay({ 
-  allowCrosslinks, ignoreCrosslink, allowCrossworld, onEdit, canEdit 
+export default function SettingsDisplay({
+  allowCrosslinks,
+  ignoreCrosslink,
+  allowCrossworld,
+  onEdit,
+  canEdit,
+  onDelete,
+  canDelete,
+  deleteLabel,
 }) {
   const settings = [
     {
@@ -45,6 +52,15 @@ export default function SettingsDisplay({
           className="ml-2 px-3 py-1 rounded-full bg-[var(--primary)] text-white text-xs font-semibold hover:bg-[var(--accent)] transition"
         >
           Edit Page
+        </button>
+      )}
+      {canDelete && (
+        <button
+          onClick={onDelete}
+          className="ml-2 flex items-center gap-1 px-3 py-1 rounded-full bg-red-600 text-white text-xs font-semibold shadow hover:bg-red-700 transition"
+        >
+          <Trash2 className="w-4 h-4" />
+          {deleteLabel || 'Delete'}
         </button>
       )}
     </div>

--- a/frontend/src/app/worlds/[worldID]/concept/[conceptID]/page/[pageID]/page.tsx
+++ b/frontend/src/app/worlds/[worldID]/concept/[conceptID]/page/[pageID]/page.tsx
@@ -24,7 +24,6 @@ import { useTranslation } from "@/app/hooks/useTranslation";
 import { hasRole } from "@/app/lib/roles";
 import ModalContainer from "@/app/components/template/modalContainer";
 import {
-  Trash2,
   ChevronLeft,
   ChevronRight,
   ScrollText,
@@ -38,7 +37,6 @@ import PageTabMenu from "@/app/components/see_page/PageTabMenu";
 import EventTimeline from "@/app/components/see_page/EventTimeline";
 import RelationshipMapTab from "@/app/components/see_page/RelationshipMapTab";
 import Changelog from "@/app/components/see_page/Changelog";
-import Image from "next/image";
 import { useAgents } from "@/app/lib/useAgents";
 
 // --- Collapsible Sidebar, grid-based, NOT fixed ---
@@ -240,37 +238,12 @@ const bodySectionValues = filterNonEmptySectionValues(getSectionValues("body"));
                     canEdit: hasRole(user?.role, "writer"),
                     onEdit: () => setShowEditModal(true),
                   }}
+                  conceptName={concept?.name}
+                  conceptLogo={concept?.logo}
+                  canDelete={hasRole(user?.role, "world builder")}
+                  onDelete={() => setShowDeleteModal(true)}
+                  deleteLabel={t("delete_page")}
                 />
-
-                <div className="flex items-center gap-3 flex-wrap">
-                  {concept && (
-                    <span className="flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--primary)]/20 border border-[var(--primary)]/40 shadow-sm">
-                      {concept.logo && (
-                        <Image
-                          src={concept.logo}
-                          alt={concept.name}
-                          width={24}
-                          height={24}
-                          className="w-6 h-6 rounded-full object-cover border border-[var(--primary)]/50"
-                        />
-                      )}
-                      <span className="text-sm font-semibold text-[var(--primary)]">
-                        {concept.name}
-                      </span>
-                    </span>
-                  )}
-
-                  {hasRole(user?.role, "world builder") && (
-                    <button
-                      onClick={() => setShowDeleteModal(true)}
-                      className="flex items-center gap-1 px-3 py-1 rounded-full bg-red-600 text-white text-sm shadow hover:bg-red-700 transition"
-                      title={t("delete_page")}
-                    >
-                      <Trash2 className="w-4 h-4" />
-                      {t("delete_page")}
-                    </button>
-                  )}
-                </div>
               </div>
 
               {/* --- Main content & details area, responsive grid --- */}


### PR DESCRIPTION
## Summary
- extend SettingsDisplay with optional delete button
- add concept badge and delete button props to PageTitleBar
- show concept name and logo in the top-right corner of the page title bar
- use the enhanced title bar on the concept page

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6880a96853008322ae3ff883a6ba9f32