### PR TITLE
Fix async news queries

### DIFF
--- a/backend/app/crud/crud_news.py
+++ b/backend/app/crud/crud_news.py
@@ -1,5 +1,5 @@
 from typing import List
-from sqlmodel import select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.model_news import News, NewsView
 from app.schemas.schema_news import NewsCreate, NewsRead
@@ -12,9 +12,12 @@ async def create_news(session: AsyncSession, news_in: NewsCreate) -> News:
     return news
 
 async def get_news_for_user(session: AsyncSession, user_id: int) -> List[NewsRead]:
-    result = await session.exec(select(News))
-    news_items = result.all()
-    seen_ids = set((await session.exec(select(NewsView.news_id).where(NewsView.user_id == user_id))).all())
+    result = await session.execute(select(News))
+    news_items = result.scalars().all()
+    seen_ids_result = await session.execute(
+        select(NewsView.news_id).where(NewsView.user_id == user_id)
+    )
+    seen_ids = set(seen_ids_result.scalars().all())
     return [
         NewsRead(
             id=n.id,
@@ -28,10 +31,10 @@ async def get_news_for_user(session: AsyncSession, user_id: int) -> List[NewsRea
     ]
 
 async def mark_news_seen(session: AsyncSession, user_id: int, news_id: int) -> None:
-    result = await session.exec(
+    result = await session.execute(
         select(NewsView).where(NewsView.user_id == user_id, NewsView.news_id == news_id)
     )
-    view = result.first()
+    view = result.scalar_one_or_none()
     if not view:
         view = NewsView(user_id=user_id, news_id=news_id)
         session.add(view)


### PR DESCRIPTION
## Summary
- fix news CRUD to use SQLAlchemy's `session.execute` and scalars

## Testing
- `pytest backend/tests/test_news.py::test_news_flow -q`


------
https://chatgpt.com/codex/tasks/task_e_688e0f9e74ac83229a8df493e0d4c2c1