### PR TITLE
Simplify world embedding storage

### DIFF
--- a/backend/app/crud/crud_page_analysis.py
+++ b/backend/app/crud/crud_page_analysis.py
@@ -71,13 +71,13 @@ async def _query_agent_world(
     embeddings = await _get_agent_embeddings(session, agent)
     for emb in embeddings:
         try:
-            parts = crud_vectordb.query_world(
+            parts = crud_vectordb.query_embedding(
+                emb.id,
                 agent.world_id,
                 query,
                 n_results=n_results,
                 views=views,
                 filters=filters,
-                collection=emb.collection,
             )
             chunks.extend(parts)
         except Exception:

--- a/backend/app/crud/crud_vectordb.py
+++ b/backend/app/crud/crud_vectordb.py
@@ -105,6 +105,15 @@ def _get_collection(world_id: int, collection: str | None = None):
         embedding_function=_embedding_fn,
     )
 
+def _get_embedding_collection(embedding_id: int) -> Chroma:
+    name = f"embedding_{embedding_id}"
+    client = get_chroma_client()
+    return Chroma(
+        client=client,
+        collection_name=name,
+        embedding_function=_embedding_fn,
+    )
+
 def _normalize_view_name(view: str) -> str:
     return view.lower().replace(" ", "_")
 
@@ -269,6 +278,9 @@ async def add_page(session: AsyncSession, page_id: int, collection: str | None =
     _safe_add_documents(collection, all_chunks)
     return True
 
+async def add_embedding_page(session: AsyncSession, page_id: int, embedding_id: int):
+    return await add_page(session, page_id, f"embedding_{embedding_id}")
+
 async def rebuild_world(session: AsyncSession, world_id: int, collection: str | None = None):
     name = collection or f"world_{world_id}"
     collection_obj = _get_collection(world_id, collection)
@@ -288,6 +300,19 @@ async def rebuild_world(session: AsyncSession, world_id: int, collection: str | 
     for agent in agents:
         agent.vector_db_update_date = now
     await session.commit()
+
+    return len(page_ids)
+
+async def rebuild_embedding(session: AsyncSession, world_id: int, embedding_id: int) -> int:
+    name = f"embedding_{embedding_id}"
+    collection_obj = _get_embedding_collection(embedding_id)
+    _delete_collection(name, collection_obj)
+
+    result = await session.execute(select(Page.id).where(Page.gameworld_id == world_id))
+    page_ids = [row[0] for row in result.all()]
+
+    for batch in chunked(page_ids, 20):
+        await asyncio.gather(*(add_embedding_page(session, pid, embedding_id) for pid in batch))
 
     return len(page_ids)
 
@@ -402,6 +427,25 @@ def query_world(
     )
 
     return results[:n_results]
+
+def query_embedding(
+    embedding_id: int,
+    world_id: int,
+    query: str,
+    n_results: int = 5,
+    views: Optional[List[str]] = None,
+    filters: Optional[Dict] = None,
+    max_chunks_per_page: Optional[int] = 15,
+) -> List[Dict]:
+    return query_world(
+        world_id,
+        query,
+        n_results=n_results,
+        views=views,
+        filters=filters,
+        collection=f"embedding_{embedding_id}",
+        max_chunks_per_page=max_chunks_per_page,
+    )
 
 
 # def query_world(world_id: int, query: str, n_results: int = 5) -> List[Dict]:

--- a/backend/app/crud/crud_world_embedding.py
+++ b/backend/app/crud/crud_world_embedding.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 
 from datetime import datetime, timezone
 from app.models.model_world_embedding import WorldEmbedding
+from app.crud.crud_vectordb import _delete_collection, _get_embedding_collection
 
 async def create_embedding(session: AsyncSession, embedding: WorldEmbedding) -> WorldEmbedding:
     session.add(embedding)
@@ -32,6 +33,9 @@ async def delete_embedding(session: AsyncSession, embedding_id: int) -> bool:
     emb = await session.get(WorldEmbedding, embedding_id)
     if not emb:
         return False
+    # Remove associated vectors
+    collection = _get_embedding_collection(embedding_id)
+    _delete_collection(f"embedding_{embedding_id}", collection)
     await session.delete(emb)
     await session.commit()
     return True

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -90,7 +90,7 @@ def _migrate(conn):
     # -- WorldEmbedding table --
     if "worldembedding" not in inspector.get_table_names():
         conn.execute(text(
-            "CREATE TABLE worldembedding (id INTEGER PRIMARY KEY AUTOINCREMENT, world_id INTEGER NOT NULL REFERENCES gameworld(id), name TEXT NOT NULL, collection TEXT NOT NULL, created_at DATETIME NOT NULL, last_index_time DATETIME, page_count INTEGER, build_seconds REAL)"
+            "CREATE TABLE worldembedding (id INTEGER PRIMARY KEY AUTOINCREMENT, world_id INTEGER NOT NULL REFERENCES gameworld(id), name TEXT NOT NULL, created_at DATETIME NOT NULL, last_index_time DATETIME, page_count INTEGER, build_seconds REAL)"
         ))
     else:
         columns = [c["name"] for c in inspector.get_columns("worldembedding")]

--- a/backend/app/models/model_world_embedding.py
+++ b/backend/app/models/model_world_embedding.py
@@ -6,7 +6,6 @@ class WorldEmbedding(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     world_id: int = Field(foreign_key="gameworld.id")
     name: str
-    collection: str
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     last_index_time: Optional[datetime] = None
     page_count: Optional[int] = None

--- a/backend/app/schemas/schema_world_embedding.py
+++ b/backend/app/schemas/schema_world_embedding.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel
 class WorldEmbeddingBase(BaseModel):
     world_id: int
     name: str
-    collection: str
 
 
 class WorldEmbeddingCreate(WorldEmbeddingBase):
@@ -16,7 +15,6 @@ class WorldEmbeddingCreate(WorldEmbeddingBase):
 class WorldEmbeddingUpdate(BaseModel):
     world_id: Optional[int] = None
     name: Optional[str] = None
-    collection: Optional[str] = None
 
 
 class WorldEmbedding(WorldEmbeddingBase):

--- a/backend/app/task_queue.py
+++ b/backend/app/task_queue.py
@@ -363,7 +363,7 @@ def task_rebuild_world_embedding(embedding_id: int, job_id: str):
                 return
             try:
                 t0 = datetime.now(timezone.utc)
-                count = await crud_vectordb.rebuild_world(session, embedding.world_id, embedding.collection)
+                count = await crud_vectordb.rebuild_embedding(session, embedding.world_id, embedding.id)
                 t1 = datetime.now(timezone.utc)
                 embedding.last_index_time = t1
                 embedding.page_count = count

--- a/backend/tests/test_world_embedding.py
+++ b/backend/tests/test_world_embedding.py
@@ -55,7 +55,7 @@ async def test_create_world_embedding(async_client, create_user, login_and_get_t
     Path(settings.world_embedding_job_dir).mkdir(parents=True, exist_ok=True)
 
     with patch("app.task_queue.task_rebuild_world_embedding.delay") as delay:
-        payload = {"world_id": gw_id, "name": "base", "collection": f"world_{gw_id}_base"}
+        payload = {"world_id": gw_id, "name": "base"}
         resp = await async_client.post("/world_embeddings/", json=payload, headers={"Authorization": f"Bearer {admin_token}"})
         assert delay.called
     assert resp.status_code == 200
@@ -77,7 +77,7 @@ async def test_update_world_embedding(async_client, create_user, login_and_get_t
     resp = await async_client.post("/gameworlds/", json=gw_payload, headers={"Authorization": f"Bearer {token}"})
     gw_id = resp.json()["id"]
 
-    payload = {"world_id": gw_id, "name": "base", "collection": f"world_{gw_id}_base"}
+    payload = {"world_id": gw_id, "name": "base"}
     resp = await async_client.post("/world_embeddings/", json=payload, headers={"Authorization": f"Bearer {token}"})
     emb_id = resp.json()["id"]
 

--- a/frontend/src/app/components/world_embeddings/WorldEmbeddingModal.tsx
+++ b/frontend/src/app/components/world_embeddings/WorldEmbeddingModal.tsx
@@ -9,7 +9,6 @@ export default function WorldEmbeddingModal({ embedding, worlds, onClose, onSave
   const [form, setForm] = useState({
     world_id: embedding.world_id,
     name: embedding.name,
-    collection: embedding.collection,
   });
   const { token } = useAuth();
   const [saving, setSaving] = useState(false);
@@ -48,12 +47,6 @@ export default function WorldEmbeddingModal({ embedding, worlds, onClose, onSave
           label="Name"
           value={form.name}
           onChange={e => setForm({ ...form, name: e.target.value })}
-          required
-        />
-        <M3FloatingInput
-          label="Collection"
-          value={form.collection}
-          onChange={e => setForm({ ...form, collection: e.target.value })}
           required
         />
         <div className="flex flex-row-reverse gap-3 mt-3">

--- a/frontend/src/app/world_embeddings/page.tsx
+++ b/frontend/src/app/world_embeddings/page.tsx
@@ -45,7 +45,6 @@ export default function WorldEmbeddingsPage() {
       {
         world_id: Number(worldId),
         name,
-        collection: `world_${worldId}_${name}`,
       },
       token || ""
     );


### PR DESCRIPTION
## Summary
- drop `collection` field from world embedding model and schema
- update CRUD and tasks to manage embeddings via `embedding_<id>` collections
- remove collection inputs from the frontend
- clean up vector store when deleting an embedding
- adjust tests accordingly

## Testing
- `python -m py_compile backend/app/**/*.py`
- `pytest -q` *(fails: ModuleNotFoundError: pydantic_settings)*

------
https://chatgpt.com/codex/tasks/task_e_68891d0080608322a6c1d8803e16ad3c