### PR TITLE
Fix duplicate inverse relationships

### DIFF
--- a/backend/app/crud/crud_page.py
+++ b/backend/app/crud/crud_page.py
@@ -158,17 +158,29 @@ async def delete_key_event(session: AsyncSession, event_id: int) -> None:
 
 async def create_relationship(session: AsyncSession, rel: PageRelationship) -> PageRelationship:
     session.add(rel)
-    inverse = PageRelationship(
-        page_id=rel.target_page_id,
-        target_page_id=rel.page_id,
-        relationship_type=rel.relationship_type,
-        direction="incoming" if rel.direction == "outgoing" else "outgoing",
-        source_page_id=rel.source_page_id,
-        description=rel.description,
-        author_type=rel.author_type,
-        author_id=rel.author_id,
+    inverse_dir = "incoming" if rel.direction == "outgoing" else "outgoing"
+    result = await session.execute(
+        select(PageRelationship).where(
+            PageRelationship.page_id == rel.target_page_id,
+            PageRelationship.target_page_id == rel.page_id,
+            PageRelationship.relationship_type == rel.relationship_type,
+            PageRelationship.direction == inverse_dir,
+            PageRelationship.source_page_id == rel.source_page_id,
+        )
     )
-    session.add(inverse)
+    existing = result.scalar_one_or_none()
+    if not existing:
+        inverse = PageRelationship(
+            page_id=rel.target_page_id,
+            target_page_id=rel.page_id,
+            relationship_type=rel.relationship_type,
+            direction=inverse_dir,
+            source_page_id=rel.source_page_id,
+            description=rel.description,
+            author_type=rel.author_type,
+            author_id=rel.author_id,
+        )
+        session.add(inverse)
     await session.commit()
     await session.flush()
     return rel

--- a/backend/tests/test_page_relationship.py
+++ b/backend/tests/test_page_relationship.py
@@ -34,3 +34,38 @@ async def test_add_relationship_adds_inverse(async_client):
     assert resp.status_code == 200
     rels = resp.json()["relationship_map"]
     assert any(r["page_id"] == p2_id and r["target_page_id"] == p1_id and r["direction"] == "incoming" for r in rels)
+
+
+@pytest.mark.anyio
+async def test_add_relationship_no_duplicate_inverse(async_client):
+    sys_token = await register_and_login(async_client, SYSTEM_ADMIN)
+    writer_token = await register_and_login(async_client, WRITER)
+
+    gw = {"name": "RelWorld2", "system": "sys", "description": "d", "logo": "l"}
+    resp = await async_client.post("/gameworlds/", json=gw, headers={"Authorization": f"Bearer {sys_token}"})
+    assert resp.status_code == 200
+    gw_id = resp.json()["id"]
+
+    concept = {"gameworld_id": gw_id, "name": "Clan", "description": "c"}
+    resp = await async_client.post("/concepts/", json=concept, headers={"Authorization": f"Bearer {sys_token}"})
+    assert resp.status_code == 200
+    concept_id = resp.json()["id"]
+
+    p1 = {"gameworld_id": gw_id, "concept_id": concept_id, "name": "A"}
+    resp = await async_client.post("/pages/", json=p1, headers={"Authorization": f"Bearer {writer_token}"})
+    assert resp.status_code == 200
+    p1_id = resp.json()["id"]
+
+    p2 = {"gameworld_id": gw_id, "concept_id": concept_id, "name": "B"}
+    resp = await async_client.post("/pages/", json=p2, headers={"Authorization": f"Bearer {writer_token}"})
+    assert resp.status_code == 200
+    p2_id = resp.json()["id"]
+
+    rel_payload = {"page_id": p1_id, "target_page_id": p2_id, "relationship_type": "friend", "author_type": "user", "author_id": 1}
+    resp = await async_client.post(f"/pages/{p1_id}/relationships/", json=rel_payload, headers={"Authorization": f"Bearer {writer_token}"})
+    assert resp.status_code == 200
+
+    resp = await async_client.get(f"/pages/{p2_id}", headers={"Authorization": f"Bearer {writer_token}"})
+    rels = resp.json()["relationship_map"]
+    count = sum(1 for r in rels if r["page_id"] == p2_id and r["target_page_id"] == p1_id and r["direction"] == "incoming")
+    assert count == 1


### PR DESCRIPTION
## Summary
- avoid inserting duplicate inverse page relationships
- test that only one inverse relationship is created

## Testing
- `pytest backend/tests/test_page_relationship.py::test_add_relationship_no_duplicate_inverse -vv`
- `pytest -q` *(fails: RuntimeError: Event loop is closed)*

------
https://chatgpt.com/codex/tasks/task_e_6880d3d9ce048322bdc4e9fa334ce962