### PR TITLE
Fix world embedding creation endpoint

### DIFF
--- a/backend/app/api/api_embedding.py
+++ b/backend/app/api/api_embedding.py
@@ -4,34 +4,63 @@ from pydantic import BaseModel
 from app.database import get_session
 from app.crud import crud_world_embedding, crud_agent_embedding
 from app.models.model_user import User, UserRole
-from app.schemas.schema_world_embedding import WorldEmbedding
+from app.schemas.schema_world_embedding import WorldEmbedding, WorldEmbeddingCreate
+from app.models.model_world_embedding import WorldEmbedding as WorldEmbeddingModel
 from app.dependencies import get_current_user, require_role
 
-router = APIRouter(prefix="/world_embeddings", tags=["WorldEmbeddings"], dependencies=[Depends(get_current_user)])
+router = APIRouter(
+    prefix="/world_embeddings",
+    tags=["WorldEmbeddings"],
+    dependencies=[Depends(get_current_user)],
+)
+
 
 @router.post("/", response_model=WorldEmbedding)
-async def create_embedding(embedding: WorldEmbedding, user: User = Depends(require_role(UserRole.system_admin)), session: AsyncSession = Depends(get_session)):
-    return await crud_world_embedding.create_embedding(session, embedding)
+async def create_embedding(
+    embedding: WorldEmbeddingCreate,
+    user: User = Depends(require_role(UserRole.system_admin)),
+    session: AsyncSession = Depends(get_session),
+):
+    db_embedding = WorldEmbeddingModel(**embedding.model_dump())
+    return await crud_world_embedding.create_embedding(session, db_embedding)
+
 
 @router.get("/", response_model=list[WorldEmbedding])
-async def list_embeddings(world_id: int | None = None, session: AsyncSession = Depends(get_session)):
+async def list_embeddings(
+    world_id: int | None = None, session: AsyncSession = Depends(get_session)
+):
     return await crud_world_embedding.get_embeddings(session, world_id)
 
+
 @router.delete("/{embedding_id}")
-async def delete_embedding(embedding_id: int, user: User = Depends(require_role(UserRole.system_admin)), session: AsyncSession = Depends(get_session)):
+async def delete_embedding(
+    embedding_id: int,
+    user: User = Depends(require_role(UserRole.system_admin)),
+    session: AsyncSession = Depends(get_session),
+):
     ok = await crud_world_embedding.delete_embedding(session, embedding_id)
     if not ok:
         raise HTTPException(status_code=404, detail="Embedding not found")
     return {"ok": True}
 
+
 @router.get("/agents/{agent_id}")
-async def get_agent_embeddings(agent_id: int, session: AsyncSession = Depends(get_session)):
+async def get_agent_embeddings(
+    agent_id: int, session: AsyncSession = Depends(get_session)
+):
     return await crud_agent_embedding.get_embeddings(session, agent_id)
+
 
 class AgentEmbeddingUpdate(BaseModel):
     embedding_ids: list[int]
 
+
 @router.post("/agents/{agent_id}")
-async def set_agent_embeddings(agent_id: int, payload: AgentEmbeddingUpdate, user: User = Depends(require_role(UserRole.world_builder)), session: AsyncSession = Depends(get_session)):
+async def set_agent_embeddings(
+    agent_id: int,
+    payload: AgentEmbeddingUpdate,
+    user: User = Depends(require_role(UserRole.world_builder)),
+    session: AsyncSession = Depends(get_session),
+):
     await crud_agent_embedding.set_embeddings(session, agent_id, payload.embedding_ids)
     return {"ok": True}

--- a/backend/app/schemas/schema_world_embedding.py
+++ b/backend/app/schemas/schema_world_embedding.py
@@ -2,10 +2,16 @@ from datetime import datetime
 from typing import Optional
 from pydantic import BaseModel
 
+
 class WorldEmbeddingBase(BaseModel):
     world_id: int
     name: str
     collection: str
+
+
+class WorldEmbeddingCreate(WorldEmbeddingBase):
+    pass
+
 
 class WorldEmbedding(WorldEmbeddingBase):
     id: int


### PR DESCRIPTION
## Summary
- allow creating embeddings without providing id or created_at
- adjust world embedding API endpoint to accept the new schema

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and 23 failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_6887c1d5f87883228584d4789d235027