### PR TITLE
Fix parse error in EventTimeline

### DIFF
--- a/frontend/src/app/components/see_page/EventTimeline.tsx
+++ b/frontend/src/app/components/see_page/EventTimeline.tsx
@@ -118,7 +118,6 @@ function EventForm({
           })()
         )}
       </div>
-      </div>
       <div className="flex flex-col gap-1">
         <label className="font-semibold text-sm">Date</label>
         <input


### PR DESCRIPTION
## Summary
- remove stray `</div>` that broke JSX parsing

## Testing
- `npm run lint` *(fails: unused variables and lint errors)*
- `npm run build` *(fails: module not found errors)*

------
https://chatgpt.com/codex/tasks/task_e_6880af230f4c83228de2d8dfc9af435b