### PR TITLE
Fix embedding chat and cleanup vectordb

### DIFF
--- a/backend/app/api/api_agent.py
+++ b/backend/app/api/api_agent.py
@@ -240,7 +240,12 @@ async def chat_test(
         raise HTTPException(status_code=400, detail="Agent unavailable")
 
     query = msgs[-1].get("content", "") if msgs else ""
-    docs = crud_vectordb.query_world(agent.world_id, query, n_results=4)
+    from app.crud import crud_agent_embedding
+    embeddings = await crud_agent_embedding.get_embeddings(session, agent_id)
+    valid_embeds = [e for e in embeddings if e.last_index_time]
+    if not valid_embeds:
+        raise HTTPException(status_code=400, detail="Agent unavailable")
+    docs = crud_vectordb.query_world(valid_embeds[0].id, query, n_results=4)
     return {"documents": docs}
 
 

--- a/backend/app/api/api_vectordb.py
+++ b/backend/app/api/api_vectordb.py
@@ -7,21 +7,25 @@ from app.crud import crud_vectordb
 router = APIRouter(prefix="/vectordb", tags=["VectorDB"])
 
 
-@router.post("/{world_id}/rebuild")
-async def rebuild_world_vector(world_id: int, session: AsyncSession = Depends(get_session)):    
-    count = await crud_vectordb.rebuild_world(session, world_id)
+@router.post("/{embedding_id}/rebuild")
+async def rebuild_embedding_vector(embedding_id: int, session: AsyncSession = Depends(get_session)):
+    from app.crud import crud_world_embedding
+    embedding = await crud_world_embedding.get_embedding(session, embedding_id)
+    if not embedding:
+        raise HTTPException(status_code=404, detail="Embedding not found")
+    count = await crud_vectordb.rebuild_embedding(session, embedding.world_id, embedding_id)
     return {"pages_indexed": count}
 
 
-@router.post("/{world_id}/add_page/{page_id}")
-async def add_page(world_id: int, page_id: int, session: AsyncSession = Depends(get_session)):
-    ok = await crud_vectordb.add_page(session, page_id)
+@router.post("/{embedding_id}/add_page/{page_id}")
+async def add_page(embedding_id: int, page_id: int, session: AsyncSession = Depends(get_session)):
+    ok = await crud_vectordb.add_page(session, page_id, embedding_id)
     if not ok:
         raise HTTPException(status_code=404, detail="Page not found")
     return {"indexed": True}
 
 
-@router.get("/{world_id}/search")
-async def search_world(world_id: int, q: str = Query(..., alias="query"), n: int = 5):
-    results = crud_vectordb.query_world(world_id, q, n_results=n)
+@router.get("/{embedding_id}/search")
+async def search_world(embedding_id: int, q: str = Query(..., alias="query"), n: int = 5):
+    results = crud_vectordb.query_world(embedding_id, q, n_results=n)
     return results

--- a/backend/app/crud/crud_agent.py
+++ b/backend/app/crud/crud_agent.py
@@ -64,19 +64,17 @@ async def async_query_all_embeddings(
     """
     embeddings = await crud_agent_embedding.get_embeddings(session, agent.id)
     valid_embeds = [e for e in embeddings if e.last_index_time]
-    collections = [e.collection for e in valid_embeds]
     tasks = [
         asyncio.to_thread(
             crud_vectordb.query_world,
-            agent.world_id,
+            emb.id,
             query,
             n_results,
             views,
             None,  # No filters
-            coll,
             max_chunks_per_page,
         )
-        for coll in collections
+        for emb in valid_embeds
     ]
     all_results = await asyncio.gather(*tasks)
     print (f"RESULTS: {all_results}")

--- a/backend/app/crud/crud_page_analysis.py
+++ b/backend/app/crud/crud_page_analysis.py
@@ -71,9 +71,8 @@ async def _query_agent_world(
     embeddings = await _get_agent_embeddings(session, agent)
     for emb in embeddings:
         try:
-            parts = crud_vectordb.query_embedding(
+            parts = crud_vectordb.query_world(
                 emb.id,
-                agent.world_id,
                 query,
                 n_results=n_results,
                 views=views,

--- a/backend/app/crud/crud_vectordb.py
+++ b/backend/app/crud/crud_vectordb.py
@@ -96,15 +96,6 @@ def _delete_collection(name: str, _client) -> None:
 def get_chroma_client():
     return chromadb.HttpClient(host=chromadbURL, port=chromadbPort)
 
-def _get_collection(world_id: int, collection: str | None = None):
-    name = collection or f"world_{world_id}"
-    client = get_chroma_client()
-    return Chroma(
-        client=client,
-        collection_name=name,
-        embedding_function=_embedding_fn,
-    )
-
 def _get_embedding_collection(embedding_id: int) -> Chroma:
     name = f"embedding_{embedding_id}"
     client = get_chroma_client()
@@ -150,7 +141,7 @@ def _safe_add_documents(collection: Chroma, docs: List[Document]) -> None:
     for i in range(0, len(docs), max_size):
         _add_batch(docs[i: i + max_size])
 
-async def add_page(session: AsyncSession, page_id: int, collection: str | None = None):
+async def add_page(session: AsyncSession, page_id: int, embedding_id: int):
     # Fetch the page
     result = await session.execute(select(Page).where(Page.id == page_id))
     page = result.scalar_one_or_none()
@@ -256,7 +247,7 @@ async def add_page(session: AsyncSession, page_id: int, collection: str | None =
     #     })
 
     # ---- Prepare chunks for vectorstore ----
-    collection = _get_collection(page.gameworld_id, collection)
+    collection = _get_embedding_collection(embedding_id)
     all_chunks = []
 
     for chunk_obj in narrative_chunks:
@@ -278,30 +269,6 @@ async def add_page(session: AsyncSession, page_id: int, collection: str | None =
     _safe_add_documents(collection, all_chunks)
     return True
 
-async def add_embedding_page(session: AsyncSession, page_id: int, embedding_id: int):
-    return await add_page(session, page_id, f"embedding_{embedding_id}")
-
-async def rebuild_world(session: AsyncSession, world_id: int, collection: str | None = None):
-    name = collection or f"world_{world_id}"
-    collection_obj = _get_collection(world_id, collection)
-    _delete_collection(name, collection_obj)
-
-    result = await session.execute(select(Page.id).where(Page.gameworld_id == world_id))
-    page_ids = [row[0] for row in result.all()]
-
-
-    for batch in chunked(page_ids, 20):
-        await asyncio.gather(*(add_page(session, pid, collection) for pid in batch))
-    
-
-    agent_result = await session.execute(select(Agent).where(Agent.world_id == world_id))
-    agents = agent_result.scalars().all()
-    now = datetime.now(timezone.utc)
-    for agent in agents:
-        agent.vector_db_update_date = now
-    await session.commit()
-
-    return len(page_ids)
 
 async def rebuild_embedding(session: AsyncSession, world_id: int, embedding_id: int) -> int:
     name = f"embedding_{embedding_id}"
@@ -312,18 +279,17 @@ async def rebuild_embedding(session: AsyncSession, world_id: int, embedding_id: 
     page_ids = [row[0] for row in result.all()]
 
     for batch in chunked(page_ids, 20):
-        await asyncio.gather(*(add_embedding_page(session, pid, embedding_id) for pid in batch))
+        await asyncio.gather(*(add_page(session, pid, embedding_id) for pid in batch))
 
     return len(page_ids)
 
 
 def query_world(
-    world_id: int,
+    embedding_id: int,
     query: str,
     n_results: int = 5,
     views: Optional[List[str]] = None,
     filters: Optional[Dict] = None,
-    collection: str | None = None,
     max_chunks_per_page: Optional[int] = 15,  # Set to 0 or None for unlimited
 ) -> List[Dict]:
     """
@@ -333,7 +299,7 @@ def query_world(
       - highlights: list of individual chunks with metadata
       - ...page-level metadata
     """
-    collection_obj = _get_collection(world_id, collection)
+    collection_obj = _get_embedding_collection(embedding_id)
 
     # --- Build filter for Chroma/your vectorstore ---
     conditions = []
@@ -356,7 +322,7 @@ def query_world(
     # --- Query vectorstore ---
     # With a 128k LLM window and pages max 8k tokens, we can return up to 8 chunks per page by default
     # If you want to further optimize, you can dynamically adjust max_chunks_per_page based on actual chunk lengths
-    print (f"CRUD_VECTOR Collection: {collection} - WORLD ID: {world_id}")
+    print (f"CRUD_VECTOR Embedding: {embedding_id}")
     print (f"CRUD_VECTOR  chroma_filter: {chroma_filter}")
     retrieved = collection_obj.max_marginal_relevance_search(
         query,
@@ -428,24 +394,9 @@ def query_world(
 
     return results[:n_results]
 
-def query_embedding(
-    embedding_id: int,
-    world_id: int,
-    query: str,
-    n_results: int = 5,
-    views: Optional[List[str]] = None,
-    filters: Optional[Dict] = None,
-    max_chunks_per_page: Optional[int] = 15,
-) -> List[Dict]:
-    return query_world(
-        world_id,
-        query,
-        n_results=n_results,
-        views=views,
-        filters=filters,
-        collection=f"embedding_{embedding_id}",
-        max_chunks_per_page=max_chunks_per_page,
-    )
+def query_embedding(*args, **kwargs):
+    """Deprecated alias for ``query_world``."""
+    return query_world(*args, **kwargs)
 
 
 # def query_world(world_id: int, query: str, n_results: int = 5) -> List[Dict]:

--- a/backend/app/task_queue.py
+++ b/backend/app/task_queue.py
@@ -210,7 +210,11 @@ def task_rebuild_vectordb(agent_id: int, job_id: str):
                 print (f" --- CALCUALTING SUGGESTIONS3 --- ")
                 print (f" --- CALCUALTING SUGGESTIONS3 --- ")
                 print (f" --- CALCUALTING SUGGESTIONS3 --- ")
-                count = await crud_vectordb.rebuild_world(session, agent.world_id)
+                from app.crud import crud_agent_embedding
+                embed_ids = await crud_agent_embedding.get_embedding_ids(session, agent.id)
+                count = 0
+                for eid in embed_ids:
+                    count += await crud_vectordb.rebuild_embedding(session, agent.world_id, eid)
                 print (f" --- CALCUALTING SUGGESTIONS4 --- ")
                 print (f" --- CALCUALTING SUGGESTIONS4 --- ")
                 print (f" --- CALCUALTING SUGGESTIONS4 --- ")

--- a/backend/tests/test_vectordb.py
+++ b/backend/tests/test_vectordb.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest.mock import patch
 
 WORLD_BUILDER = {
     "nickname": "builder",
@@ -47,6 +48,14 @@ async def test_rebuild_vectordb(async_client, create_user, login_and_get_token):
         resp = await async_client.post("/pages/", json=page, headers={"Authorization": f"Bearer {writer_token}"})
         assert resp.status_code == 200
 
-    resp = await async_client.post(f"/vectordb/{gw_id}/rebuild")
+    with patch("app.task_queue.task_rebuild_world_embedding.delay"):
+        resp = await async_client.post(
+            "/world_embeddings/",
+            json={"world_id": gw_id, "name": "base"},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+    emb_id = resp.json()["id"]
+
+    resp = await async_client.post(f"/vectordb/{emb_id}/rebuild")
     assert resp.status_code == 200
     assert resp.json()["pages_indexed"] == 3

--- a/frontend/src/app/lib/vectordbAPI.ts
+++ b/frontend/src/app/lib/vectordbAPI.ts
@@ -1,7 +1,7 @@
 import { API_URL } from "./config";
 
-export async function rebuildVectorDB(token: string, worldId: number) {
-  const res = await fetch(`${API_URL}/vectordb/${worldId}/rebuild`, {
+export async function rebuildVectorDB(token: string, embeddingId: number) {
+  const res = await fetch(`${API_URL}/vectordb/${embeddingId}/rebuild`, {
     method: "POST",
     headers: token ? { Authorization: `Bearer ${token}` } : {},
   });


### PR DESCRIPTION
## Summary
- remove unused rebuild_world pipeline and collection helper
- simplify vectordb functions to work directly with world embeddings
- update agent chat and page analysis to call new helpers
- adjust vectordb API endpoints and frontend helper
- update tests for new embedding workflow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_68893e2f7e0483229c870be7b92945de