### PR TITLE
Move page changelog to modal

### DIFF
--- a/frontend/src/app/components/see_page/PageTabMenu.tsx
+++ b/frontend/src/app/components/see_page/PageTabMenu.tsx
@@ -1,11 +1,14 @@
 "use client";
 import { motion } from "framer-motion";
 import type { LucideIcon } from "lucide-react";
+import { Sparkles } from "lucide-react";
+import { useTranslation } from "@/app/hooks/useTranslation";
 
 export interface PageTab {
   value: string;
   label: string;
   icon?: LucideIcon;
+  ai?: boolean;
 }
 
 export default function PageTabMenu({
@@ -17,8 +20,9 @@ export default function PageTabMenu({
   onTabChange: (tab: string) => void;
   tabs: PageTab[];
 }) {
+  const { t } = useTranslation();
   return (
-    <nav className="relative flex w-full bg-[var(--surface-variant)] p-1 rounded-xl border border-[var(--primary)]/10">
+    <nav className="relative flex w-full bg-[var(--surface-variant)] p-1 rounded-xl border border-[var(--primary)]/10 text-xs">
       {tabs.map((tab) => {
         const isActive = activeTab === tab.value;
         const Icon = tab.icon;
@@ -32,7 +36,7 @@ export default function PageTabMenu({
               />
             )}
             <button
-              className={`relative w-full z-10 flex items-center justify-center gap-2 text-sm font-semibold px-3 py-2 rounded-md transition-colors ${
+              className={`relative w-full z-10 flex items-center justify-center gap-1 font-semibold px-2 py-1 rounded-md transition-colors ${
                 isActive
                   ? "text-[var(--primary-foreground)]"
                   : "text-[var(--primary)] hover:bg-[var(--primary)]/10"
@@ -40,8 +44,21 @@ export default function PageTabMenu({
               style={{ letterSpacing: ".02em" }}
               onClick={() => onTabChange(tab.value)}
             >
-              {Icon && <Icon className="w-4 h-4" />}
-              {tab.label}
+              {Icon && (
+                <span
+                  className={`w-5 h-5 flex items-center justify-center rounded-md ${
+                    isActive
+                      ? "bg-[var(--primary)] text-[var(--primary-foreground)]"
+                      : "bg-[var(--primary)]/20 text-[var(--primary)]"
+                  }`}
+                >
+                  <Icon className="w-4 h-4" />
+                </span>
+              )}
+              {tab.ai && (
+                <Sparkles className="w-3 h-3 text-[var(--primary)]" />
+              )}
+              {t(tab.label as any)}
             </button>
           </div>
         );

--- a/frontend/src/app/components/see_page/PageTitleBar.tsx
+++ b/frontend/src/app/components/see_page/PageTitleBar.tsx
@@ -4,6 +4,8 @@ import Image from "next/image";
 import { useState } from "react";
 import ModalContainer from "../template/modalContainer";
 import SettingsDisplay from "./SettingsDisplay"; // Update the path if needed
+import { History } from "lucide-react";
+import { useTranslation } from "@/app/hooks/useTranslation";
 
 export default function PageTitleBar({
   pageName,
@@ -14,30 +16,45 @@ export default function PageTitleBar({
   onDelete,
   canDelete,
   deleteLabel,
+  onShowChangelog,
 }) {
   const [zoomOpen, setZoomOpen] = useState(false);
+  const { t } = useTranslation();
 
   return (
     <div
       className="relative rounded-2xl md:rounded-3xl -mt-5 mb-10 px-4 py-6 md:px-8 shadow-2xl border border-white/20 backdrop-blur-[14px] bg-gradient-to-br from-[#29196620] via-[#7b2ff25] to-[#36205a15] bg-white/15 flex flex-col md:flex-row items-center gap-8"
       style={{ boxShadow: "0 6px 40px 0 #7b2ff225, 0 1.5px 8px #2e205933" }}
     >
-  {/* --- Concept badge top right --- */}
-  {conceptName && (
-    <span className="absolute top-3 right-4 flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--primary)]/20 border border-[var(--primary)]/40 shadow-sm">
-      {conceptLogo && (
-        <Image
-          src={conceptLogo}
-          alt={conceptName}
-          width={24}
-          height={24}
-          className="w-6 h-6 rounded-full object-cover border border-[var(--primary)]/50"
-        />
+  {/* --- Concept badge and changelog --- */}
+  {(conceptName || onShowChangelog) && (
+    <div className="absolute top-3 right-4 flex items-center gap-2">
+      {conceptName && (
+        <span className="flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--primary)]/20 border border-[var(--primary)]/40 shadow-sm">
+          {conceptLogo && (
+            <Image
+              src={conceptLogo}
+              alt={conceptName}
+              width={24}
+              height={24}
+              className="w-6 h-6 rounded-full object-cover border border-[var(--primary)]/50"
+            />
+          )}
+          <span className="text-sm font-semibold text-[var(--primary)] whitespace-nowrap">
+            {conceptName}
+          </span>
+        </span>
       )}
-      <span className="text-sm font-semibold text-[var(--primary)] whitespace-nowrap">
-        {conceptName}
-      </span>
-    </span>
+      {onShowChangelog && (
+        <button
+          onClick={onShowChangelog}
+          className="flex items-center gap-1 px-3 py-1 rounded-full bg-[var(--primary)] text-[var(--primary-foreground)] text-xs font-semibold shadow hover:bg-[var(--accent)] transition"
+        >
+          <History className="w-4 h-4" />
+          {t("tab_changelog")}
+        </button>
+      )}
+    </div>
   )}
 
   {/* --- Logo with modal zoom --- */}

--- a/frontend/src/app/locales/en.json
+++ b/frontend/src/app/locales/en.json
@@ -261,5 +261,10 @@
   "import_backup": "Import Backup",
   "backup_importing": "Importing backup...",
   "backup_imported": "Backup imported!",
-  "backup_failed": "Backup failed. Please try again!"
+  "backup_failed": "Backup failed. Please try again!",
+  "tab_description": "Description",
+  "tab_writer_notes": "Writer's Notes",
+  "tab_key_events": "Key Events",
+  "tab_relationships": "Relationship Map",
+  "tab_changelog": "Changelog"
 }

--- a/frontend/src/app/locales/it.json
+++ b/frontend/src/app/locales/it.json
@@ -265,5 +265,10 @@
   "import_backup": "Importa Backup",
   "backup_importing": "Importazione backup...",
   "backup_imported": "Backup importato!",
-  "backup_failed": "Backup fallito. Riprova!"
+  "backup_failed": "Backup fallito. Riprova!",
+  "tab_description": "Descrizione",
+  "tab_writer_notes": "Note dell'autore",
+  "tab_key_events": "Eventi Chiave",
+  "tab_relationships": "Mappa Relazioni",
+  "tab_changelog": "Cronologia"
 }

--- a/frontend/src/app/locales/pt.json
+++ b/frontend/src/app/locales/pt.json
@@ -262,5 +262,10 @@
   "import_backup": "Importar Backup",
   "backup_importing": "Importando backup...",
   "backup_imported": "Backup importado!",
-  "backup_failed": "Falha no backup. Tente novamente!"
+  "backup_failed": "Falha no backup. Tente novamente!",
+  "tab_description": "Descrição",
+  "tab_writer_notes": "Notas do Autor",
+  "tab_key_events": "Eventos Chave",
+  "tab_relationships": "Mapa de Relações",
+  "tab_changelog": "Alterações"
 }

--- a/frontend/src/app/worlds/[worldID]/concept/[conceptID]/page/[pageID]/page.tsx
+++ b/frontend/src/app/worlds/[worldID]/concept/[conceptID]/page/[pageID]/page.tsx
@@ -30,7 +30,6 @@ import {
   Brain,
   Calendar,
   Map,
-  History,
 } from "lucide-react";
 import CreatePageForm from "../../../../../../components/create_page/CreatePageForm";
 import PageTabMenu from "@/app/components/see_page/PageTabMenu";
@@ -85,8 +84,9 @@ export default function PageView() {
   // For sidebar open/collapse
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [activeTab, setActiveTab] = useState<
-    "description" | "notes" | "events" | "relationships" | "changelog"
+    "description" | "notes" | "events" | "relationships"
   >("description");
+  const [showChangelog, setShowChangelog] = useState(false);
   const [imgError, setImgError] = useState(false);
 
   
@@ -243,6 +243,7 @@ const bodySectionValues = filterNonEmptySectionValues(getSectionValues("body"));
                   canDelete={hasRole(user?.role, "world builder")}
                   onDelete={() => setShowDeleteModal(true)}
                   deleteLabel={t("delete_page")}
+                  onShowChangelog={() => setShowChangelog(true)}
                 />
               </div>
 
@@ -267,15 +268,14 @@ const bodySectionValues = filterNonEmptySectionValues(getSectionValues("body"));
                     activeTab={activeTab}
                     onTabChange={(tab) =>
                       setActiveTab(
-                        tab as "description" | "notes" | "events" | "relationships" | "changelog"
+                        tab as "description" | "notes" | "events" | "relationships"
                       )
                     }
                     tabs={[
-                      { value: "description", label: "Description", icon: ScrollText },
-                      { value: "notes", label: "Writer's Notes", icon: Brain },
-                      { value: "events", label: "Key Events", icon: Calendar },
-                      { value: "relationships", label: "Relationship Map", icon: Map },
-                      { value: "changelog", label: "Changelog", icon: History },
+                      { value: "description", label: "tab_description", icon: ScrollText },
+                      { value: "notes", label: "tab_writer_notes", icon: Brain, ai: true },
+                      { value: "events", label: "tab_key_events", icon: Calendar },
+                      { value: "relationships", label: "tab_relationships", icon: Map },
                     ]}
                   />
                   {activeTab === "description" ? (
@@ -322,9 +322,7 @@ const bodySectionValues = filterNonEmptySectionValues(getSectionValues("body"));
                     />
                   ) : activeTab === "relationships" ? (
                     <RelationshipMapTab page={page} pages={worldPages} />
-                  ) : (
-                    <Changelog changes={page.changelog || []} />
-                  )}
+                  ) : null}
                 </div>
 
                 {/* --- Details Sidebar --- */}
@@ -392,6 +390,16 @@ const bodySectionValues = filterNonEmptySectionValues(getSectionValues("body"));
                   </button>
                 </div>
               </div>
+            </ModalContainer>
+          )}
+
+          {showChangelog && (
+            <ModalContainer
+              title={t("tab_changelog")}
+              onClose={() => setShowChangelog(false)}
+              className="max-w-2xl"
+            >
+              <Changelog changes={page.changelog || []} />
             </ModalContainer>
           )}
         </div>


### PR DESCRIPTION
## Summary
- add localized tab labels
- update PageTabMenu style and localization
- move changelog display to PageTitleBar modal link
- adjust page view to remove changelog tab and show modal

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: numerous type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6880b90202488322ad2a278bd9ead322