### PR TITLE
Improve chat agent embedding validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Shrecknet is a collaborative world building and story telling platform. It mixes
 - **CRM like wiki** with Worlds, Concepts, Characteristics and Pages
 - **Automatic cross linking** and vector search powered by Celery workers
 - **Conversational, Specialist, Writer and Novelist AI agents**
+- **Optional world embeddings** can be linked to agents to provide extra lore
 - Import/export utilities and example data
 - Docker based development environment
 

--- a/backend/app/crud/crud_agent.py
+++ b/backend/app/crud/crud_agent.py
@@ -70,7 +70,16 @@ async def chat_with_agent(
     query = messages[-1].get("content", "") if messages else ""
     world = await session.get(GameWorld, agent.world_id)
     embeddings = await crud_agent_embedding.get_embeddings(session, agent_id)
-    collections = [e.collection for e in embeddings] or [None]
+    valid_embeds = [e for e in embeddings if e.last_index_time]
+    if not valid_embeds:
+        return {
+            "answer": (
+                "The agent stares into the abyss, lacking any forged lore. "
+                "Craft world embeddings before seeking its counsel!"
+            ),
+            "sources": [],
+        }
+    collections = [e.collection for e in valid_embeds]
 
     # Run step 1 and 2 concurrently: extract query structure + load pages/concepts
     async def extract_query_structure():


### PR DESCRIPTION
## Summary
- ensure `chat_with_agent` checks that any associated world embeddings were built
- document world embedding feature

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6887e137b56883229bfbfa5e0474537a