### PR TITLE
Add world embedding background jobs

### DIFF
--- a/backend/app/api/api_embedding.py
+++ b/backend/app/api/api_embedding.py
@@ -3,6 +3,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from pydantic import BaseModel
 from app.database import get_session
 from app.crud import crud_world_embedding, crud_agent_embedding
+from uuid import uuid4
+from pathlib import Path
+import json
+from app.config import settings
+from app.task_queue import task_rebuild_world_embedding
 from app.models.model_user import User, UserRole
 from app.schemas.schema_world_embedding import WorldEmbedding, WorldEmbeddingCreate
 from app.models.model_world_embedding import WorldEmbedding as WorldEmbeddingModel
@@ -22,7 +27,16 @@ async def create_embedding(
     session: AsyncSession = Depends(get_session),
 ):
     db_embedding = WorldEmbeddingModel(**embedding.model_dump())
-    return await crud_world_embedding.create_embedding(session, db_embedding)
+    created = await crud_world_embedding.create_embedding(session, db_embedding)
+
+    job_id = uuid4().hex
+    job_dir = Path(settings.world_embedding_job_dir)
+    job_dir.mkdir(parents=True, exist_ok=True)
+    job_path = job_dir / f"{job_id}.json"
+    with open(job_path, "w") as f:
+        json.dump({"status": "queued", "embedding_id": created.id, "job_type": "rebuild_world_embedding"}, f)
+    task_rebuild_world_embedding.delay(created.id, job_id)
+    return created
 
 
 @router.get("/", response_model=list[WorldEmbedding])
