### PR TITLE
feat: add newsboard feature

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -14,6 +14,7 @@ for _mod in [
     "api_jobs",
     "api_user_note",
     "api_embedding",
+    "api_news",
 ]:
     try:
         globals()[_mod] = __import__(f"app.api.{_mod}", fromlist=["router"])

--- a/backend/app/api/api_news.py
+++ b/backend/app/api/api_news.py
@@ -1,0 +1,36 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from typing import List
+from app.database import get_session
+from app.dependencies import get_current_user
+from app.models.model_user import User
+from app.schemas.schema_news import NewsCreate, NewsRead
+from app.crud.crud_news import create_news, get_news_for_user, mark_news_seen
+
+router = APIRouter(prefix="/news", tags=["news"])
+
+@router.post("/", response_model=NewsRead)
+async def create_news_endpoint(
+    news: NewsCreate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(get_current_user),
+):
+    if user.role != "system admin":
+        raise HTTPException(status_code=403, detail="Not authorized")
+    return await create_news(session, news)
+
+@router.get("/", response_model=List[NewsRead])
+async def list_news_endpoint(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(get_current_user),
+):
+    return await get_news_for_user(session, user.id)
+
+@router.post("/{news_id}/seen")
+async def mark_seen_endpoint(
+    news_id: int,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(get_current_user),
+):
+    await mark_news_seen(session, user.id, news_id)
+    return {"ok": True}

--- a/backend/app/crud/crud_news.py
+++ b/backend/app/crud/crud_news.py
@@ -1,0 +1,39 @@
+from typing import List
+from sqlmodel import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.models.model_news import News, NewsView
+from app.schemas.schema_news import NewsCreate, NewsRead
+
+async def create_news(session: AsyncSession, news_in: NewsCreate) -> News:
+    news = News(**news_in.model_dump())
+    session.add(news)
+    await session.commit()
+    await session.refresh(news)
+    return news
+
+async def get_news_for_user(session: AsyncSession, user_id: int) -> List[NewsRead]:
+    result = await session.exec(select(News))
+    news_items = result.all()
+    seen_ids = set((await session.exec(select(NewsView.news_id).where(NewsView.user_id == user_id))).all())
+    return [
+        NewsRead(
+            id=n.id,
+            title=n.title,
+            type=n.type,
+            description=n.description,
+            created_at=n.created_at,
+            seen=n.id in seen_ids,
+        )
+        for n in news_items
+    ]
+
+async def mark_news_seen(session: AsyncSession, user_id: int, news_id: int) -> None:
+    result = await session.exec(
+        select(NewsView).where(NewsView.user_id == user_id, NewsView.news_id == news_id)
+    )
+    view = result.first()
+    if not view:
+        view = NewsView(user_id=user_id, news_id=news_id)
+        session.add(view)
+        await session.commit()
+    return view

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,6 +16,7 @@ from .api import (
     api_jobs,
     api_user_note,
     api_embedding,
+    api_news,
 )
 from contextlib import asynccontextmanager
 
@@ -102,6 +103,7 @@ app.include_router(api_library.router)
 app.include_router(api_jobs.router)
 app.include_router(api_user_note.router)
 app.include_router(api_embedding.router)
