### PR TITLE
Refactor writer analysis

### DIFF
--- a/backend/app/api/api_agent.py
+++ b/backend/app/api/api_agent.py
@@ -319,8 +319,8 @@ async def analyze_page_endpoint(
     if agent.world_id != page.gameworld_id:
         raise HTTPException(status_code=400, detail="Agent and page belong to different worlds")
 
-    result = await analyze_page(session, agent, page)
-    return result
+    result = await analyze_pages_bulk(session, agent, [page])
+    return {"suggestions": result}
 
 
 class GeneratePagesRequest(BaseModel):

--- a/backend/app/crud/crud_page_analysis.py
+++ b/backend/app/crud/crud_page_analysis.py
@@ -66,6 +66,7 @@ async def _query_agent_world(
     n_results: int = 5,
     views: List[str] | None = None,
     filters: Dict | None = None,
+    max_chunks_per_page: int | None = 15,
 ):
     chunks = []
     embeddings = await _get_agent_embeddings(session, agent)
@@ -77,6 +78,7 @@ async def _query_agent_world(
                 n_results=n_results,
                 views=views,
                 filters=filters,
+                max_chunks_per_page=max_chunks_per_page,
             )
             chunks.extend(parts)
         except Exception:
@@ -196,13 +198,20 @@ async def analyze_page(session, agent, page) -> dict:
     existing_pages = await crud_page.get_pages(session, gameworld_id=page.gameworld_id)
     existing_titles_norm = {normalize_name(p.name): p for p in existing_pages if p.name}
 
-    # Chunk page content
-    content = page.content or ""
-    text_chunks = split_html_by_headers(content)
+    # Gather page text directly from the vector database if available
+    page_chunks: List[str] = []
+    for emb in valid_embeds:
+        page_chunks = crud_vectordb.get_page_chunks(emb.id, page.id)
+        if page_chunks:
+            break
+    if not page_chunks:
+        page_chunks = split_html_by_headers(page.content or "")
 
-    # Gather additional context from the agent's world embeddings
+    # Add a few extra relevant chunks from the world embedding for context
     embed_chunks = await _query_agent_world(session, agent, page.name, n_results=3)
-    text_chunks.extend(c["document"] for c in embed_chunks)
+    page_chunks.extend(c["document"] for c in embed_chunks)
+
+    full_text = "\n".join(page_chunks)
  
     # Prompt LLM for {page_name: concept_name} mappings
     prompt = ChatPromptTemplate.from_messages([
@@ -220,10 +229,10 @@ async def analyze_page(session, agent, page) -> dict:
     llm = ChatOpenAI(api_key=settings.openai_api_key, model=settings.open_ai_model)
     chain = prompt | llm
 
-    # Collect all page_name: concept_name pairs from all chunks
+    # Collect page_name: concept_name pairs using a single LLM call
     all_pairs = []
-    for chunk in text_chunks:
-        result = await chain.ainvoke({"chunk": chunk})
+    if full_text.strip():
+        result = await chain.ainvoke({"chunk": full_text})
         parsed = json.loads(result.content.strip())
         if isinstance(parsed, dict):
             all_pairs.extend(parsed.items())

--- a/backend/app/crud/crud_vectordb.py
+++ b/backend/app/crud/crud_vectordb.py
@@ -230,6 +230,20 @@ async def add_page(session: AsyncSession, page_id: int, embedding_id: int):
     _safe_add_documents(collection, chunks)
     return True
 
+def get_page_chunks(embedding_id: int, page_id: int) -> List[str]:
+    """Return ordered text chunks for a single page from the embedding."""
+    collection = _get_embedding_collection(embedding_id)
+    try:
+        data = collection.get(where={"page_id": page_id}, include=["documents", "metadatas"])
+    except Exception:
+        return []
+    docs = data.get("documents") or []
+    metas = data.get("metadatas") or []
+    pairs = zip(metas, docs)
+    ordered = sorted(pairs, key=lambda p: p[0].get("chunk_index", 0))
+    return [doc for _, doc in ordered]
+
+
 
 async def rebuild_embedding(session: AsyncSession, world_id: int, embedding_id: int) -> int:
     name = f"embedding_{embedding_id}"

--- a/backend/app/task_queue.py
+++ b/backend/app/task_queue.py
@@ -139,11 +139,7 @@ def task_analyze_pages_job(agent_id: int, page_ids: list[int], job_id: str):
                         default=str,
                     )
 
-            if len(pages) == 1:
-                result = await analyze_page(session, agent, pages[0])
-                suggestions = result.get("suggestions", [])
-            else:
-                suggestions = await analyze_pages_bulk(session, agent, pages)
+            suggestions = await analyze_pages_bulk(session, agent, pages)
 
         end_time = datetime.now(timezone.utc).isoformat()
         with open(job_path, "w") as f:

--- a/frontend/src/app/lib/agentAPI.ts
+++ b/frontend/src/app/lib/agentAPI.ts
@@ -123,12 +123,17 @@ export async function analyzePageWithAgent(
   pageId: number,
   token: string
 ) {
-  const res = await fetch(`${API_URL}/agents/${agentId}/pages/${pageId}/analyze`, {
-    method: "POST",
-    headers: token ? { Authorization: `Bearer ${token}` } : {},
-  });
-  if (!res.ok) throw await res.text();
-  return await res.json();
+  const { job_id } = await startAnalyzeJob(agentId, [pageId], token);
+  let attempts = 0;
+  while (attempts < 30) {
+    await new Promise(r => setTimeout(r, 2000));
+    const job = await getWriterJob(job_id, token);
+    if (job.status === "done") {
+      return { suggestions: job.suggestions || job.analysis || [] };
+    }
+    attempts++;
+  }
+  throw new Error("timeout");
 }
 export async function generatePagesWithAgent(
   agentId: number,


### PR DESCRIPTION
## Summary
- always run writer analysis through bulk pipeline
- pull page text from embeddings when analyzing
- add helper to fetch page chunks from vector DB
- poll for job completion in the frontend API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_688a77aaf3c48322962c1effeaeee3e3