### PR TITLE
Add world embedding editing UI

### DIFF
--- a/backend/app/api/api_embedding.py
+++ b/backend/app/api/api_embedding.py
@@ -9,7 +9,11 @@ import json
 from app.config import settings
 from app.task_queue import task_rebuild_world_embedding
 from app.models.model_user import User, UserRole
-from app.schemas.schema_world_embedding import WorldEmbedding, WorldEmbeddingCreate
+from app.schemas.schema_world_embedding import (
+    WorldEmbedding,
+    WorldEmbeddingCreate,
+    WorldEmbeddingUpdate,
+)
 from app.models.model_world_embedding import WorldEmbedding as WorldEmbeddingModel
 from app.dependencies import get_current_user, require_role
 
@@ -56,6 +60,21 @@ async def delete_embedding(
     if not ok:
         raise HTTPException(status_code=404, detail="Embedding not found")
     return {"ok": True}
+
+
+@router.patch("/{embedding_id}", response_model=WorldEmbedding)
+async def update_embedding_endpoint(
+    embedding_id: int,
+    updates: WorldEmbeddingUpdate,
+    user: User = Depends(require_role(UserRole.system_admin)),
+    session: AsyncSession = Depends(get_session),
+):
+    embedding = await crud_world_embedding.update_embedding(
+        session, embedding_id, updates.model_dump(exclude_unset=True)
+    )
+    if not embedding:
+        raise HTTPException(status_code=404, detail="Embedding not found")
+    return embedding
 
 
 @router.post("/{embedding_id}/embed_async")

--- a/backend/app/crud/crud_world_embedding.py
+++ b/backend/app/crud/crud_world_embedding.py
@@ -36,3 +36,14 @@ async def delete_embedding(session: AsyncSession, embedding_id: int) -> bool:
     await session.commit()
     return True
 
+async def update_embedding(session: AsyncSession, embedding_id: int, updates: dict) -> Optional[WorldEmbedding]:
+    emb = await session.get(WorldEmbedding, embedding_id)
+    if not emb:
+        return None
+    for key, value in updates.items():
+        setattr(emb, key, value)
+    session.add(emb)
+    await session.commit()
+    await session.refresh(emb)
+    return emb
+

--- a/backend/app/schemas/schema_world_embedding.py
+++ b/backend/app/schemas/schema_world_embedding.py
@@ -13,6 +13,12 @@ class WorldEmbeddingCreate(WorldEmbeddingBase):
     pass
 
 
+class WorldEmbeddingUpdate(BaseModel):
+    world_id: Optional[int] = None
+    name: Optional[str] = None
+    collection: Optional[str] = None
+
+
 class WorldEmbedding(WorldEmbeddingBase):
     id: int
     created_at: datetime

--- a/backend/tests/test_world_embedding.py
+++ b/backend/tests/test_world_embedding.py
@@ -66,3 +66,25 @@ async def test_create_world_embedding(async_client, create_user, login_and_get_t
     with open(job_files[0]) as f:
         job = json.load(f)
     assert job["status"] == "queued"
+
+
+@pytest.mark.anyio
+async def test_update_world_embedding(async_client, create_user, login_and_get_token):
+    await create_user(**ADMIN)
+    token = await login_and_get_token(ADMIN["email"], ADMIN["password"], ADMIN["role"])
+
+    gw_payload = {"name": "UpdateWorld", "system": "sys", "description": "d", "logo": "logo"}
+    resp = await async_client.post("/gameworlds/", json=gw_payload, headers={"Authorization": f"Bearer {token}"})
+    gw_id = resp.json()["id"]
+
+    payload = {"world_id": gw_id, "name": "base", "collection": f"world_{gw_id}_base"}
+    resp = await async_client.post("/world_embeddings/", json=payload, headers={"Authorization": f"Bearer {token}"})
+    emb_id = resp.json()["id"]
+
+    resp = await async_client.patch(
+        f"/world_embeddings/{emb_id}",
+        json={"name": "changed"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "changed"

--- a/frontend/src/app/components/world_embeddings/WorldEmbeddingModal.tsx
+++ b/frontend/src/app/components/world_embeddings/WorldEmbeddingModal.tsx
@@ -1,0 +1,79 @@
+"use client";
+import { useState } from "react";
+import ModalContainer from "../template/modalContainer";
+import { M3FloatingInput } from "../template/M3FloatingInput";
+import { useAuth } from "../auth/AuthProvider";
+import { updateWorldEmbedding } from "../../lib/worldEmbeddingAPI";
+
+export default function WorldEmbeddingModal({ embedding, worlds, onClose, onSaved }) {
+  const [form, setForm] = useState({
+    world_id: embedding.world_id,
+    name: embedding.name,
+    collection: embedding.collection,
+  });
+  const { token } = useAuth();
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleSubmit(e: any) {
+    e.preventDefault();
+    setSaving(true);
+    setError("");
+    try {
+      await updateWorldEmbedding(embedding.id, form, token || "");
+      onSaved?.();
+      onClose();
+    } catch (err: any) {
+      setError(err?.detail || err?.message || String(err));
+    }
+    setSaving(false);
+  }
+
+  return (
+    <ModalContainer title="Edit Embedding" onClose={onClose}>
+      {error && (
+        <div className="bg-red-100 text-red-700 rounded-lg px-3 py-2 mb-3 text-sm">{error}</div>
+      )}
+      <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
+        <select
+          value={form.world_id}
+          onChange={e => setForm({ ...form, world_id: Number(e.target.value) })}
+          className="border px-3 py-2 rounded-xl"
+        >
+          {worlds.map((w:any) => (
+            <option key={w.id} value={w.id}>{w.name}</option>
+          ))}
+        </select>
+        <M3FloatingInput
+          label="Name"
+          value={form.name}
+          onChange={e => setForm({ ...form, name: e.target.value })}
+          required
+        />
+        <M3FloatingInput
+          label="Collection"
+          value={form.collection}
+          onChange={e => setForm({ ...form, collection: e.target.value })}
+          required
+        />
+        <div className="flex flex-row-reverse gap-3 mt-3">
+          <button
+            type="submit"
+            className="px-7 py-2 rounded-xl font-bold bg-purple-600 text-white shadow-md"
+            disabled={saving}
+          >
+            {saving ? "Saving..." : "Save"}
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={saving}
+            className="px-6 py-2 rounded-xl font-semibold border"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </ModalContainer>
+  );
+}

--- a/frontend/src/app/lib/worldEmbeddingAPI.ts
+++ b/frontend/src/app/lib/worldEmbeddingAPI.ts
@@ -21,6 +21,19 @@ export async function createWorldEmbedding(data: any, token: string) {
   return await res.json();
 }
 
+export async function updateWorldEmbedding(id: number, data: any, token: string) {
+  const res = await fetch(`${API_URL}/world_embeddings/${id}`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw await res.text();
+  return await res.json();
+}
+
 export async function deleteWorldEmbedding(id: number, token: string) {
   const res = await fetch(`${API_URL}/world_embeddings/${id}`, {
     method: "DELETE",

--- a/frontend/src/app/world_embeddings/page.tsx
+++ b/frontend/src/app/world_embeddings/page.tsx
@@ -8,7 +8,8 @@ import { useWorldEmbeddings } from "../lib/useWorldEmbeddings";
 import { createWorldEmbedding, deleteWorldEmbedding, startWorldEmbeddingJob } from "../lib/worldEmbeddingAPI";
 import { useWorldEmbeddingJobs } from "../lib/useWorldEmbeddingJobs";
 import { useState } from "react";
-import { Sparkles, BookOpen, Trash2, Globe } from "lucide-react";
+import { Sparkles, BookOpen, Trash2, Globe, Pencil } from "lucide-react";
+import WorldEmbeddingModal from "../components/world_embeddings/WorldEmbeddingModal";
 
 export default function WorldEmbeddingsPage() {
   const { token } = useAuth();
@@ -18,6 +19,7 @@ export default function WorldEmbeddingsPage() {
   const [worldId, setWorldId] = useState("");
   const [name, setName] = useState("");
   const [deletingId, setDeletingId] = useState<number | null>(null);
+  const [editing, setEditing] = useState<any | null>(null);
   const allowed = useRoleRedirect("system admin");
   if (!allowed) return null;
 
@@ -43,6 +45,20 @@ export default function WorldEmbeddingsPage() {
     await deleteWorldEmbedding(id, token || "");
     setDeletingId(null);
     mutate();
+  }
+
+  function openEdit(e: any) {
+    setEditing(e);
+  }
+
+  function closeEdit() {
+    setEditing(null);
+    mutate();
+  }
+
+  async function handleRebuild(id: number) {
+    await startWorldEmbeddingJob(id, token || "");
+    refreshJobs();
   }
 
   function getWorldName(id: number) {
@@ -101,15 +117,22 @@ export default function WorldEmbeddingsPage() {
             </button>
           </form>
 
-          <table className="w-full border">
-            <thead><tr><th>ID</th><th>Name</th><th>World</th><th></th></tr></thead>
+          <table className="w-full border text-sm">
+            <thead><tr><th>ID</th><th>Name</th><th>World</th><th>Pages</th><th>Last Build</th><th>Time</th><th></th></tr></thead>
             <tbody>
               {embeddings.map((e:any)=>(
                 <tr key={e.id} className="border-t">
                   <td className="px-2">{e.id}</td>
                   <td className="px-2">{e.name}</td>
-                  <td className="px-2">{e.world_id}</td>
-                  <td className="px-2"><button onClick={()=>handleDelete(e.id)} className="text-red-600">Delete</button></td>
+                  <td className="px-2">{getWorldName(e.world_id)}</td>
+                  <td className="px-2">{e.page_count ?? 'None'}</td>
+                  <td className="px-2">{e.last_index_time ? new Date(e.last_index_time).toLocaleString() : 'Never'}</td>
+                  <td className="px-2">{e.build_seconds ? `${e.build_seconds}s` : '-'}</td>
+                  <td className="px-2 flex gap-2">
+                    <button onClick={()=>openEdit(e)} className="text-blue-600">Edit</button>
+                    <button onClick={()=>handleRebuild(e.id)} className="text-purple-600">Rebuild</button>
+                    <button onClick={()=>handleDelete(e.id)} className="text-red-600">Delete</button>
+                  </td>
                 </tr>
               ))}
             </tbody>
@@ -142,6 +165,13 @@ export default function WorldEmbeddingsPage() {
               >
                 <div className="absolute top-3 right-3 flex gap-2">
                   <button
+                    className="rounded-full bg-blue-100 hover:bg-blue-300 dark:bg-blue-900 dark:hover:bg-blue-700 p-2 shadow text-blue-600 dark:text-blue-300 transition"
+                    title="Edit"
+                    onClick={() => openEdit(e)}
+                  >
+                    <Pencil className="w-5 h-5" />
+                  </button>
+                  <button
                     className="rounded-full bg-red-100 hover:bg-red-300 dark:bg-red-900 dark:hover:bg-red-700 p-2 shadow text-red-600 dark:text-red-300 transition"
                     title="Shatter Crystal"
                     disabled={deletingId === e.id}
@@ -165,6 +195,15 @@ export default function WorldEmbeddingsPage() {
                 <div className="text-xs text-purple-800/70 dark:text-purple-100/70 mt-2">
                   Codex Entry ID: <span className="font-mono">{e.id}</span>
                 </div>
+                <div className="text-xs mt-1">Pages: {e.page_count ?? 'None'}</div>
+                <div className="text-xs mt-1">Last Build: {e.last_index_time ? new Date(e.last_index_time).toLocaleString() : 'Never'}</div>
+                <div className="text-xs mt-1">Build Time: {e.build_seconds ? `${e.build_seconds}s` : '-'}</div>
+                <button
+                  className="mt-2 px-3 py-1 rounded-xl bg-purple-600 text-white text-sm hover:bg-purple-700"
+                  onClick={() => handleRebuild(e.id)}
+                >
+                  Rebuild
+                </button>
               </div>
             ))}
             {embeddings.length === 0 && (
@@ -176,6 +215,14 @@ export default function WorldEmbeddingsPage() {
 
         </div>
       </DashboardLayout>
+      {editing && (
+        <WorldEmbeddingModal
+          embedding={editing}
+          worlds={worlds}
+          onClose={closeEdit}
+          onSaved={closeEdit}
+        />
+      )}
     </AuthGuard>
   );
 }


### PR DESCRIPTION
## Summary
- allow editing world embedding models via PATCH API
- track metadata fields with a new `WorldEmbeddingUpdate` schema
- expose update route in backend
- provide modal component in frontend for editing
- show detailed info and rebuild button on world embeddings page

## Testing
- `pytest tests/test_world_embedding.py::test_update_world_embedding -q` *(fails: ModuleNotFoundError: No module named 'langchain_openai')*

------
https://chatgpt.com/codex/tasks/task_e_6887e5af172c8322833c0937df1b6ffd