### PR TITLE
Fix writer job review link

### DIFF
--- a/frontend/src/app/agent_writer/[agentID]/history/[jobID]/page.tsx
+++ b/frontend/src/app/agent_writer/[agentID]/history/[jobID]/page.tsx
@@ -33,6 +33,12 @@ export default function HistoryJobPage() {
     setLoading(false);
   }
 
+  function handleReviewAgain() {
+    if (!job) return;
+    const path = `/agent_writer/${agentID}/${job.job_type === 'analyze_pages' ? 'suggestions' : 'review'}/${job.job_id}`;
+    router.push(path);
+  }
+
   if (!job) return (
     <AuthGuard><DashboardLayout>Loading...</DashboardLayout></AuthGuard>
   );
@@ -42,10 +48,16 @@ export default function HistoryJobPage() {
       <DashboardLayout>
         <div className="min-h-screen w-full p-4 space-y-4">
           <h1 className="text-xl font-bold">Request {jobID}</h1>
-          <button onClick={handleRedo} disabled={loading}
-            className="px-3 py-2 rounded bg-fuchsia-600 text-white disabled:opacity-50">
-            {loading ? <Loader2 className="w-4 h-4 animate-spin"/> : "Redo"}
-          </button>
+          <div className="flex gap-2">
+            <button onClick={handleRedo} disabled={loading}
+              className="px-3 py-2 rounded bg-fuchsia-600 text-white disabled:opacity-50">
+              {loading ? <Loader2 className="w-4 h-4 animate-spin"/> : "Redo"}
+            </button>
+            <button onClick={handleReviewAgain}
+              className="px-3 py-2 rounded bg-indigo-600 text-white">
+              Review Again
+            </button>
+          </div>
           <div className="space-y-4">
             <div>
               <h2 className="font-semibold">Analysis</h2>

--- a/frontend/src/app/agent_writer/page.tsx
+++ b/frontend/src/app/agent_writer/page.tsx
@@ -217,7 +217,12 @@ function AgentWriterPageContent() {
                         </table>
                         <div className="mt-2 flex gap-2">
                           {j.status === 'done' && j.action_needed === 'review' && (
-                            <Link className="text-fuchsia-700 underline font-bold" href={`/agent_writer/${selectedAgent.id}/review/${j.job_id}`}>Review</Link>
+                            <Link
+                              className="text-fuchsia-700 underline font-bold"
+                              href={`/agent_writer/${selectedAgent.id}/${j.job_type === 'analyze_pages' ? 'suggestions' : 'review'}/${j.job_id}`}
+                            >
+                              Review
+                            </Link>
                           )}
                           <Link className="text-fuchsia-700 underline" href={`/agent_writer/${selectedAgent.id}/history/${j.job_id}`}>View</Link>
                         </div>


### PR DESCRIPTION
## Summary
- when writer jobs are of type `analyze_pages`, link to suggestions page
- add **Review Again** option on the job history screen

## Testing
- `npm run lint` *(fails: no-unused-vars etc.)*
- `pytest` *(fails: 25 failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_688d0315c9688322987f0f02f816ebff