### PR TITLE
refactor: modularize agent writer orchestrator

### DIFF
--- a/backend/app/agentic_ai/agentic_workers.py
+++ b/backend/app/agentic_ai/agentic_workers.py
@@ -1,4 +1,4 @@
-"""Reusable agentic worker functions for conversational agents."""
+"""Reusable agentic worker functions for conversational and writing agents."""
 
 import asyncio
 import json
@@ -7,7 +7,7 @@ from typing import Iterable, List, Tuple
 from langchain_openai import ChatOpenAI
 
 from app.config import settings
-from app.crud import crud_vectordb, crud_agent_embedding
+from app.crud import crud_vectordb, crud_agent_embedding, crud_page_analysis
 
 openai_model = settings.open_ai_model
 
@@ -150,3 +150,13 @@ async def validate_response(query: str, answer: str, user_nickname: str | None, 
     validator_prompt = make_validator_prompt(query, answer, user_nickname, tone)
     resp = await llm.ainvoke(validator_prompt)
     return "no" not in resp.content.lower()
+
+
+async def analyze_pages_worker(session, agent, pages):
+    """Analyze a batch of pages for an agent."""
+    return await crud_page_analysis.analyze_pages_bulk(session, agent, pages)
+
+
+async def generate_pages_worker(session, agent, page, page_specs):
+    """Generate or update pages based on specifications."""
+    return await crud_page_analysis.generate_pages(session, agent, page, page_specs)

--- a/backend/app/api/api_agent.py
+++ b/backend/app/api/api_agent.py
@@ -13,7 +13,7 @@ from app.crud.crud_agent import (
 )
 from app.crud.crud_agent_conversational import chat_with_agent
 from app.crud import crud_vectordb, crud_chat_history
-from app.crud.crud_page_analysis import analyze_page, generate_pages
+from app.crud import crud_agent_writer
 from app.crud.crud_page import get_page
 from app.schemas.schema_agent import AgentCreate, AgentRead, AgentUpdate
 from app.database import get_session
@@ -333,7 +333,7 @@ async def analyze_page_endpoint(
     if agent.world_id != page.gameworld_id:
         raise HTTPException(status_code=400, detail="Agent and page belong to different worlds")
 
-    result = await analyze_pages_bulk(session, agent, [page])
+    result = await crud_agent_writer.analyze_pages(session, agent, [page])
     return {"suggestions": result}
 
 
@@ -357,7 +357,7 @@ async def generate_pages_endpoint(
         raise HTTPException(status_code=400, detail="Agent and page belong to different worlds")
 
     page_specs = [p.model_dump() for p in payload.pages]
-    result = await generate_pages(session, agent, page, page_specs)
+    result = await crud_agent_writer.generate_pages(session, agent, page, page_specs)
     return result
 
 

--- a/backend/app/crud/crud_agent_conversational.py
+++ b/backend/app/crud/crud_agent_conversational.py
@@ -6,7 +6,7 @@ from langgraph.graph import Graph
 from app.config import settings
 from app.crud.crud_agent import get_agent, ensure_personality_prompts
 from app.models.model_gameworld import GameWorld
-from app.agentic_workers import (
+from app.agentic_ai.agentic_workers import (
     decompose_question,
     query_world_embeddings,
     aggregate_prune_and_dedup,

--- a/backend/app/crud/crud_agent_writer.py
+++ b/backend/app/crud/crud_agent_writer.py
@@ -1,0 +1,26 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+from typing import List
+
+from app.agentic_ai.agentic_workers import analyze_pages_worker, generate_pages_worker
+from app.models.model_agent import Agent
+from app.models.model_page import Page
+
+
+async def analyze_pages(session: AsyncSession, agent: Agent, pages: List[Page]) -> List[dict]:
+    """Orchestrate analysis of multiple pages."""
+    valid_pages = [p for p in pages if p.gameworld_id == agent.world_id]
+    if not valid_pages:
+        return []
+    return await analyze_pages_worker(session, agent, valid_pages)
+
+
+async def generate_pages(
+    session: AsyncSession,
+    agent: Agent,
+    page: Page,
+    page_specs: List[dict],
+) -> dict:
+    """Orchestrate generation or update of pages from specs."""
+    if page.gameworld_id != agent.world_id:
+        raise ValueError("Agent and page belong to different worlds")
+    return await generate_pages_worker(session, agent, page, page_specs)

--- a/backend/app/task_queue.py
+++ b/backend/app/task_queue.py
@@ -68,7 +68,7 @@ def task_sync_page_ref_attributes(page_id: int):
 def task_auto_crosslink_note_content(note_id: int):
     asyncio.run(auto_crosslink_note_content(note_id))
 
-from app.crud.crud_page_analysis import analyze_pages_bulk
+from app.crud import crud_agent_writer
 from app.crud.crud_agent import get_agent
 from app.crud.crud_page import get_page, update_page, get_pages
 from app.database import async_session_maker
@@ -78,7 +78,6 @@ from app.crud import crud_library_vectordb
 from datetime import datetime, timezone
 import json
 from pathlib import Path
-from app.crud.crud_page_analysis import analyze_page, generate_pages
 
 
 @celery_app.task
@@ -139,7 +138,7 @@ def task_analyze_pages_job(agent_id: int, page_ids: list[int], job_id: str):
                         default=str,
                     )
 
-            suggestions = await analyze_pages_bulk(session, agent, pages)
+            suggestions = await crud_agent_writer.analyze_pages(session, agent, pages)
 
         end_time = datetime.now(timezone.utc).isoformat()
         with open(job_path, "w") as f:
@@ -437,7 +436,7 @@ def task_generate_pages_job(
                         "start_time": start_time,
                     }, ff, default=str)
                 return
-            result = await generate_pages(session, agent, page, pages)
+            result = await crud_agent_writer.generate_pages(session, agent, page, pages)
             result_pages = result.get("pages", [])
             auto_updated = []
 


### PR DESCRIPTION
## Summary
- relocate agentic worker utilities into new `agentic_ai` package and add page analysis & generation workers
- introduce `crud_agent_writer` orchestrator to coordinate page analysis and page creation
- update API and background tasks to use the new orchestrator

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_688e16cd0730832297089a11d3a779d5