### PR TITLE
Add relationship CRUD

### DIFF
--- a/backend/app/api/api_page.py
+++ b/backend/app/api/api_page.py
@@ -10,6 +10,7 @@ from app.models.model_page import (
     PageCharacteristicValue,
     PageChange,
     PageKeyEvent,
+    PageRelationship,
 )
 from app.schemas.schema_page import PageCreate, PageRead, PageUpdate
 from app.schemas.schema_page_characteristic_value import PageCharacteristicValueUpdate, PageCharacteristicValueRead, PageCharacteristicValueCreate
@@ -18,6 +19,11 @@ from app.schemas.schema_page_key_event import (
     PageKeyEventCreate,
     PageKeyEventRead,
     PageKeyEventUpdate,
+)
+from app.schemas.schema_page_relationship import (
+    PageRelationshipCreate,
+    PageRelationshipRead,
+    PageRelationshipUpdate,
 )
 from app.crud.crud_page import (
     create_page,
@@ -39,6 +45,8 @@ from app.crud.crud_page import (
     delete_key_event,
     create_relationship,
     get_relationships,
+    update_relationship,
+    delete_relationship,
 )
 from datetime import datetime, timezone
 from app.dependencies import get_current_user, require_role
@@ -364,6 +372,73 @@ async def delete_key_event_endpoint(
         author_type="user",
         author_id=user.id,
         values={"event_id": event_id},
+    )
+    await create_page_change(session, change)
+    return {"ok": True}
+
+# -- Relationship endpoints --
+
+@router.post("/{page_id}/relationships/", response_model=PageRelationshipRead)
+async def add_relationship_endpoint(
+    page_id: int,
+    rel: PageRelationshipCreate,
+    user: User = Depends(require_role(UserRole.writer)),
+    session: AsyncSession = Depends(get_session),
+):
+    if rel.page_id != page_id:
+        rel.page_id = page_id
+    db_rel = await create_relationship(session, PageRelationship(**rel.model_dump()))
+    change = PageChange(
+        page_id=page_id,
+        change_type="relationship_added",
+        author_type="user",
+        author_id=user.id,
+        values=db_rel.model_dump(),
+    )
+    await create_page_change(session, change)
+    return db_rel
+
+
+@router.patch("/relationships/{rel_id}", response_model=PageRelationshipRead)
+async def update_relationship_endpoint(
+    rel_id: int,
+    updates: PageRelationshipUpdate,
+    user: User = Depends(require_role(UserRole.writer)),
+    session: AsyncSession = Depends(get_session),
+):
+    update_dict = updates.model_dump(exclude_unset=True)
+    rel = await update_relationship(session, rel_id, update_dict)
+    if not rel:
+        raise HTTPException(status_code=404, detail="Relationship not found")
+    change = PageChange(
+        page_id=rel.page_id,
+        change_type="relationship_updated",
+        author_type="user",
+        author_id=user.id,
+        values=update_dict,
+    )
+    await create_page_change(session, change)
+    return rel
+
+
+@router.delete("/relationships/{rel_id}")
+async def delete_relationship_endpoint(
+    rel_id: int,
+    user: User = Depends(require_role(UserRole.writer)),
+    session: AsyncSession = Depends(get_session),
+):
+    result = await session.execute(select(PageRelationship).where(PageRelationship.id == rel_id))
+    rel = result.scalar_one_or_none()
+    if not rel:
+        raise HTTPException(status_code=404, detail="Relationship not found")
+    page_id = rel.page_id
+    await delete_relationship(session, rel_id)
+    change = PageChange(
+        page_id=page_id,
+        change_type="relationship_deleted",
+        author_type="user",
+        author_id=user.id,
+        values={"relationship_id": rel_id},
     )
     await create_page_change(session, change)
     return {"ok": True}

--- a/backend/app/crud/crud_page.py
+++ b/backend/app/crud/crud_page.py
@@ -168,6 +168,22 @@ async def get_relationships(session: AsyncSession, page_id: int) -> List[PageRel
     )
     return result.scalars().all()
 
+async def update_relationship(session: AsyncSession, rel_id: int, updates: dict) -> Optional[PageRelationship]:
+    result = await session.execute(select(PageRelationship).where(PageRelationship.id == rel_id))
+    rel = result.scalar_one_or_none()
+    if not rel:
+        return None
+    for key, value in updates.items():
+        setattr(rel, key, value)
+    await session.commit()
+    await session.flush()
+    return rel
+
+async def delete_relationship(session: AsyncSession, rel_id: int) -> None:
+    await session.execute(delete(PageRelationship).where(PageRelationship.id == rel_id))
+    await session.commit()
+    await session.flush()
+
 from app.utils import serialize_value
 
 async def create_page_change(session: AsyncSession, change: PageChange) -> PageChange:

--- a/backend/app/schemas/schema_page_relationship.py
+++ b/backend/app/schemas/schema_page_relationship.py
@@ -18,3 +18,10 @@ class PageRelationshipRead(PageRelationshipBase):
     id: int
     page_id: int
     added_at: datetime
+
+class PageRelationshipUpdate(SQLModel):
+    target_page_id: Optional[int] = None
+    relationship_type: Optional[str] = None
+    direction: Optional[str] = None
+    source_page_id: Optional[int] = None
+    description: Optional[str] = None

--- a/frontend/src/app/components/see_page/AddRelationshipModal.tsx
+++ b/frontend/src/app/components/see_page/AddRelationshipModal.tsx
@@ -9,7 +9,7 @@ interface PageInfo {
   logo?: string;
 }
 
-interface RelationshipInput {
+export interface RelationshipInput {
   target_page_id: number;
   relationship_type: string;
   description?: string;
@@ -17,19 +17,28 @@ interface RelationshipInput {
   direction: string;
 }
 
-export default function AddRelationshipModal({ pages, onAdd, onClose }: { pages: PageInfo[]; onAdd: (r: RelationshipInput) => void; onClose: () => void }) {
-  const [target, setTarget] = useState<string>(""
-  );
+export default function AddRelationshipModal({
+  pages,
+  onSubmit,
+  onClose,
+  initial,
+}: {
+  pages: PageInfo[];
+  onSubmit: (r: RelationshipInput) => void;
+  onClose: () => void;
+  initial?: RelationshipInput;
+}) {
+  const [target, setTarget] = useState<string>(initial?.target_page_id?.toString() || "");
   const [filter, setFilter] = useState("");
-  const [type, setType] = useState("friend");
-  const [description, setDescription] = useState("");
-  const [source, setSource] = useState<string>("");
-  const [direction, setDirection] = useState("outgoing");
+  const [type, setType] = useState(initial?.relationship_type || "friend");
+  const [description, setDescription] = useState(initial?.description || "");
+  const [source, setSource] = useState<string>(initial?.source_page_id?.toString() || "");
+  const [direction, setDirection] = useState(initial?.direction || "outgoing");
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!target) return;
-    onAdd({
+    onSubmit({
       target_page_id: Number(target),
       relationship_type: type,
       description,
@@ -40,7 +49,7 @@ export default function AddRelationshipModal({ pages, onAdd, onClose }: { pages:
   };
 
   return (
-    <ModalContainer title="Add Relationship" onClose={onClose}>
+    <ModalContainer title={initial ? "Edit Relationship" : "Add Relationship"} onClose={onClose}>
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
           <label className="font-semibold text-sm">Target Page</label>
@@ -86,7 +95,7 @@ export default function AddRelationshipModal({ pages, onAdd, onClose }: { pages:
           </select>
         </div>
         <button type="submit" className="px-3 py-1 bg-[var(--primary)] text-white rounded">
-          Add
+          {initial ? "Save" : "Add"}
         </button>
       </form>
     </ModalContainer>

--- a/frontend/src/app/components/see_page/RelationshipMapTab.tsx
+++ b/frontend/src/app/components/see_page/RelationshipMapTab.tsx
@@ -2,9 +2,9 @@
 import { useState, useEffect } from "react";
 import RelationshipGraph from "./RelationshipGraph";
 import RelationshipTable from "./RelationshipTable";
-import AddRelationshipModal from "./AddRelationshipModal";
+import AddRelationshipModal, { RelationshipInput } from "./AddRelationshipModal";
 import { useAuth } from "../auth/AuthProvider";
-import { getPage } from "@/app/lib/pagesAPI";
+import { getPage, createRelationship, updateRelationship, deleteRelationship } from "@/app/lib/pagesAPI";
 
 interface Relationship {
   id: number;
@@ -35,6 +35,7 @@ export default function RelationshipMapTab({
   const { token } = useAuth();
   const [relationships, setRelationships] = useState<Relationship[]>([]);
   const [showModal, setShowModal] = useState(false);
+  const [editing, setEditing] = useState<Relationship | null>(null);
   const [graphNodes, setGraphNodes] = useState<any[]>([]);
   const [graphLinks, setGraphLinks] = useState<any[]>([]);
 
@@ -81,7 +82,7 @@ export default function RelationshipMapTab({
       addNode(pageMap.get(page.id));
 
       let queue = [
-        { id: page.id, rels: page.relationship_map || [] },
+        { id: page.id, rels: relationships },
       ];
       let depth = 0;
       const MAX_DEPTH = 2;
@@ -132,40 +133,78 @@ export default function RelationshipMapTab({
     }
 
     buildGraph();
-  }, [page, pages, token]);
+  }, [page.id, pages, token, relationships]);
 
-  const handleAdd = (
-    rel: Omit<
-      Relationship,
-      "id" | "page_id" | "author_type" | "author_id" | "added_at"
-    >
-  ) => {
-    const newRel: Relationship = {
-      id: Date.now(),
-      page_id: page.id,
-      author_type: "user",
-      author_id: 0,
-      added_at: new Date().toISOString(),
-      ...rel,
-    };
-    setRelationships((r) => [...r, newRel]);
+  const handleAdd = async (rel: RelationshipInput) => {
+    if (!token) return;
+    try {
+      const newRel: Relationship = await createRelationship(
+        page.id,
+        { ...rel, page_id: page.id, author_type: "user", author_id: 0 },
+        token
+      );
+      setRelationships((r) => [...r, newRel]);
+    } catch (err) {
+      console.error("Failed to create relationship", err);
+    }
+  };
+
+  const handleEdit = async (id: number, rel: RelationshipInput) => {
+    if (!token) return;
+    try {
+      const updated: Relationship = await updateRelationship(id, rel, token);
+      setRelationships((r) => r.map((p) => (p.id === id ? updated : p)));
+    } catch (err) {
+      console.error("Failed to update relationship", err);
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    if (!token) return;
+    try {
+      await deleteRelationship(id, token);
+      setRelationships((r) => r.filter((rel) => rel.id !== id));
+    } catch (err) {
+      console.error("Failed to delete relationship", err);
+    }
   };
 
   return (
     <div className="space-y-4">
       <RelationshipGraph nodes={graphNodes} links={graphLinks} />
-      <RelationshipTable relationships={relationships} pages={pages} />
+      <RelationshipTable
+        relationships={relationships}
+        pages={pages}
+        onEdit={(rel) => {
+          setEditing(rel);
+          setShowModal(true);
+        }}
+        onDelete={handleDelete}
+      />
       <button
         className="px-3 py-1 bg-[var(--primary)] text-white rounded"
-        onClick={() => setShowModal(true)}
+        onClick={() => {
+          setEditing(null);
+          setShowModal(true);
+        }}
       >
         Add Relationship
       </button>
       {showModal && (
         <AddRelationshipModal
           pages={pages}
-          onAdd={handleAdd}
-          onClose={() => setShowModal(false)}
+          onSubmit={(data) => {
+            if (editing) {
+              handleEdit(editing.id, data);
+            } else {
+              handleAdd(data);
+            }
+          }}
+          onClose={() => {
+            setShowModal(false);
+            setEditing(null);
+          }}
+          initial={editing || undefined}
         />
       )}
     </div>

--- a/frontend/src/app/components/see_page/RelationshipTable.tsx
+++ b/frontend/src/app/components/see_page/RelationshipTable.tsx
@@ -19,7 +19,17 @@ interface PageInfo {
   logo?: string;
 }
 
-export default function RelationshipTable({ relationships, pages }: { relationships: Relationship[]; pages: PageInfo[] }) {
+export default function RelationshipTable({
+  relationships,
+  pages,
+  onEdit,
+  onDelete,
+}: {
+  relationships: Relationship[];
+  pages: PageInfo[];
+  onEdit?: (r: Relationship) => void;
+  onDelete?: (id: number) => void;
+}) {
   const getPage = (id: number) => pages.find((p) => p.id === id);
   return (
     <table className="w-full text-sm mt-4 border">
@@ -29,6 +39,7 @@ export default function RelationshipTable({ relationships, pages }: { relationsh
           <th className="px-2 py-1 text-left">Type</th>
           <th className="px-2 py-1 text-left">Description</th>
           <th className="px-2 py-1 text-left">Source</th>
+          {onEdit && <th></th>}
         </tr>
       </thead>
       <tbody>
@@ -45,6 +56,12 @@ export default function RelationshipTable({ relationships, pages }: { relationsh
               <td className="px-2 py-1">
                 {source ? <Link href={`/pages/${source.id}`}>{source.name}</Link> : "-"}
               </td>
+              {onEdit && (
+                <td className="px-2 py-1 space-x-1">
+                  <button onClick={() => onEdit(rel)} className="text-xs text-blue-500">Edit</button>
+                  <button onClick={() => onDelete?.(rel.id)} className="text-xs text-red-500">Delete</button>
+                </td>
+              )}
             </tr>
           );
         })}

--- a/frontend/src/app/lib/pagesAPI.ts
+++ b/frontend/src/app/lib/pagesAPI.ts
@@ -99,3 +99,33 @@ export async function deleteKeyEvent(eventId: number, token: string) {
   if (!res.ok) throw await res.json();
   return await res.json();
 }
+
+// --- Relationships ---
+export async function createRelationship(pageId: number, data: unknown, token: string) {
+  const res = await fetch(`${API_URL}/pages/${pageId}/relationships/`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw await res.json();
+  return await res.json();
+}
+
+export async function updateRelationship(relId: number, data: unknown, token: string) {
+  const res = await fetch(`${API_URL}/pages/relationships/${relId}`, {
+    method: "PATCH",
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw await res.json();
+  return await res.json();
+}
+
+export async function deleteRelationship(relId: number, token: string) {
+  const res = await fetch(`${API_URL}/pages/relationships/${relId}`, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw await res.json();
+  return await res.json();
+}


### PR DESCRIPTION
## Summary
- add API endpoints for page relationships
- support editing and deleting relationships in the frontend
- expose helpers to manage relationships via the API

## Testing
- `pytest -q` *(fails: ValueError connecting to Chroma, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6880bcc22c248322bbf4cf0a5e2fcd3f