### PR TITLE
Enable drag-to-merge writer suggestions

### DIFF
--- a/frontend/src/app/agent_writer/[agentID]/suggestions/[jobID]/page.tsx
+++ b/frontend/src/app/agent_writer/[agentID]/suggestions/[jobID]/page.tsx
@@ -224,6 +224,19 @@ export default function SuggestionsPage() {
     a.name.localeCompare(b.name)
   );
 
+  const handleDragMerge = (fromIdx: number, toIdx: number) => {
+    setSelectedSuggestions((prev) => {
+      const copy = [...prev];
+      const from = copy[fromIdx];
+      const to = copy[toIdx];
+      if (!from || !to) return prev;
+      const set = new Set<string>(from.merge_targets || []);
+      set.add(to.name);
+      from.merge_targets = Array.from(set);
+      return copy;
+    });
+  };
+
   return (
     <AuthGuard>
       <DashboardLayout>
@@ -297,6 +310,7 @@ export default function SuggestionsPage() {
                       pages={allPages}
                       token={token}
                       subStep={subStep}
+                      onDragMerge={handleDragMerge}
                       onUpdate={(i: number, data: any) => {
                         const copy = [...selectedSuggestions];
                         copy[i] = { ...copy[i], ...data };

--- a/frontend/src/app/components/agents/SuggestionCard.tsx
+++ b/frontend/src/app/components/agents/SuggestionCard.tsx
@@ -11,6 +11,7 @@ export default function SuggestionCard({
     token,
     subStep,
     onUpdate,
+    onDragMerge,
   }) {
     const { t } = useTranslation();
     const [filter, setFilter] = useState("");
@@ -46,6 +47,24 @@ export default function SuggestionCard({
   
     return (
       <div
+        draggable={subStep === 'b'}
+        onDragStart={(e) => {
+          if (subStep === 'b') {
+            e.dataTransfer.setData('text/plain', String(index));
+          }
+        }}
+        onDragOver={(e) => {
+          if (subStep === 'b') e.preventDefault();
+        }}
+        onDrop={(e) => {
+          if (subStep === 'b') {
+            e.preventDefault();
+            const from = Number(e.dataTransfer.getData('text/plain'));
+            if (!isNaN(from) && from !== index) {
+              onDragMerge?.(from, index);
+            }
+          }
+        }}
         className={`border-2 ${
           isMerged ? "border-gray-300 bg-gray-100" : backgroundClass
         } rounded-xl p-4 space-y-3 transition-colors duration-200`}
@@ -223,6 +242,4 @@ export default function SuggestionCard({
         )}
       </div>
     );
-  }
-  
-  
+}

--- a/frontend/src/app/locales/en.json
+++ b/frontend/src/app/locales/en.json
@@ -195,7 +195,7 @@
   "step2a_hint": "Click \u201cRemove\u201d on any suggestion you don't want to keep.",
   "step2b_merge": "Step 2B: Merge Similar Suggestions",
   "step2b_desc": "Now, group together suggestions that refer to the same topic.",
-  "step2b_hint": "Use the \u201cMerge With\u201d dropdown on each card to link related suggestions.",
+  "step2b_hint": "Use the \u201cMerge With\u201d dropdown on each card or simply drag one suggestion onto another to combine them.",
   "step2c_finalize": "Step 2C: Finalize Pages",
   "step2c_desc": "Time to assign concepts and decide whether to create or update pages.",
   "step2c_hint": "Set the action, select the target concept, and pick an existing page if updating.",

--- a/frontend/src/app/locales/it.json
+++ b/frontend/src/app/locales/it.json
@@ -198,7 +198,7 @@
   "step2a_hint": "Fai clic su \u201cRimuovi\u201d per ogni suggerimento che non vuoi mantenere.",
   "step2b_merge": "Passo 2B: Unisci i Suggerimenti Simili",
   "step2b_desc": "Ora raggruppa i suggerimenti che si riferiscono allo stesso argomento.",
-  "step2b_hint": "Usa il menu \u201cUnisci Con\u201d su ogni scheda per collegare i suggerimenti correlati.",
+  "step2b_hint": "Usa il menu \u201cUnisci Con\u201d su ogni scheda o trascina semplicemente una scheda sopra un'altra per unirle.",
   "step2c_finalize": "Passo 2C: Finalizza le Pagine",
   "step2c_desc": "È il momento di assegnare i concetti e decidere se creare o aggiornare le pagine.",
   "step2c_hint": "Imposta l'azione, seleziona il concetto di destinazione e scegli una pagina esistente se devi aggiornarla.",

--- a/frontend/src/app/locales/pt.json
+++ b/frontend/src/app/locales/pt.json
@@ -196,7 +196,7 @@
   "step2a_hint": "Clique em \u201cRemover\u201d em qualquer sugestão que não desejar manter.",
   "step2b_merge": "Etapa 2B: Mesclar Sugestões Semelhantes",
   "step2b_desc": "Agora agrupe sugestões que se refiram ao mesmo tópico.",
-  "step2b_hint": "Use o menu \u201cMesclar Com\u201d em cada cartão para vincular sugestões relacionadas.",
+  "step2b_hint": "Use o menu \u201cMesclar Com\u201d em cada cartão ou simplesmente arraste um cartão sobre outro para mesclá-los.",
   "step2c_finalize": "Etapa 2C: Finalizar Páginas",
   "step2c_desc": "Hora de atribuir conceitos e decidir se cria ou atualiza páginas.",
   "step2c_hint": "Defina a ação, selecione o conceito alvo e escolha uma página existente se for atualizar.",


### PR DESCRIPTION
## Summary
- allow SuggestionCard elements to be draggable
- add drag merging logic in suggestions page
- update instructions about merging with drag in English, Italian and Portuguese translations

## Testing
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688bb17c323c8322af652bb861fb4e4b