### PR TITLE
Optimize page listing queries

### DIFF
--- a/backend/app/api/api_page.py
+++ b/backend/app/api/api_page.py
@@ -34,6 +34,9 @@ from app.crud.crud_page import (
     create_page_characteristic_value,
     get_page_characteristic_values,
     get_pages_characteristic_values,
+    get_pages_key_events,
+    get_pages_relationships,
+    get_pages_changes,
     update_page_characteristic_value,
     delete_page_characteristic_value,
     delete_page_characteristic_values,
@@ -149,14 +152,17 @@ async def read_pages(
     db_pages = await get_pages(session, gameworld_id=gameworld_id, concept_id=concept_id)
     page_id_list = [p.id for p in db_pages]
     values_map = await get_pages_characteristic_values(session, page_id_list)
+    events_map = await get_pages_key_events(session, page_id_list)
+    relationships_map = await get_pages_relationships(session, page_id_list)
+    changes_map = await get_pages_changes(session, page_id_list)
     return [
         PageRead.model_validate(
             {
                 **page.model_dump(),
                 "values": values_map.get(page.id, []),
-                "key_events": await get_key_events(session, page.id),
-                "relationship_map": await get_relationships(session, page.id),
-                "changelog": await get_page_changes(session, page.id),
+                "key_events": events_map.get(page.id, []),
+                "relationship_map": relationships_map.get(page.id, []),
+                "changelog": changes_map.get(page.id, []),
             }
         )
         for page in db_pages

--- a/backend/app/crud/crud_page.py
+++ b/backend/app/crud/crud_page.py
@@ -140,6 +140,22 @@ async def get_key_events(session: AsyncSession, page_id: int) -> List[PageKeyEve
     )
     return result.scalars().all()
 
+async def get_pages_key_events(
+    session: AsyncSession, page_ids: List[int]
+) -> Dict[int, List[PageKeyEvent]]:
+    if not page_ids:
+        return {}
+    result = await session.execute(
+        select(PageKeyEvent)
+        .where(PageKeyEvent.page_id.in_(page_ids))
+        .order_by(PageKeyEvent.added_at)
+    )
+    events = result.scalars().all()
+    events_by_page: Dict[int, List[PageKeyEvent]] = {}
+    for ev in events:
+        events_by_page.setdefault(ev.page_id, []).append(ev)
+    return events_by_page
+
 async def update_key_event(session: AsyncSession, event_id: int, updates: dict) -> Optional[PageKeyEvent]:
     result = await session.execute(select(PageKeyEvent).where(PageKeyEvent.id == event_id))
     event = result.scalar_one_or_none()
@@ -191,6 +207,22 @@ async def get_relationships(session: AsyncSession, page_id: int) -> List[PageRel
     )
     return result.scalars().all()
 
+async def get_pages_relationships(
+    session: AsyncSession, page_ids: List[int]
+) -> Dict[int, List[PageRelationship]]:
+    if not page_ids:
+        return {}
+    result = await session.execute(
+        select(PageRelationship)
+        .where(PageRelationship.page_id.in_(page_ids))
+        .order_by(PageRelationship.added_at)
+    )
+    rels = result.scalars().all()
+    rels_by_page: Dict[int, List[PageRelationship]] = {}
+    for rel in rels:
+        rels_by_page.setdefault(rel.page_id, []).append(rel)
+    return rels_by_page
+
 async def update_relationship(session: AsyncSession, rel_id: int, updates: dict) -> Optional[PageRelationship]:
     result = await session.execute(select(PageRelationship).where(PageRelationship.id == rel_id))
     rel = result.scalar_one_or_none()
@@ -222,6 +254,22 @@ async def get_page_changes(session: AsyncSession, page_id: int) -> List[PageChan
         select(PageChange).where(PageChange.page_id == page_id).order_by(PageChange.date)
     )
     return result.scalars().all()
+
+async def get_pages_changes(
+    session: AsyncSession, page_ids: List[int]
+) -> Dict[int, List[PageChange]]:
+    if not page_ids:
+        return {}
+    result = await session.execute(
+        select(PageChange)
+        .where(PageChange.page_id.in_(page_ids))
+        .order_by(PageChange.date)
+    )
+    changes = result.scalars().all()
+    changes_by_page: Dict[int, List[PageChange]] = {}
+    for change in changes:
+        changes_by_page.setdefault(change.page_id, []).append(change)
+    return changes_by_page
 
 # --- Optional: update individual value (not used in atomic pattern) ---
 


### PR DESCRIPTION
## Summary
- batch load page relations in CRUD helpers
- use the batched helpers in the page list endpoint

## Testing
- `pytest tests/test_page.py::test_page_create_update_delete_rbac -q` *(fails: ModuleNotFoundError: No module named 'celery')*

------
https://chatgpt.com/codex/tasks/task_e_6884c7e6b81c832284eeb1c004226acb