### PR TITLE
Fix escaping in page analysis prompt

### DIFF
--- a/backend/app/crud/crud_page_analysis.py
+++ b/backend/app/crud/crud_page_analysis.py
@@ -237,7 +237,7 @@ async def analyze_page(session, agent, page) -> dict:
             "\nConcept list:\n"
             + "\n".join(f"- {name}: {desc}" for name, desc in concept_defs.items())
             + "\nReturn a JSON object mapping each page name to its concept (category), e.g.:\n"
-            + "{\n  \"Barão de Karst\": \"NPC\",\n  \"Abelardo\": \"NPC\",\n  \"Yudennach\": \"Reino\",\n  \"Green Dragon\": \"Monstro\"\n}"
+            + "{{\n  \"Barão de Karst\": \"NPC\",\n  \"Abelardo\": \"NPC\",\n  \"Yudennach\": \"Reino\",\n  \"Green Dragon\": \"Monstro\"\n}}"
             + "\nDo not include mentions that are not mapped to a concept. Only return the JSON object."
         ),
         ("user", "{chunk}")


### PR DESCRIPTION
## Summary
- escape braces in `crud_page_analysis` system prompt so LLM templates don't treat the example JSON as variables

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_688bc8f62ab08322891bcd4efb3088d4