@@ -42,6 +56,21 @@ async def delete_embedding(
     if not ok:
         raise HTTPException(status_code=404, detail="Embedding not found")
     return {"ok": True}
+
+
+@router.post("/{embedding_id}/embed_async")
+async def embed_world_async(
+    embedding_id: int,
+    user: User = Depends(require_role(UserRole.system_admin)),
+):
+    job_id = uuid4().hex
+    job_dir = Path(settings.world_embedding_job_dir)
+    job_dir.mkdir(parents=True, exist_ok=True)
+    job_path = job_dir / f"{job_id}.json"
+    with open(job_path, "w") as f:
+        json.dump({"status": "queued", "embedding_id": embedding_id, "job_type": "rebuild_world_embedding"}, f)
+    task_rebuild_world_embedding.delay(embedding_id, job_id)
+    return {"job_id": job_id}
 
 
 @router.get("/agents/{agent_id}")
@@ -64,3 +93,26 @@ async def set_agent_embeddings(
 ):
     await crud_agent_embedding.set_embeddings(session, agent_id, payload.embedding_ids)
     return {"ok": True}
+
+
+@router.get("/vector_jobs/{job_id}")
+async def world_embedding_job_status(job_id: str):
+    job_path = Path(settings.world_embedding_job_dir) / f"{job_id}.json"
+    if not job_path.is_file():
+        raise HTTPException(status_code=404, detail="Job not found")
+    with open(job_path) as f:
+        data = json.load(f)
+    return data
+
+
+@router.get("/vector_jobs")
+async def list_world_embedding_jobs():
+    job_dir = Path(settings.world_embedding_job_dir)
+    job_dir.mkdir(parents=True, exist_ok=True)
+    jobs = []
+    for p in job_dir.glob("*.json"):
+        with open(p) as f:
+            data = json.load(f)
+        data["job_id"] = p.stem
+        jobs.append(data)
+    return jobs

--- a/backend/app/api/api_jobs.py
+++ b/backend/app/api/api_jobs.py
@@ -15,6 +15,7 @@ JOB_DIRS = {
     "specialist": settings.specialist_job_dir,
     "novelist": settings.novelist_job_dir,
     "library": settings.library_job_dir,
+    "world_embedding": settings.world_embedding_job_dir,
 }
 
 class JobRef(BaseModel):

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -14,6 +14,7 @@ class Settings(BaseSettings):
     specialist_job_dir: str = "./data/specialist_jobs"
     novelist_job_dir: str = "./data/novelist_jobs"
     library_job_dir: str = "./data/library_jobs"
+    world_embedding_job_dir: str = "./data/world_embedding_jobs"
     celery_broker_url: str = "redis://localhost:6379/0"
     celery_result_backend: str = "redis://localhost:6379/0"
     vector_db_url: str = "localhost"

--- a/backend/app/crud/crud_world_embedding.py
+++ b/backend/app/crud/crud_world_embedding.py
@@ -4,24 +4,22 @@ from typing import List, Optional
 
 from datetime import datetime, timezone
 from app.models.model_world_embedding import WorldEmbedding
-from app.crud import crud_vectordb
 
 async def create_embedding(session: AsyncSession, embedding: WorldEmbedding) -> WorldEmbedding:
     session.add(embedding)
     await session.commit()
     await session.refresh(embedding)
+    return embedding
 
-    start = datetime.now(timezone.utc)
-    count = await crud_vectordb.rebuild_world(session, embedding.world_id, embedding.collection)
-    end = datetime.now(timezone.utc)
+async def get_embedding(session: AsyncSession, embedding_id: int) -> Optional[WorldEmbedding]:
+    return await session.get(WorldEmbedding, embedding_id)
 
+async def update_embedding_stats(session: AsyncSession, embedding: WorldEmbedding, count: int, start: datetime, end: datetime) -> None:
     embedding.last_index_time = end
     embedding.page_count = count
     embedding.build_seconds = (end - start).total_seconds()
     session.add(embedding)
     await session.commit()
-    await session.refresh(embedding)
-    return embedding
 
 async def get_embeddings(session: AsyncSession, world_id: int | None = None) -> List[WorldEmbedding]:
     stmt = select(WorldEmbedding)
@@ -37,3 +35,4 @@ async def delete_embedding(session: AsyncSession, embedding_id: int) -> bool:
     await session.delete(emb)
     await session.commit()
     return True
+

--- a/backend/app/task_queue.py
+++ b/backend/app/task_queue.py
@@ -336,6 +336,57 @@ def task_rebuild_library_vectors(item_id: int, job_id: str):
     asyncio.run(run())
 
 
+@celery_app.task
+def task_rebuild_world_embedding(embedding_id: int, job_id: str):
+    async def run():
+        job_dir = Path(settings.world_embedding_job_dir)
+        job_dir.mkdir(parents=True, exist_ok=True)
+        job_path = job_dir / f"{job_id}.json"
+        start_time = datetime.now(timezone.utc).isoformat()
+        with open(job_path, "w") as f:
+            json.dump({
+                "status": "processing",
+                "embedding_id": embedding_id,
+                "job_type": "rebuild_world_embedding",
+                "start_time": start_time,
+            }, f, default=str)
+
+        async with async_session_maker() as session:
+            from app.crud import crud_world_embedding
+            embedding = await crud_world_embedding.get_embedding(session, embedding_id)
+            if not embedding:
+                with open(job_path, "w") as ff:
+                    json.dump({"status": "error", "error": "Embedding not found", "start_time": start_time}, ff, default=str)
+                return
+            try:
+                t0 = datetime.now(timezone.utc)
+                count = await crud_vectordb.rebuild_world(session, embedding.world_id, embedding.collection)
+                t1 = datetime.now(timezone.utc)
+                embedding.last_index_time = t1
+                embedding.page_count = count
+                embedding.build_seconds = (t1 - t0).total_seconds()
+                session.add(embedding)
+                await session.commit()
+                await session.refresh(embedding)
+            except Exception as exc:
+                with open(job_path, "w") as ff:
+                    json.dump({"status": "error", "error": str(exc), "start_time": start_time}, ff, default=str)
+                raise
+
+        end_time = datetime.now(timezone.utc).isoformat()
+        with open(job_path, "w") as f:
+            json.dump({
+                "status": "done",
+                "embedding_id": embedding_id,
+                "job_type": "rebuild_world_embedding",
+                "pages_indexed": count,
+                "start_time": start_time,
+                "end_time": end_time,
+            }, f, default=str)
+
+    asyncio.run(run())
+
+
 
 
 @celery_app.task

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -11,8 +11,9 @@ async def test_list_and_delete_jobs(async_client, create_user, login_and_get_tok
     settings.specialist_job_dir = str(tmp_path / "specialist")
     settings.novelist_job_dir = str(tmp_path / "novelist")
     settings.library_job_dir = str(tmp_path / "library")
+    settings.world_embedding_job_dir = str(tmp_path / "embeddings")
 
-    for p in [settings.vectordb_job_dir, settings.writer_job_dir, settings.specialist_job_dir, settings.novelist_job_dir, settings.library_job_dir]:
+    for p in [settings.vectordb_job_dir, settings.writer_job_dir, settings.specialist_job_dir, settings.novelist_job_dir, settings.library_job_dir, settings.world_embedding_job_dir]:
         Path(p).mkdir(parents=True, exist_ok=True)
 
     # create sample job files
@@ -24,6 +25,8 @@ async def test_list_and_delete_jobs(async_client, create_user, login_and_get_tok
 
     novel_job = Path(settings.novelist_job_dir) / "n1.json"
     novel_job.write_text(json.dumps({"status": "error", "start_time": "2024"}))
+    embed_job = Path(settings.world_embedding_job_dir) / "e1.json"
+    embed_job.write_text(json.dumps({"status": "queued", "start_time": "2024"}))
 
     await create_user("admin@test.com", "pass", "system admin")
     token = await login_and_get_token("admin@test.com", "pass", "system admin")
@@ -33,6 +36,7 @@ async def test_list_and_delete_jobs(async_client, create_user, login_and_get_tok
     data = resp.json()
     assert any(j["job_id"] == "v1" and j["kind"] == "vectordb" for j in data)
     assert any(j["job_id"] == "w1" for j in data)
+    assert any(j["job_id"] == "e1" and j["kind"] == "world_embedding" for j in data)
 
     # attempt delete (should remove done and error but not running)
     delete_payload = {
@@ -40,6 +44,7 @@ async def test_list_and_delete_jobs(async_client, create_user, login_and_get_tok
             {"kind": "vectordb", "job_id": "v1"},
             {"kind": "novelist", "job_id": "n1"},
             {"kind": "writer", "job_id": "w1"},
+            {"kind": "world_embedding", "job_id": "e1"},
         ]
     }
     del_resp = await async_client.delete(
@@ -52,8 +57,10 @@ async def test_list_and_delete_jobs(async_client, create_user, login_and_get_tok
     assert {"kind": "vectordb", "job_id": "v1"} in res["deleted"]
     assert {"kind": "novelist", "job_id": "n1"} in res["deleted"]
     assert {"kind": "writer", "job_id": "w1"} not in res["deleted"]
+    assert {"kind": "world_embedding", "job_id": "e1"} not in res["deleted"]
 
     # ensure files deleted appropriately
     assert not vec_job.exists()
     assert not novel_job.exists()
     assert writer_job.exists()
+    assert embed_job.exists()

--- a/backend/tests/test_world_embedding.py
+++ b/backend/tests/test_world_embedding.py
@@ -1,5 +1,7 @@
 import pytest
 from unittest.mock import patch
+import json
+from pathlib import Path
 
 WORLD_BUILDER = {
     "nickname": "builder",
@@ -24,7 +26,7 @@ WRITER = {
 }
 
 @pytest.mark.anyio
-async def test_create_world_embedding(async_client, create_user, login_and_get_token):
+async def test_create_world_embedding(async_client, create_user, login_and_get_token, tmp_path):
     await create_user(**WORLD_BUILDER)
     await create_user(**ADMIN)
     await create_user(**WRITER)
@@ -48,12 +50,19 @@ async def test_create_world_embedding(async_client, create_user, login_and_get_t
         resp = await async_client.post("/pages/", json=page, headers={"Authorization": f"Bearer {writer_token}"})
         assert resp.status_code == 200
 
-    with patch("app.crud.crud_vectordb.rebuild_world", return_value=2) as rebuild:
+    from app.config import settings
+    settings.world_embedding_job_dir = str(tmp_path)
+    Path(settings.world_embedding_job_dir).mkdir(parents=True, exist_ok=True)
+
+    with patch("app.task_queue.task_rebuild_world_embedding.delay") as delay:
         payload = {"world_id": gw_id, "name": "base", "collection": f"world_{gw_id}_base"}
         resp = await async_client.post("/world_embeddings/", json=payload, headers={"Authorization": f"Bearer {admin_token}"})
+        assert delay.called
     assert resp.status_code == 200
     data = resp.json()
-    assert data["page_count"] == 2
-    assert data["build_seconds"] >= 0
-    assert data["last_index_time"] is not None
-    assert rebuild.called
+    assert data["page_count"] is None
+    job_files = list(Path(settings.world_embedding_job_dir).glob("*.json"))
+    assert len(job_files) == 1
+    with open(job_files[0]) as f:
+        job = json.load(f)
+    assert job["status"] == "queued"

--- a/frontend/src/app/lib/useWorldEmbeddingJobs.ts
+++ b/frontend/src/app/lib/useWorldEmbeddingJobs.ts
@@ -1,0 +1,14 @@
+import useSWR from "swr";
+import { listWorldEmbeddingJobs } from "./worldEmbeddingAPI";
+import { useAuth } from "../components/auth/AuthProvider";
+
+export function useWorldEmbeddingJobs() {
+  const { token } = useAuth();
+  const fetcher = () => listWorldEmbeddingJobs(token || "");
+  const { data, error, mutate } = useSWR(
+    token ? ["world-embedding-jobs", token] : null,
+    fetcher,
+    { refreshInterval: 2000 }
+  );
+  return { jobs: data || [], error, mutate };
+}

--- a/frontend/src/app/lib/worldEmbeddingAPI.ts
+++ b/frontend/src/app/lib/worldEmbeddingAPI.ts
@@ -30,6 +30,23 @@ export async function deleteWorldEmbedding(id: number, token: string) {
   return await res.json();
 }
 
+export async function startWorldEmbeddingJob(id: number, token: string) {
+  const res = await fetch(`${API_URL}/world_embeddings/${id}/embed_async`, {
+    method: "POST",
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) throw await res.text();
+  return await res.json();
+}
+
+export async function listWorldEmbeddingJobs(token: string) {
+  const res = await fetch(`${API_URL}/world_embeddings/vector_jobs`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) throw await res.text();
+  return await res.json();
+}
+
 export async function getAgentEmbeddings(agentId: number, token: string) {
   const res = await fetch(`${API_URL}/world_embeddings/agents/${agentId}`, {
     headers: token ? { Authorization: `Bearer ${token}` } : {},

--- a/frontend/src/app/world_embeddings/page.tsx
+++ b/frontend/src/app/world_embeddings/page.tsx
@@ -5,13 +5,15 @@ import { useAuth } from "../components/auth/AuthProvider";
 import useRoleRedirect from "../hooks/useRoleRedirect";
 import { useWorlds } from "../lib/userWorlds";
 import { useWorldEmbeddings } from "../lib/useWorldEmbeddings";
-import { createWorldEmbedding, deleteWorldEmbedding } from "../lib/worldEmbeddingAPI";
+import { createWorldEmbedding, deleteWorldEmbedding, startWorldEmbeddingJob } from "../lib/worldEmbeddingAPI";
+import { useWorldEmbeddingJobs } from "../lib/useWorldEmbeddingJobs";
 import { useState } from "react";
 
 export default function WorldEmbeddingsPage() {
   const { token } = useAuth();
   const { worlds } = useWorlds();
   const { embeddings, mutate } = useWorldEmbeddings();
+  const { jobs, mutate: refreshJobs } = useWorldEmbeddingJobs();
   const [worldId, setWorldId] = useState("");
   const [name, setName] = useState("");
   const allowed = useRoleRedirect("system admin");
@@ -23,6 +25,7 @@ export default function WorldEmbeddingsPage() {
     await createWorldEmbedding({ world_id: Number(worldId), name, collection: `world_${worldId}_${name}` }, token||"" );
     setName("");
     mutate();
+    refreshJobs();
   }
 
   async function handleDelete(id:number) {
@@ -57,6 +60,23 @@ export default function WorldEmbeddingsPage() {
               ))}
             </tbody>
           </table>
+          {jobs.length > 0 && (
+            <div className="mt-8">
+              <h2 className="text-xl font-semibold mb-2">Embedding Jobs</h2>
+              <table className="w-full border text-sm">
+                <thead><tr><th>ID</th><th>Status</th><th>Embedding</th></tr></thead>
+                <tbody>
+                  {jobs.map((j:any)=>(
+                    <tr key={j.job_id} className="border-t">
+                      <td className="px-2 font-mono">{j.job_id}</td>
+                      <td className="px-2">{j.status}</td>
+                      <td className="px-2">{j.embedding_id}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
         </div>
       </DashboardLayout>
     </AuthGuard>


### PR DESCRIPTION
## Summary
- enable background job support for world embeddings
- start rebuild job on world embedding creation
- expose world embedding job APIs
- display world embedding job list in frontend
- keep track of jobs in global job list

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and multiple assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_6887dc633f74832294d10cc48c81beaa