### PR TITLE
Add world embedding management

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -13,6 +13,7 @@ for _mod in [
     "api_library",
     "api_jobs",
     "api_user_note",
+    "api_embedding",
 ]:
     try:
         globals()[_mod] = __import__(f"app.api.{_mod}", fromlist=["router"])

--- a/backend/app/api/api_embedding.py
+++ b/backend/app/api/api_embedding.py
@@ -1,0 +1,37 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from pydantic import BaseModel
+from app.database import get_session
+from app.crud import crud_world_embedding, crud_agent_embedding
+from app.models.model_user import User, UserRole
+from app.schemas.schema_world_embedding import WorldEmbedding
+from app.dependencies import get_current_user, require_role
+
+router = APIRouter(prefix="/world_embeddings", tags=["WorldEmbeddings"], dependencies=[Depends(get_current_user)])
+
+@router.post("/", response_model=WorldEmbedding)
+async def create_embedding(embedding: WorldEmbedding, user: User = Depends(require_role(UserRole.system_admin)), session: AsyncSession = Depends(get_session)):
+    return await crud_world_embedding.create_embedding(session, embedding)
+
+@router.get("/", response_model=list[WorldEmbedding])
+async def list_embeddings(world_id: int | None = None, session: AsyncSession = Depends(get_session)):
+    return await crud_world_embedding.get_embeddings(session, world_id)
+
+@router.delete("/{embedding_id}")
+async def delete_embedding(embedding_id: int, user: User = Depends(require_role(UserRole.system_admin)), session: AsyncSession = Depends(get_session)):
+    ok = await crud_world_embedding.delete_embedding(session, embedding_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Embedding not found")
+    return {"ok": True}
+
+@router.get("/agents/{agent_id}")
+async def get_agent_embeddings(agent_id: int, session: AsyncSession = Depends(get_session)):
+    return await crud_agent_embedding.get_embeddings(session, agent_id)
+
+class AgentEmbeddingUpdate(BaseModel):
+    embedding_ids: list[int]
+
+@router.post("/agents/{agent_id}")
+async def set_agent_embeddings(agent_id: int, payload: AgentEmbeddingUpdate, user: User = Depends(require_role(UserRole.world_builder)), session: AsyncSession = Depends(get_session)):
+    await crud_agent_embedding.set_embeddings(session, agent_id, payload.embedding_ids)
+    return {"ok": True}

--- a/backend/app/crud/__init__.py
+++ b/backend/app/crud/__init__.py
@@ -29,6 +29,8 @@ except Exception:
     crud_library_vectordb = None
 from . import crud_agent_library_item
 from . import crud_user_note
+from . import crud_world_embedding
+from . import crud_agent_embedding
 try:
     from . import crud_vectordb
 except Exception:  # pragma: no cover - optional dependency
@@ -50,6 +52,8 @@ __all__ = [
     "crud_library_item",
     "crud_agent_library_item",
     "crud_user_note",
+    "crud_world_embedding",
+    "crud_agent_embedding",
 ]
 if crud_vectordb:
     __all__.append("crud_vectordb")

--- a/backend/app/crud/crud_agent.py
+++ b/backend/app/crud/crud_agent.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import json
 
 from app.config import settings
-from app.crud import crud_vectordb, crud_concept, crud_page
+from app.crud import crud_vectordb, crud_concept, crud_page, crud_agent_embedding
 from app.models.model_agent import Agent
 from app.models.model_gameworld import GameWorld
 from rapidfuzz import fuzz
@@ -69,6 +69,8 @@ async def chat_with_agent(
 
     query = messages[-1].get("content", "") if messages else ""
     world = await session.get(GameWorld, agent.world_id)
+    embeddings = await crud_agent_embedding.get_embeddings(session, agent_id)
+    collections = [e.collection for e in embeddings] or [None]
 
     # Run step 1 and 2 concurrently: extract query structure + load pages/concepts
     async def extract_query_structure():
@@ -128,14 +130,21 @@ async def chat_with_agent(
 
     print(f"FILTERS USED IN QUERY: {filters}")
 
-    # Step 3: Retrieve chunks
-    chunks = crud_vectordb.query_world(
-        agent.world_id,
-        semantic_query,
-        n_results=n_results * 8,
-        views=views,
-        filters=filters
-    )
+    # Step 3: Retrieve chunks from all associated embeddings
+    chunks = []
+    for coll in collections:
+        try:
+            parts = crud_vectordb.query_world(
+                agent.world_id,
+                semantic_query,
+                n_results=n_results * 8,
+                views=views,
+                filters=filters,
+                collection=coll,
+            )
+            chunks.extend(parts)
+        except Exception:
+            continue
 
     # Step 4: Top-K semantic compression (keep only strongest chunks by size)
     chunks = sorted(chunks, key=lambda c: len(c["document"]), reverse=True)[:n_results * 2]

--- a/backend/app/crud/crud_agent_embedding.py
+++ b/backend/app/crud/crud_agent_embedding.py
@@ -1,0 +1,29 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+from typing import List
+
+from app.models.model_agent_embedding import AgentEmbedding
+from app.models.model_world_embedding import WorldEmbedding
+
+async def set_embeddings(session: AsyncSession, agent_id: int, embedding_ids: List[int]) -> None:
+    await session.execute(
+        select(AgentEmbedding).where(AgentEmbedding.agent_id == agent_id)
+    )
+    await session.execute(
+        AgentEmbedding.__table__.delete().where(AgentEmbedding.agent_id == agent_id)
+    )
+    for eid in embedding_ids:
+        session.add(AgentEmbedding(agent_id=agent_id, embedding_id=eid))
+    await session.commit()
+
+async def get_embeddings(session: AsyncSession, agent_id: int) -> List[WorldEmbedding]:
+    result = await session.execute(
+        select(WorldEmbedding).join(AgentEmbedding, WorldEmbedding.id == AgentEmbedding.embedding_id).where(AgentEmbedding.agent_id == agent_id)
+    )
+    return result.scalars().all()
+
+async def get_embedding_ids(session: AsyncSession, agent_id: int) -> List[int]:
+    result = await session.execute(
+        select(AgentEmbedding.embedding_id).where(AgentEmbedding.agent_id == agent_id)
+    )
+    return [row[0] for row in result.all()]

--- a/backend/app/crud/crud_vectordb.py
+++ b/backend/app/crud/crud_vectordb.py
@@ -61,8 +61,8 @@ def _delete_collection(name: str, _client) -> None:
 def get_chroma_client():
     return chromadb.HttpClient(host=chromadbURL, port=chromadbPort)
 
-def _get_collection(world_id: int):
-    name = f"world_{world_id}"
+def _get_collection(world_id: int, collection: str | None = None):
+    name = collection or f"world_{world_id}"
     client = get_chroma_client()
     return Chroma(
         client=client,
@@ -106,7 +106,7 @@ def _safe_add_documents(collection: Chroma, docs: List[Document]) -> None:
     for i in range(0, len(docs), max_size):
         _add_batch(docs[i: i + max_size])
 
-async def add_page(session: AsyncSession, page_id: int):
+async def add_page(session: AsyncSession, page_id: int, collection: str | None = None):
     result = await session.execute(select(Page).where(Page.id == page_id))
     page = result.scalar_one_or_none()
     if not page:
@@ -160,7 +160,7 @@ async def add_page(session: AsyncSession, page_id: int):
     ]
     relationships_text = "\n".join(rel_parts)
 
-    collection = _get_collection(page.gameworld_id)
+    collection = _get_collection(page.gameworld_id, collection)
     all_chunks = []
 
     for view_name, text in [
@@ -181,15 +181,15 @@ async def add_page(session: AsyncSession, page_id: int):
     _safe_add_documents(collection, all_chunks)
     return True
 
-async def rebuild_world(session: AsyncSession, world_id: int):
-    name = f"world_{world_id}"
-    collection = _get_collection(world_id)
-    _delete_collection(name, collection)
+async def rebuild_world(session: AsyncSession, world_id: int, collection: str | None = None):
+    name = collection or f"world_{world_id}"
+    collection_obj = _get_collection(world_id, collection)
+    _delete_collection(name, collection_obj)
 
     result = await session.execute(select(Page.id).where(Page.gameworld_id == world_id))
     page_ids = [row[0] for row in result.all()]
     for pid in page_ids:
-        await add_page(session, pid)
+        await add_page(session, pid, collection)
 
     agent_result = await session.execute(select(Agent).where(Agent.world_id == world_id))
     agents = agent_result.scalars().all()
@@ -201,8 +201,8 @@ async def rebuild_world(session: AsyncSession, world_id: int):
     return len(page_ids)
 
 
-def query_world(world_id: int, query: str, n_results: int = 5, views: Optional[List[str]] = None, filters: Optional[Dict] = None) -> List[Dict]:
-    collection = _get_collection(world_id)
+def query_world(world_id: int, query: str, n_results: int = 5, views: Optional[List[str]] = None, filters: Optional[Dict] = None, collection: str | None = None) -> List[Dict]:
+    collection_obj = _get_collection(world_id, collection)
     
     # Build valid Chroma filter format using $and for multiple conditions
     conditions = []
@@ -229,7 +229,7 @@ def query_world(world_id: int, query: str, n_results: int = 5, views: Optional[L
     print(f"FILTERS USED IN QUERY: {chroma_filter}")
 
     # Run query
-    retrieved = collection.max_marginal_relevance_search(
+    retrieved = collection_obj.max_marginal_relevance_search(
         query,
         k=n_results * 4,
         filter=chroma_filter if chroma_filter else None

--- a/backend/app/crud/crud_world_embedding.py
+++ b/backend/app/crud/crud_world_embedding.py
@@ -1,0 +1,26 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+from typing import List, Optional
+
+from app.models.model_world_embedding import WorldEmbedding
+
+async def create_embedding(session: AsyncSession, embedding: WorldEmbedding) -> WorldEmbedding:
+    session.add(embedding)
+    await session.commit()
+    await session.refresh(embedding)
+    return embedding
+
+async def get_embeddings(session: AsyncSession, world_id: int | None = None) -> List[WorldEmbedding]:
+    stmt = select(WorldEmbedding)
+    if world_id:
+        stmt = stmt.where(WorldEmbedding.world_id == world_id)
+    result = await session.execute(stmt)
+    return result.scalars().all()
+
+async def delete_embedding(session: AsyncSession, embedding_id: int) -> bool:
+    emb = await session.get(WorldEmbedding, embedding_id)
+    if not emb:
+        return False
+    await session.delete(emb)
+    await session.commit()
+    return True

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -87,6 +87,18 @@ def _migrate(conn):
             "CREATE TABLE agentlibraryitem (agent_id INTEGER NOT NULL REFERENCES agent(id), item_id INTEGER NOT NULL REFERENCES libraryitem(id), added_at DATETIME NOT NULL, PRIMARY KEY (agent_id, item_id))"
         ))
 
+    # -- WorldEmbedding table --
+    if "worldembedding" not in inspector.get_table_names():
+        conn.execute(text(
+            "CREATE TABLE worldembedding (id INTEGER PRIMARY KEY AUTOINCREMENT, world_id INTEGER NOT NULL REFERENCES gameworld(id), name TEXT NOT NULL, collection TEXT NOT NULL, created_at DATETIME NOT NULL)"
+        ))
+
+    # -- AgentEmbedding table --
+    if "agentembedding" not in inspector.get_table_names():
+        conn.execute(text(
+            "CREATE TABLE agentembedding (agent_id INTEGER NOT NULL REFERENCES agent(id), embedding_id INTEGER NOT NULL REFERENCES worldembedding(id), added_at DATETIME NOT NULL, PRIMARY KEY (agent_id, embedding_id))"
+        ))
+
     # -- UserNote table --
     if "usernote" not in inspector.get_table_names():
         conn.execute(text(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,6 +15,7 @@ from .api import (
     api_library,
     api_jobs,
     api_user_note,
+    api_embedding,
 )
 from contextlib import asynccontextmanager
 
@@ -100,6 +101,7 @@ app.include_router(api_backup.router)
 app.include_router(api_library.router)
 app.include_router(api_jobs.router)
 app.include_router(api_user_note.router)
+app.include_router(api_embedding.router)
 
 
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,4 +1,17 @@
-from . import model_agent, model_characteristic, model_concept, model_gameworld, model_page, model_user, model_specialist_source, model_library_item, model_agent_library_item, model_user_note
+from . import (
+    model_agent,
+    model_characteristic,
+    model_concept,
+    model_gameworld,
+    model_page,
+    model_user,
+    model_specialist_source,
+    model_library_item,
+    model_agent_library_item,
+    model_user_note,
+    model_world_embedding,
+    model_agent_embedding,
+)
 
 __all__ = [
     "model_agent",
@@ -11,4 +24,6 @@ __all__ = [
     "model_library_item",
     "model_agent_library_item",
     "model_user_note",
+    "model_world_embedding",
+    "model_agent_embedding",
 ]

--- a/backend/app/models/model_agent_embedding.py
+++ b/backend/app/models/model_agent_embedding.py
@@ -1,0 +1,7 @@
+from sqlmodel import SQLModel, Field
+from datetime import datetime, timezone
+
+class AgentEmbedding(SQLModel, table=True):
+    agent_id: int = Field(foreign_key="agent.id", primary_key=True)
+    embedding_id: int = Field(foreign_key="worldembedding.id", primary_key=True)
+    added_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/backend/app/models/model_world_embedding.py
+++ b/backend/app/models/model_world_embedding.py
@@ -1,0 +1,10 @@
+from typing import Optional
+from sqlmodel import SQLModel, Field
+from datetime import datetime, timezone
+
+class WorldEmbedding(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    world_id: int = Field(foreign_key="gameworld.id")
+    name: str
+    collection: str
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/backend/app/schemas/schema_world_embedding.py
+++ b/backend/app/schemas/schema_world_embedding.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+from typing import Optional
+from pydantic import BaseModel
+
+class WorldEmbeddingBase(BaseModel):
+    world_id: int
+    name: str
+    collection: str
+
+class WorldEmbedding(WorldEmbeddingBase):
+    id: int
+    created_at: datetime
+
+    class Config:
+        orm_mode = True

--- a/frontend/src/app/agents_settings/agent_conversational/page.tsx
+++ b/frontend/src/app/agents_settings/agent_conversational/page.tsx
@@ -8,6 +8,7 @@ import useRoleRedirect from "../../hooks/useRoleRedirect";
 import { useAgents } from "../../lib/useAgents";
 import { useWorlds } from "../../lib/userWorlds";
 import AgentModal from "../../components/agents/AgentModal";
+import AgentEmbeddingModal from "../../components/agents/AgentEmbeddingModal";
 import { startVectorUpdate } from "../../lib/vectordbAPI";
 import { getPagesForWorld } from "../../lib/pagesAPI";
 import { useVectorJobs } from "../../lib/useVectorJobs";
@@ -272,6 +273,7 @@ export default function AgentsGuildhallPage() {
   const [search, setSearch] = useState("");
   const [modalOpen, setModalOpen] = useState(false);
   const [selectedAgent, setSelectedAgent] = useState(null);
+  const [embeddingModal, setEmbeddingModal] = useState<{id:number, world:number}|null>(null);
   const [success, setSuccess] = useState("");
   const [updatingAgentId, setUpdatingAgentId] = useState<number | null>(null);
   const [bulkUpdating, setBulkUpdating] = useState(false);
@@ -418,17 +420,23 @@ function AgentGuildTable({ title, icon, agents, task, canRebuild }) {
                   >
                     Edit
                   </button>
-                  <button
-                    className="px-3 py-1 rounded-lg font-semibold text-white bg-rose-600 hover:bg-rose-800 transition text-sm shadow"
-                    onClick={() => {
-                      setSelectedAgent(agent);
-                      setModalOpen(true);
-                      setNpcFlavor(`Are you sure you want to remove agent ${agent.name}?`);
-                    }}
-                  >
-                    Delete
-                  </button>
-                  {canRebuild && (
+                <button
+                  className="px-3 py-1 rounded-lg font-semibold text-white bg-rose-600 hover:bg-rose-800 transition text-sm shadow"
+                  onClick={() => {
+                    setSelectedAgent(agent);
+                    setModalOpen(true);
+                    setNpcFlavor(`Are you sure you want to remove agent ${agent.name}?`);
+                  }}
+                >
+                  Delete
+                </button>
+                <button
+                  className="px-3 py-1 rounded-lg font-semibold text-white bg-sky-600 hover:bg-sky-800 transition text-sm shadow"
+                  onClick={() => setEmbeddingModal({id:agent.id, world:agent.world_id})}
+                >
+                  Embeddings
+                </button>
+                {canRebuild && (
                     <button
                       className="px-3 py-1 rounded-lg font-semibold text-indigo-700 bg-purple-200 hover:bg-yellow-300 transition text-sm shadow border border-purple-300"
                       onClick={() => handleRebuild(agent)}
@@ -527,6 +535,14 @@ return (
               onSave={handleModalSave}
               onDelete={handleModalDelete}
               worlds={worlds}
+            />
+          )}
+          {embeddingModal && (
+            <AgentEmbeddingModal
+              agentId={embeddingModal.id}
+              worldId={embeddingModal.world}
+              onClose={()=>setEmbeddingModal(null)}
+              onSaved={()=>{}}
             />
           )}
         </div>

--- a/frontend/src/app/components/agents/AgentEmbeddingModal.tsx
+++ b/frontend/src/app/components/agents/AgentEmbeddingModal.tsx
@@ -1,0 +1,53 @@
+"use client";
+import { useState } from "react";
+import ModalContainer from "../template/modalContainer";
+import { useWorldEmbeddings } from "../../lib/useWorldEmbeddings";
+import { setAgentEmbeddings } from "../../lib/worldEmbeddingAPI";
+import { useAuth } from "../auth/AuthProvider";
+
+export default function AgentEmbeddingModal({ agentId, worldId, onClose, onSaved }) {
+  const { token } = useAuth();
+  const { embeddings } = useWorldEmbeddings();
+  const [selected, setSelected] = useState<number[]>([]);
+  const [saving, setSaving] = useState(false);
+
+  const filtered = embeddings.filter((e:any)=>e.world_id===worldId);
+
+  function toggle(id:number) {
+    setSelected(prev=>prev.includes(id)?prev.filter(i=>i!==id):[...prev,id]);
+  }
+
+  async function handleSave(e:any){
+    e.preventDefault();
+    setSaving(true);
+    try {
+      await setAgentEmbeddings(agentId, selected, token||"" );
+      onSaved?.();
+      onClose();
+    } catch(err){
+      console.error(err);
+    }
+    setSaving(false);
+  }
+
+  return (
+    <ModalContainer title="Select Embeddings" onClose={onClose}>
+      <form className="flex flex-col gap-4" onSubmit={handleSave}>
+        <div className="max-h-80 overflow-y-auto grid sm:grid-cols-2 gap-3 p-1">
+          {filtered.map(e=> (
+            <label key={e.id} className="border rounded-xl p-3 flex gap-2 items-center">
+              <input type="checkbox" className="accent-[var(--primary)]" checked={selected.includes(e.id)} onChange={()=>toggle(e.id)} />
+              <span>{e.name}</span>
+            </label>
+          ))}
+        </div>
+        <div className="flex justify-end gap-2 mt-2">
+          <button type="submit" disabled={saving} className="px-4 py-2 rounded-xl bg-[var(--primary)] text-white">
+            {saving?"Saving...":"Save"}
+          </button>
+          <button type="button" onClick={onClose} className="px-4 py-2 rounded-xl border">Cancel</button>
+        </div>
+      </form>
+    </ModalContainer>
+  );
+}

--- a/frontend/src/app/lib/useWorldEmbeddings.ts
+++ b/frontend/src/app/lib/useWorldEmbeddings.ts
@@ -1,0 +1,10 @@
+import useSWR from "swr";
+import { getWorldEmbeddings } from "./worldEmbeddingAPI";
+import { useAuth } from "../components/auth/AuthProvider";
+
+export function useWorldEmbeddings() {
+  const { token } = useAuth();
+  const fetcher = () => getWorldEmbeddings(token || "");
+  const { data, error, mutate } = useSWR(token ? ["world_embeddings", token] : null, fetcher);
+  return { embeddings: data || [], error, mutate };
+}

--- a/frontend/src/app/lib/worldEmbeddingAPI.ts
+++ b/frontend/src/app/lib/worldEmbeddingAPI.ts
@@ -1,0 +1,52 @@
+import { API_URL } from "./config";
+
+export async function getWorldEmbeddings(token: string) {
+  const res = await fetch(`${API_URL}/world_embeddings/`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) throw await res.text();
+  return await res.json();
+}
+
+export async function createWorldEmbedding(data: any, token: string) {
+  const res = await fetch(`${API_URL}/world_embeddings/`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw await res.text();
+  return await res.json();
+}
+
+export async function deleteWorldEmbedding(id: number, token: string) {
+  const res = await fetch(`${API_URL}/world_embeddings/${id}`, {
+    method: "DELETE",
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) throw await res.text();
+  return await res.json();
+}
+
+export async function getAgentEmbeddings(agentId: number, token: string) {
+  const res = await fetch(`${API_URL}/world_embeddings/agents/${agentId}`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) throw await res.text();
+  return await res.json();
+}
+
+export async function setAgentEmbeddings(agentId: number, ids: number[], token: string) {
+  const res = await fetch(`${API_URL}/world_embeddings/agents/${agentId}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify({ embedding_ids: ids }),
+  });
+  if (!res.ok) throw await res.text();
+  return await res.json();
+}

--- a/frontend/src/app/system_settings/page.tsx
+++ b/frontend/src/app/system_settings/page.tsx
@@ -21,6 +21,7 @@ import {
   History,
   Users2,
   Book,
+  Layers,
 } from "lucide-react";
 import SimpleBarChart from "../components/charts/SimpleBarChart";
 import { useLibraryItems } from "../lib/useLibraryItems";
@@ -155,6 +156,18 @@ export default function AdminDashboardPage() {
                 actions={
                   <Link className="btn-primary" href="/library_admin">
                     Enter Library
+                  </Link>
+                }
+              />
+
+              <DashboardCard
+                title="World Embeddings"
+                description="Manage vector stores for your worlds."
+                icon={<Layers className="w-6 h-6" />}
+                color="from-violet-600 to-purple-500"
+                actions={
+                  <Link className="btn-primary" href="/world_embeddings">
+                    Manage Embeddings
                   </Link>
                 }
               />

--- a/frontend/src/app/world_embeddings/page.tsx
+++ b/frontend/src/app/world_embeddings/page.tsx
@@ -1,0 +1,64 @@
+"use client";
+import AuthGuard from "../components/auth/AuthGuard";
+import DashboardLayout from "../components/DashboardLayout";
+import { useAuth } from "../components/auth/AuthProvider";
+import useRoleRedirect from "../hooks/useRoleRedirect";
+import { useWorlds } from "../lib/userWorlds";
+import { useWorldEmbeddings } from "../lib/useWorldEmbeddings";
+import { createWorldEmbedding, deleteWorldEmbedding } from "../lib/worldEmbeddingAPI";
+import { useState } from "react";
+
+export default function WorldEmbeddingsPage() {
+  const { token } = useAuth();
+  const { worlds } = useWorlds();
+  const { embeddings, mutate } = useWorldEmbeddings();
+  const [worldId, setWorldId] = useState("");
+  const [name, setName] = useState("");
+  const allowed = useRoleRedirect("system admin");
+  if (!allowed) return null;
+
+  async function handleCreate(e:any) {
+    e.preventDefault();
+    if (!worldId || !name) return;
+    await createWorldEmbedding({ world_id: Number(worldId), name, collection: `world_${worldId}_${name}` }, token||"" );
+    setName("");
+    mutate();
+  }
+
+  async function handleDelete(id:number) {
+    if (!confirm("Delete embedding?")) return;
+    await deleteWorldEmbedding(id, token||"");
+    mutate();
+  }
+
+  return (
+    <AuthGuard>
+      <DashboardLayout>
+        <div className="min-h-screen w-full px-4 py-10">
+          <h1 className="text-2xl font-bold mb-4">World Embeddings</h1>
+          <form onSubmit={handleCreate} className="flex gap-2 mb-4">
+            <select value={worldId} onChange={e=>setWorldId(e.target.value)} className="border p-1 rounded">
+              <option value="">Select world</option>
+              {worlds.map(w=>(<option key={w.id} value={w.id}>{w.name}</option>))}
+            </select>
+            <input value={name} onChange={e=>setName(e.target.value)} placeholder="Name" className="border p-1 rounded" />
+            <button type="submit" className="btn-primary">Create</button>
+          </form>
+          <table className="w-full border">
+            <thead><tr><th>ID</th><th>Name</th><th>World</th><th></th></tr></thead>
+            <tbody>
+              {embeddings.map((e:any)=>(
+                <tr key={e.id} className="border-t">
+                  <td className="px-2">{e.id}</td>
+                  <td className="px-2">{e.name}</td>
+                  <td className="px-2">{e.world_id}</td>
+                  <td className="px-2"><button onClick={()=>handleDelete(e.id)} className="text-red-600">Delete</button></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </DashboardLayout>
+    </AuthGuard>
+  );
+}


### PR DESCRIPTION
## Summary
- allow many embedding collections per world and link them to agents
- support storing embeddings in new tables
- API endpoints for creating and assigning embeddings
- query multiple embedding collections when chatting with an agent
- minimal UI to manage embeddings and link them to agents

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: Could not connect to a Chroma server)*

------
https://chatgpt.com/codex/tasks/task_e_6887b6be69608322b6eb64dcfc0ae166