+app.include_router(api_news.router)
 
 
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -11,6 +11,7 @@ from . import (
     model_user_note,
     model_world_embedding,
     model_agent_embedding,
+    model_news,
 )
 
 __all__ = [
@@ -26,4 +27,5 @@ __all__ = [
     "model_user_note",
     "model_world_embedding",
     "model_agent_embedding",
+    "model_news",
 ]

--- a/backend/app/models/model_news.py
+++ b/backend/app/models/model_news.py
@@ -1,0 +1,16 @@
+from typing import Optional
+from sqlmodel import SQLModel, Field
+from datetime import datetime, timezone
+
+class News(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    title: str
+    type: str
+    description: str
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+class NewsView(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    news_id: int = Field(foreign_key="news.id")
+    user_id: int = Field(foreign_key="user.id")
+    seen_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/backend/app/schemas/schema_news.py
+++ b/backend/app/schemas/schema_news.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+from typing import Optional
+from sqlmodel import SQLModel
+
+class NewsBase(SQLModel):
+    title: str
+    type: str
+    description: str
+
+class NewsCreate(NewsBase):
+    pass
+
+class NewsRead(NewsBase):
+    id: int
+    created_at: datetime
+    seen: Optional[bool] = False
+
+NewsCreate.model_rebuild()
+NewsRead.model_rebuild()

--- a/backend/tests/test_news.py
+++ b/backend/tests/test_news.py
@@ -1,0 +1,32 @@
+import pytest
+
+@pytest.mark.asyncio
+async def test_news_flow(async_client, create_user, login_and_get_token):
+    await create_user(email="admin@test.com", password="pass", role="system admin")
+    await create_user(email="user@test.com", password="pass", role="player")
+    admin_token = await login_and_get_token("admin@test.com", "pass", "system admin")
+    user_token = await login_and_get_token("user@test.com", "pass", "player")
+
+    resp = await async_client.post(
+        "/news/",
+        json={"title": "Hello", "type": "feature", "description": "desc"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 200, resp.text
+    news_id = resp.json()["id"]
+
+    resp = await async_client.get("/news/", headers={"Authorization": f"Bearer {user_token}"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["seen"] is False
+
+    resp = await async_client.post(
+        f"/news/{news_id}/seen",
+        headers={"Authorization": f"Bearer {user_token}"},
+    )
+    assert resp.status_code == 200
+
+    resp = await async_client.get("/news/", headers={"Authorization": f"Bearer {user_token}"})
+    assert resp.status_code == 200
+    assert resp.json()[0]["seen"] is True

--- a/frontend/src/app/components/news/NewsDialog.tsx
+++ b/frontend/src/app/components/news/NewsDialog.tsx
@@ -1,0 +1,28 @@
+"use client";
+import ModalContainer from "../template/modalContainer";
+import { useTranslation } from "../../hooks/useTranslation";
+
+export default function NewsDialog({ open, onClose, news }) {
+  const { t } = useTranslation();
+  if (!open) return null;
+  return (
+    <ModalContainer title={t("newsboard")} onClose={onClose} className="max-w-2xl">
+      {(!news || news.length === 0) ? (
+        <p>{t("no_news")}</p>
+      ) : (
+        <ul className="space-y-4">
+          {news.map((n) => (
+            <li key={n.id} className="border-b pb-2">
+              <div className="flex justify-between">
+                <span className="font-semibold">{n.title}</span>
+                <span className="text-xs">{new Date(n.created_at).toLocaleDateString()}</span>
+              </div>
+              <span className="text-xs italic">{n.type}</span>
+              <p className="text-sm mt-1 whitespace-pre-line">{n.description}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </ModalContainer>
+  );
+}

--- a/frontend/src/app/components/template/Sidebar.tsx
+++ b/frontend/src/app/components/template/Sidebar.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { usePathname } from "next/navigation";
 import { useAuth } from "../auth/AuthProvider";
 import UserModal from "../user_management/User_Modal";
@@ -15,7 +15,10 @@ import BuildRoundedIcon from "@mui/icons-material/BuildRounded";
 import SettingsRoundedIcon from "@mui/icons-material/SettingsRounded";
 import HomeIcon from "@mui/icons-material/HomeRounded";
 import PersonEditAlt1RoundedIcon from "@mui/icons-material/EditRounded";
+import NotificationsIcon from "@mui/icons-material/NotificationsRounded";
 import { Bot, BookOpenText, FileText, PenLine, Sparkles } from "lucide-react";
+import NewsDialog from "../news/NewsDialog";
+import { getNews, markNewsSeen } from "../../lib/newsAPI";
 
 export default function Sidebar({ mobileOpen = false, setMobileOpen = () => {} }) {
   const { user, token, isLoading: authLoading, refreshUser } = useAuth();
@@ -23,8 +26,40 @@ export default function Sidebar({ mobileOpen = false, setMobileOpen = () => {} }
   const [profileModalOpen, setProfileModalOpen] = useState(false);
   const [profileSuccess, setProfileSuccess] = useState("");
   const [profileError, setProfileError] = useState("");
+  const [newsOpen, setNewsOpen] = useState(false);
+  const [newsItems, setNewsItems] = useState([]);
 
   const pathname = usePathname();
+
+  useEffect(() => {
+    if (!token) return;
+    getNews(token)
+      .then((items) => {
+        setNewsItems(items);
+        const unseen = items.filter((n: any) => !n.seen);
+        const today = new Date().toDateString();
+        const last = typeof window !== "undefined" ? localStorage.getItem("news_last_seen") : null;
+        if (last !== today && unseen.length > 0) {
+          setNewsOpen(true);
+          localStorage.setItem("news_last_seen", today);
+          unseen.forEach((n: any) => markNewsSeen(n.id, token));
+          setNewsItems(items.map((n: any) => ({ ...n, seen: true })));
+        }
+      })
+      .catch(() => {});
+  }, [token]);
+
+  function handleOpenNews() {
+    setNewsOpen(true);
+    const unseen = newsItems.filter((n: any) => !n.seen);
+    if (unseen.length > 0) {
+      unseen.forEach((n: any) => markNewsSeen(n.id, token));
+      setNewsItems(newsItems.map((n: any) => ({ ...n, seen: true })));
+      if (typeof window !== "undefined") {
+        localStorage.setItem("news_last_seen", new Date().toDateString());
+      }
+    }
+  }
 
   async function handleProfileSave() {
     if (typeof refreshUser === "function") await refreshUser();
@@ -183,6 +218,19 @@ export default function Sidebar({ mobileOpen = false, setMobileOpen = () => {} }
           
         </div>
 
+        <div className="flex justify-end px-4 mt-2">
+          <button
+            onClick={handleOpenNews}
+            className="relative text-[var(--primary)] hover:text-[var(--accent)]"
+            aria-label={t("news")}
+          >
+            <NotificationsIcon />
+            {newsItems.some((n: any) => !n.seen) && (
+              <span className="absolute -top-1 -right-1 w-2 h-2 bg-red-600 rounded-full" />
+            )}
+          </button>
+        </div>
+
         {/* Menu Items */}
         <nav className="flex-1 flex flex-col gap-1 py-6">
           {menu.filter((m) => m.show).map((m) => (
@@ -292,6 +340,7 @@ export default function Sidebar({ mobileOpen = false, setMobileOpen = () => {} }
           />
         )}
       </aside>
+      <NewsDialog open={newsOpen} onClose={() => setNewsOpen(false)} news={newsItems} />
     </>
   );
 }

--- a/frontend/src/app/lib/newsAPI.ts
+++ b/frontend/src/app/lib/newsAPI.ts
@@ -1,0 +1,31 @@
+import { API_URL } from "./config";
+
+export async function getNews(token: string) {
+  const res = await fetch(`${API_URL}/news`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error("Failed to fetch news");
+  return res.json();
+}
+
+export async function createNews(data: any, token: string) {
+  const res = await fetch(`${API_URL}/news`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error("Failed to create news");
+  return res.json();
+}
+
+export async function markNewsSeen(id: number, token: string) {
+  const res = await fetch(`${API_URL}/news/${id}/seen`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error("Failed to mark news seen");
+  return res.json();
+}

--- a/frontend/src/app/locales/en.json
+++ b/frontend/src/app/locales/en.json
@@ -268,5 +268,9 @@
   "tab_writer_notes": "Writer's Notes",
   "tab_key_events": "Key Events",
   "tab_relationships": "Relationship Map",
-  "tab_changelog": "Changelog"
+  "tab_changelog": "Changelog",
+  "news": "News",
+  "newsboard": "Newsboard",
+  "no_news": "No news available.",
+  "add_news": "Add News"
 }

--- a/frontend/src/app/locales/it.json
+++ b/frontend/src/app/locales/it.json
@@ -272,5 +272,9 @@
   "tab_writer_notes": "Note dell'autore",
   "tab_key_events": "Eventi Chiave",
   "tab_relationships": "Mappa Relazioni",
-  "tab_changelog": "Cronologia"
+  "tab_changelog": "Cronologia",
+  "news": "Notizie",
+  "newsboard": "Bacheca Notizie",
+  "no_news": "Nessuna notizia.",
+  "add_news": "Aggiungi Notizia"
 }

--- a/frontend/src/app/locales/pt.json
+++ b/frontend/src/app/locales/pt.json
@@ -269,5 +269,9 @@
   "tab_writer_notes": "Notas do Autor",
   "tab_key_events": "Eventos Chave",
   "tab_relationships": "Mapa de Relações",
-  "tab_changelog": "Alterações"
+  "tab_changelog": "Alterações",
+  "news": "Notícias",
+  "newsboard": "Quadro de Notícias",
+  "no_news": "Sem notícias.",
+  "add_news": "Adicionar Notícia"
 }

--- a/frontend/src/app/system_settings/newsboard/page.tsx
+++ b/frontend/src/app/system_settings/newsboard/page.tsx
@@ -1,0 +1,85 @@
+"use client";
+import AuthGuard from "../../components/auth/AuthGuard";
+import DashboardLayout from "../../components/DashboardLayout";
+import { useAuth } from "../../components/auth/AuthProvider";
+import { useTranslation } from "../../hooks/useTranslation";
+import { useState, useEffect } from "react";
+import { getNews, createNews } from "../../lib/newsAPI";
+import useRoleRedirect from "../../hooks/useRoleRedirect";
+
+export default function NewsAdminPage() {
+  const { token } = useAuth();
+  const { t } = useTranslation();
+  const allowed = useRoleRedirect("system admin");
+  const [items, setItems] = useState([]);
+  const [form, setForm] = useState({ title: "", type: "news", description: "" });
+
+  useEffect(() => {
+    if (!token) return;
+    getNews(token).then(setItems).catch(() => {});
+  }, [token]);
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    if (!token) return;
+    await createNews(form, token);
+    setForm({ title: "", type: "news", description: "" });
+    const data = await getNews(token);
+    setItems(data);
+  }
+
+  if (!allowed) return null;
+
+  return (
+    <AuthGuard>
+      <DashboardLayout>
+        <div className="space-y-4">
+          <h1 className="text-2xl font-bold">{t("newsboard")}</h1>
+          <form onSubmit={handleSubmit} className="space-y-2">
+            <input
+              className="w-full p-2 border rounded"
+              placeholder="Title"
+              value={form.title}
+              onChange={(e) => setForm({ ...form, title: e.target.value })}
+              required
+            />
+            <select
+              className="w-full p-2 border rounded"
+              value={form.type}
+              onChange={(e) => setForm({ ...form, type: e.target.value })}
+            >
+              <option value="feature">feature</option>
+              <option value="content">content</option>
+              <option value="news">news</option>
+            </select>
+            <textarea
+              className="w-full p-2 border rounded"
+              placeholder="Description"
+              value={form.description}
+              onChange={(e) => setForm({ ...form, description: e.target.value })}
+              required
+            />
+            <button
+              type="submit"
+              className="px-4 py-2 bg-[var(--primary)] text-[var(--primary-foreground)] rounded"
+            >
+              {t("add_news")}
+            </button>
+          </form>
+          <ul className="space-y-2">
+            {items.map((n) => (
+              <li key={n.id} className="border p-2 rounded">
+                <div className="flex justify-between">
+                  <span className="font-semibold">{n.title}</span>
+                  <span className="text-xs">{new Date(n.created_at).toLocaleDateString()}</span>
+                </div>
+                <span className="text-xs italic">{n.type}</span>
+                <p className="text-sm">{n.description}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </DashboardLayout>
+    </AuthGuard>
+  );
+}

--- a/frontend/src/app/system_settings/page.tsx
+++ b/frontend/src/app/system_settings/page.tsx
@@ -23,6 +23,7 @@ import {
   Book,
   Layers,
   Timer,
+  Bell,
 } from "lucide-react";
 import SimpleBarChart from "../components/charts/SimpleBarChart";
 import { useLibraryItems } from "../lib/useLibraryItems";
@@ -211,6 +212,18 @@ export default function AdminDashboardPage() {
                 actions={
                   <Link className="btn-primary" href="/user_management">
                     Manage Users
+                  </Link>
+                }
+              />
+
+              <DashboardCard
+                title="News Board"
+                description="Create announcements for all users."
+                icon={<Bell className="w-6 h-6" />}
+                color="from-amber-500 to-orange-500"
+                actions={
+                  <Link className="btn-primary" href="/system_settings/newsboard">
+                    Manage News
                   </Link>
                 }
               />


### PR DESCRIPTION
## Summary
- add News and NewsView models with CRUD and API
- show news via sidebar dialog and allow admin news management
- include basic tests for news flow

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'bs4')*
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688defa51ea08322886e9d1476e7ebe4