### PR TITLE
Fix writer page creation

### DIFF
--- a/backend/app/crud/crud_page_analysis.py
+++ b/backend/app/crud/crud_page_analysis.py
@@ -355,8 +355,10 @@ async def generate_pages(
     that source.
     """
 
-    # Filter only brand new pages
-    create_specs = [s for s in page_specs if s.get("mode") == "create"]
+    # Filter only brand new pages. Treat specs without an explicit mode as
+    # creations so the UI can omit this field when using the writer job
+    # endpoint.
+    create_specs = [s for s in page_specs if s.get("mode", "create") == "create"]
     if not create_specs:
         return {"pages": []}
 


### PR DESCRIPTION
## Summary
- fix writer generate-pages path to treat missing `mode` as create

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'chromadb')*

------
https://chatgpt.com/codex/tasks/task_e_688bdb6f2dd88322b8bab8e3abc531f2