### PR TITLE
Fix heavy page queries by adding search API

### DIFF
--- a/backend/app/api/api_page.py
+++ b/backend/app/api/api_page.py
@@ -12,7 +12,7 @@ from app.models.model_page import (
     PageKeyEvent,
     PageRelationship,
 )
-from app.schemas.schema_page import PageCreate, PageRead, PageUpdate
+from app.schemas.schema_page import PageCreate, PageRead, PageUpdate, PageSummary
 from app.schemas.schema_page_characteristic_value import PageCharacteristicValueUpdate, PageCharacteristicValueRead, PageCharacteristicValueCreate
 from app.schemas.schema_page_change import PageChangeRead
 from app.schemas.schema_page_key_event import (
@@ -28,6 +28,7 @@ from app.schemas.schema_page_relationship import (
 from app.crud.crud_page import (
     create_page,
     get_pages,
+    search_pages,
     get_page,
     update_page,
     delete_page,
@@ -135,6 +136,22 @@ async def create_page_endpoint(
         task_auto_crosslink_batch.delay(db_page.id)
         task_sync_page_ref_attributes.delay(db_page.id)
     return response
+
+
+@router.get("/search", response_model=List[PageSummary])
+async def search_pages_endpoint(
+    q: Optional[str] = Query(None, alias="query"),
+    gameworld_id: Optional[int] = Query(None),
+    concept_id: Optional[int] = Query(None),
+    session: AsyncSession = Depends(get_session),
+):
+    pages = await search_pages(
+        session,
+        search=q,
+        gameworld_id=gameworld_id,
+        concept_id=concept_id,
+    )
+    return pages
 
     # values = await get_page_characteristic_values(session, db_page.id)
     # return PageRead.model_validate({**db_page.model_dump(), "values": values})

--- a/backend/app/crud/crud_page.py
+++ b/backend/app/crud/crud_page.py
@@ -13,7 +13,7 @@ from app.models.model_page import (
     PageChange,
 )
 from app.models.model_characteristic import Characteristic
-from app.schemas.schema_page import PageCreate, PageUpdate
+from app.schemas.schema_page import PageCreate, PageUpdate, PageSummary
 from app.schemas.schema_page_characteristic_value import PageCharacteristicValueCreate
 
 # --- PAGE CRUD ---
@@ -38,6 +38,35 @@ async def get_pages(session: AsyncSession, *, gameworld_id: Optional[int] = None
         query = query.where(Page.concept_id == concept_id)
     result = await session.execute(query)
     return result.scalars().all()
+
+async def search_pages(
+    session: AsyncSession,
+    *,
+    search: Optional[str] = None,
+    gameworld_id: Optional[int] = None,
+    concept_id: Optional[int] = None
+) -> List[PageSummary]:
+    query = select(Page.id, Page.name, Page.gameworld_id, Page.concept_id, Page.logo)
+    if gameworld_id:
+        query = query.where(Page.gameworld_id == gameworld_id)
+    if concept_id:
+        query = query.where(Page.concept_id == concept_id)
+    if search:
+        like = f"%{search}%"
+        query = query.where(Page.name.ilike(like))
+    query = query.order_by(Page.name)
+    result = await session.execute(query)
+    rows = result.all()
+    return [
+        PageSummary(
+            id=row.id,
+            name=row.name,
+            gameworld_id=row.gameworld_id,
+            concept_id=row.concept_id,
+            logo=row.logo,
+        )
+        for row in rows
+    ]
 
 async def update_page(session: AsyncSession, page_id: int, updates: dict) -> Optional[Page]:
     db_page = await get_page(session, page_id)

--- a/backend/app/schemas/schema_page.py
+++ b/backend/app/schemas/schema_page.py
@@ -51,6 +51,14 @@ class PageRead(PageBase):
     relationship_map: List["PageRelationshipRead"] = []
     changelog: List["PageChangeRead"] = []
 
+# New lightweight schema for search results
+class PageSummary(SQLModel):
+    id: int
+    gameworld_id: int
+    concept_id: int
+    name: str
+    logo: Optional[str] = None
+
 # resolve forward references on import
 from .schema_page_characteristic_value import (
     PageCharacteristicValueCreate,
@@ -64,5 +72,6 @@ from .schema_page_change import PageChangeRead
 PageCreate.model_rebuild()
 PageUpdate.model_rebuild()
 PageRead.model_rebuild()
+PageSummary.model_rebuild()
 
 

--- a/backend/tests/test_page.py
+++ b/backend/tests/test_page.py
@@ -195,3 +195,27 @@ async def test_safe_delete_removes_page_refs(async_client):
     assert resp.status_code == 200
     vals = resp.json()["values"]
     assert not vals or str(p1_id) not in (vals[0]["value"] or [])
+
+
+@pytest.mark.anyio
+async def test_page_search_endpoint(async_client):
+    token = await register_and_login(async_client, SYSTEM_ADMIN)
+
+    gw_payload = {"name": "SearchWorld", "system": "sys", "description": "d", "logo": "logo"}
+    resp = await async_client.post("/gameworlds/", json=gw_payload, headers={"Authorization": f"Bearer {token}"})
+    gw_id = resp.json()["id"]
+
+    concept_payload = {"gameworld_id": gw_id, "name": "Clan", "description": "c"}
+    resp = await async_client.post("/concepts/", json=concept_payload, headers={"Authorization": f"Bearer {token}"})
+    concept_id = resp.json()["id"]
+
+    for name in ["Alpha", "Beta"]:
+        page_payload = {"gameworld_id": gw_id, "concept_id": concept_id, "name": name}
+        resp = await async_client.post("/pages/", json=page_payload, headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 200
+
+    resp = await async_client.get("/pages/search", params={"query": "Al"}, headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    results = resp.json()
+    assert any(p["name"] == "Alpha" for p in results)
+    assert all("values" not in p for p in results)

--- a/frontend/src/app/components/template/TopBar.tsx
+++ b/frontend/src/app/components/template/TopBar.tsx
@@ -5,7 +5,7 @@ import ThemeToggle from "../ui/ThemeToggle";
 import Image from "next/image";
 import { FaSearch, FaBookmark, FaSignOutAlt } from "react-icons/fa";
 import { useEffect, useRef, useState } from "react";
-import { usePages } from "@/app/lib/usePage";
+import { usePageSearch } from "@/app/lib/usePageSearch";
 import { getGameWorlds } from "@/app/lib/gameworldsAPI";
 import { MdPublic } from "react-icons/md";
 import { RiFile3Line } from "react-icons/ri";
@@ -23,8 +23,8 @@ export default function TopBar() {
       user.role === "system admin");
 
   // --- Search Logic ---
-  const { pages = [], isLoading } = usePages();
   const [searchValue, setSearchValue] = useState("");
+  const { pages = [], isLoading } = usePageSearch(searchValue);
   const [searchOpen, setSearchOpen] = useState(false);
   const [worldsMap, setWorldsMap] = useState({});
   const [worldsLoaded, setWorldsLoaded] = useState(false);
@@ -45,16 +45,7 @@ export default function TopBar() {
   }, [token, worldsLoaded]);
 
   // Filter pages on search
-  const searchResults =
-    searchValue.length < 2
-      ? []
-      : pages
-          .filter(
-            (page) =>
-              page.name &&
-              page.name.toLowerCase().includes(searchValue.toLowerCase())
-          )
-          .slice(0, 10);
+  const searchResults = searchValue.length < 2 ? [] : pages.slice(0, 10);
 
   // Keyboard nav
   const [selectedIdx, setSelectedIdx] = useState(0);

--- a/frontend/src/app/lib/pagesAPI.ts
+++ b/frontend/src/app/lib/pagesAPI.ts
@@ -70,6 +70,16 @@ export async function getPagesForWorld(gameworld_id: number, token: string) {
   return getPages(token, { gameworld_id });
 }
 
+export async function searchPages(query: string, token: string) {
+  const params = new URLSearchParams();
+  if (query) params.append("query", query);
+  const res = await fetch(`${API_URL}/pages/search?${params.toString()}`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) throw new Error("Could not search pages");
+  return await res.json();
+}
+
 // --- Key Events ---
 export async function createKeyEvent(pageId: number, data: unknown, token: string) {
   const res = await fetch(`${API_URL}/pages/${pageId}/events/`, {

--- a/frontend/src/app/lib/usePageSearch.ts
+++ b/frontend/src/app/lib/usePageSearch.ts
@@ -1,0 +1,13 @@
+import useSWR from "swr";
+import { searchPages } from "./pagesAPI";
+import { useAuth } from "../components/auth/AuthProvider";
+
+export function usePageSearch(term: string) {
+  const { token } = useAuth();
+  const fetcher = () => searchPages(term, token);
+  const { data, error, isLoading } = useSWR(
+    term.length >= 2 && token ? ["pageSearch", term, token] : null,
+    fetcher
+  );
+  return { pages: data || [], error, isLoading };
+}


### PR DESCRIPTION
## Summary
- add `PageSummary` schema
- add `search_pages` crud method and `/pages/search` endpoint
- optimize TopBar search with new usePageSearch hook
- add integration test for new search API

## Testing
- `pip install httpx sqlmodel fastapi pytest pytest-asyncio pydantic_settings aiosqlite -q`
- `pytest -q` *(fails: ModuleNotFoundError / Not Found)*

------
https://chatgpt.com/codex/tasks/task_e_6884cf2b9b908322b3d321679f48495e