### PR TITLE
Add party tables and session scheduling

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -15,6 +15,8 @@ for _mod in [
     "api_user_note",
     "api_embedding",
     "api_news",
+    "api_table",
+    "api_session",
 ]:
     try:
         globals()[_mod] = __import__(f"app.api.{_mod}", fromlist=["router"])

--- a/backend/app/api/api_session.py
+++ b/backend/app/api/api_session.py
@@ -1,0 +1,49 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+from typing import List
+from app.database import get_session
+from app.models.model_user import User
+from app.dependencies import get_current_user
+from app.schemas.schema_session import SessionCreate, SessionRead
+from app.crud.crud_session import create_session, get_sessions_for_table
+
+router = APIRouter(prefix="/tables", tags=["sessions"], dependencies=[Depends(get_current_user)])
+
+@router.post("/{table_id}/sessions", response_model=SessionRead)
+async def create_session_endpoint(
+    table_id: int,
+    session_in: SessionCreate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(get_current_user),
+):
+    session_in.table_id = table_id
+    sess = await create_session(session, session_in, user.id)
+    return SessionRead(
+        id=sess.id,
+        table_id=sess.table_id,
+        scheduled_time=sess.scheduled_time,
+        summary=sess.summary,
+        location=sess.location,
+        created_by=sess.created_by,
+        created_at=sess.created_at,
+    )
+
+@router.get("/{table_id}/sessions", response_model=List[SessionRead])
+async def list_sessions_endpoint(
+    table_id: int,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(get_current_user),
+):
+    sessions = await get_sessions_for_table(session, table_id)
+    return [
+        SessionRead(
+            id=s.id,
+            table_id=s.table_id,
+            scheduled_time=s.scheduled_time,
+            summary=s.summary,
+            location=s.location,
+            created_by=s.created_by,
+            created_at=s.created_at,
+        )
+        for s in sessions
+    ]

--- a/backend/app/api/api_table.py
+++ b/backend/app/api/api_table.py
@@ -1,0 +1,36 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+from typing import List
+from app.database import get_session
+from app.models.model_user import User, UserRole
+from app.dependencies import get_current_user, require_role
+from app.schemas.schema_table import TableCreate, TableRead
+from app.crud.crud_table import create_table, get_tables_for_user
+
+router = APIRouter(prefix="/tables", tags=["tables"], dependencies=[Depends(get_current_user)])
+
+@router.post("/", response_model=TableRead)
+async def create_table_endpoint(
+    table: TableCreate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_role(UserRole.world_builder)),
+):
+    return await create_table(session, table, user.id)
+
+@router.get("/", response_model=List[TableRead])
+async def list_tables_endpoint(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(get_current_user),
+):
+    tables = await get_tables_for_user(session, user.id)
+    return [
+        TableRead(
+            id=t.id,
+            world_id=t.world_id,
+            name=t.name,
+            crest_url=t.crest_url,
+            created_by=t.created_by,
+            created_at=t.created_at,
+        )
+        for t in tables
+    ]

--- a/backend/app/crud/crud_session.py
+++ b/backend/app/crud/crud_session.py
@@ -1,0 +1,42 @@
+from typing import List, Set
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.models.model_session import Session, SessionAttendance
+from app.models.model_table import TableMember
+from app.schemas.schema_session import SessionCreate
+from app.crud.crud_news import create_news
+from app.schemas.schema_news import NewsCreate
+
+async def create_session(session: AsyncSession, session_in: SessionCreate, creator_id: int) -> Session:
+    sess = Session(
+        table_id=session_in.table_id,
+        scheduled_time=session_in.scheduled_time,
+        summary=session_in.summary,
+        location=session_in.location,
+        created_by=creator_id,
+    )
+    session.add(sess)
+    await session.commit()
+    await session.refresh(sess)
+
+    attendee_ids: Set[int] = set(session_in.attendee_ids or [])
+    if not attendee_ids:
+        result = await session.execute(
+            select(TableMember.user_id).where(TableMember.table_id == session_in.table_id)
+        )
+        attendee_ids = set(result.scalars().all())
+    for uid in attendee_ids:
+        session.add(SessionAttendance(session_id=sess.id, user_id=uid, attending=True))
+    await session.commit()
+
+    news = NewsCreate(
+        title="Session Scheduled",
+        type="session",
+        description=f"Session for table {session_in.table_id} on {sess.scheduled_time.isoformat()}"
+    )
+    await create_news(session, news)
+    return sess
+
+async def get_sessions_for_table(session: AsyncSession, table_id: int) -> List[Session]:
+    result = await session.execute(select(Session).where(Session.table_id == table_id))
+    return result.scalars().all()

--- a/backend/app/crud/crud_table.py
+++ b/backend/app/crud/crud_table.py
@@ -1,0 +1,29 @@
+from typing import List
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.models.model_table import Table, TableMember
+from app.schemas.schema_table import TableCreate
+
+async def create_table(session: AsyncSession, table_in: TableCreate, creator_id: int) -> Table:
+    table = Table(
+        world_id=table_in.world_id,
+        name=table_in.name,
+        crest_url=table_in.crest_url,
+        created_by=creator_id,
+    )
+    session.add(table)
+    await session.commit()
+    await session.refresh(table)
+
+    member_ids = set(table_in.member_ids or [])
+    member_ids.add(creator_id)
+    for uid in member_ids:
+        session.add(TableMember(table_id=table.id, user_id=uid, is_gm=(uid == creator_id)))
+    await session.commit()
+    return table
+
+async def get_tables_for_user(session: AsyncSession, user_id: int) -> List[Table]:
+    result = await session.execute(
+        select(Table).join(TableMember).where(TableMember.user_id == user_id)
+    )
+    return result.scalars().all()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,6 +17,8 @@ from .api import (
     api_user_note,
     api_embedding,
     api_news,
+    api_table,
+    api_session,
 )
 from contextlib import asynccontextmanager
 
@@ -104,6 +106,8 @@ app.include_router(api_jobs.router)
 app.include_router(api_user_note.router)
 app.include_router(api_embedding.router)
 app.include_router(api_news.router)
+app.include_router(api_table.router)
+app.include_router(api_session.router)
 
 
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -12,6 +12,8 @@ from . import (
     model_world_embedding,
     model_agent_embedding,
     model_news,
+    model_table,
+    model_session,
 )
 
 __all__ = [
@@ -28,4 +30,6 @@ __all__ = [
     "model_world_embedding",
     "model_agent_embedding",
     "model_news",
+    "model_table",
+    "model_session",
 ]

--- a/backend/app/models/model_session.py
+++ b/backend/app/models/model_session.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+from typing import Optional, List
+from sqlmodel import SQLModel, Field, Relationship
+from datetime import datetime, timezone
+
+class Session(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    table_id: int = Field(foreign_key="table.id")
+    scheduled_time: datetime
+    summary: Optional[str] = None
+    location: Optional[str] = None
+    created_by: int = Field(foreign_key="user.id")
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+    attendances: List["SessionAttendance"] = Relationship(back_populates="session")
+
+class SessionAttendance(SQLModel, table=True):
+    session_id: int = Field(foreign_key="session.id", primary_key=True)
+    user_id: int = Field(foreign_key="user.id", primary_key=True)
+    attending: bool = Field(default=True)
+
+    session: "Session" = Relationship(back_populates="attendances")

--- a/backend/app/models/model_table.py
+++ b/backend/app/models/model_table.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+from typing import Optional, List
+from sqlmodel import SQLModel, Field, Relationship
+from datetime import datetime, timezone
+
+class Table(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    world_id: int = Field(foreign_key="gameworld.id")
+    name: str
+    crest_url: Optional[str] = None
+    created_by: int = Field(foreign_key="user.id")
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+    members: List["TableMember"] = Relationship(back_populates="table")
+
+class TableMember(SQLModel, table=True):
+    table_id: int = Field(foreign_key="table.id", primary_key=True)
+    user_id: int = Field(foreign_key="user.id", primary_key=True)
+    is_gm: bool = Field(default=False)
+
+    table: "Table" = Relationship(back_populates="members")

--- a/backend/app/schemas/schema_session.py
+++ b/backend/app/schemas/schema_session.py
@@ -1,0 +1,21 @@
+from typing import Optional, List
+from datetime import datetime
+from sqlmodel import SQLModel
+
+class SessionBase(SQLModel):
+    scheduled_time: datetime
+    summary: Optional[str] = None
+    location: Optional[str] = None
+
+class SessionCreate(SessionBase):
+    table_id: int
+    attendee_ids: List[int] = []
+
+class SessionRead(SessionBase):
+    id: int
+    table_id: int
+    created_by: int
+    created_at: datetime
+
+SessionCreate.model_rebuild()
+SessionRead.model_rebuild()

--- a/backend/app/schemas/schema_table.py
+++ b/backend/app/schemas/schema_table.py
@@ -1,0 +1,25 @@
+from typing import Optional, List
+from datetime import datetime
+from sqlmodel import SQLModel
+
+class TableBase(SQLModel):
+    world_id: int
+    name: str
+    crest_url: Optional[str] = None
+
+class TableCreate(TableBase):
+    member_ids: List[int] = []
+
+class TableRead(TableBase):
+    id: int
+    created_by: int
+    created_at: datetime
+
+class TableMemberRead(SQLModel):
+    table_id: int
+    user_id: int
+    is_gm: bool = False
+
+TableCreate.model_rebuild()
+TableRead.model_rebuild()
+TableMemberRead.model_rebuild()

--- a/frontend/src/app/lib/sessionAPI.ts
+++ b/frontend/src/app/lib/sessionAPI.ts
@@ -1,0 +1,19 @@
+import { API_URL } from "./config";
+
+export async function getSessions(tableId: number, token: string) {
+  const res = await fetch(`${API_URL}/tables/${tableId}/sessions`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error("Failed to fetch sessions");
+  return await res.json();
+}
+
+export async function createSession(tableId: number, data: unknown, token: string) {
+  const res = await fetch(`${API_URL}/tables/${tableId}/sessions`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw await res.json();
+  return await res.json();
+}

--- a/frontend/src/app/lib/tableAPI.ts
+++ b/frontend/src/app/lib/tableAPI.ts
@@ -1,0 +1,19 @@
+import { API_URL } from "./config";
+
+export async function getTables(token: string) {
+  const res = await fetch(`${API_URL}/tables/`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) throw new Error("Failed to fetch tables");
+  return await res.json();
+}
+
+export async function createTable(data: unknown, token: string) {
+  const res = await fetch(`${API_URL}/tables/`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw await res.json();
+  return await res.json();
+}

--- a/frontend/src/app/lib/useSessions.ts
+++ b/frontend/src/app/lib/useSessions.ts
@@ -1,0 +1,13 @@
+import useSWR from "swr";
+import { getSessions } from "./sessionAPI";
+import { useAuth } from "../components/auth/AuthProvider";
+
+export function useSessions(tableId: number) {
+  const { token } = useAuth();
+  const fetcher = (id: number, t: string) => getSessions(id, t);
+  const { data, error, mutate, isLoading } = useSWR(
+    tableId && token ? ["sessions", tableId, token] : null,
+    () => fetcher(tableId, token)
+  );
+  return { sessions: data || [], error, mutate, isLoading };
+}

--- a/frontend/src/app/lib/useTables.ts
+++ b/frontend/src/app/lib/useTables.ts
@@ -1,0 +1,13 @@
+import useSWR from "swr";
+import { getTables } from "./tableAPI";
+import { useAuth } from "../components/auth/AuthProvider";
+
+export function useTables() {
+  const { token } = useAuth();
+  const fetcher = (t: string) => getTables(t);
+  const { data, error, mutate, isLoading } = useSWR(
+    token ? ["tables", token] : null,
+    () => fetcher(token)
+  );
+  return { tables: data || [], error, mutate, isLoading };
+}

--- a/frontend/src/app/tables/[id]/sessions/page.tsx
+++ b/frontend/src/app/tables/[id]/sessions/page.tsx
@@ -1,0 +1,73 @@
+"use client";
+import { useState } from "react";
+import { useParams } from "next/navigation";
+import DashboardLayout from "@/app/components/DashboardLayout";
+import { useSessions } from "@/app/lib/useSessions";
+import { createSession } from "@/app/lib/sessionAPI";
+import { useAuth } from "@/app/components/auth/AuthProvider";
+import M3FloatingInput from "@/app/components/template/M3FloatingInput";
+
+export default function TableSessionsPage() {
+  const params = useParams();
+  const tableId = Number(params?.id);
+  const { token } = useAuth();
+  const { sessions, mutate } = useSessions(tableId);
+  const [open, setOpen] = useState(false);
+  const [time, setTime] = useState("");
+  const [location, setLocation] = useState("");
+  const [summary, setSummary] = useState("");
+
+  async function handleCreate() {
+    await createSession(tableId, { scheduled_time: time, location, summary }, token);
+    setOpen(false);
+    setTime("");
+    setLocation("");
+    setSummary("");
+    mutate();
+  }
+
+  return (
+    <DashboardLayout>
+      <div className="w-full max-w-4xl mx-auto p-4">
+        <div className="flex justify-between items-center mb-4">
+          <h1 className="text-2xl font-bold">Sessions</h1>
+          <button
+            className="px-4 py-2 rounded-lg bg-[var(--primary)] text-[var(--primary-foreground)]"
+            onClick={() => setOpen(true)}
+          >
+            Schedule
+          </button>
+        </div>
+        <ul className="space-y-2">
+          {sessions.map((s: any) => (
+            <li key={s.id} className="p-4 rounded-xl bg-[var(--surface-variant)]">
+              <div className="font-semibold">{new Date(s.scheduled_time).toLocaleString()}</div>
+              {s.location && <div className="text-sm">{s.location}</div>}
+              {s.summary && <div className="text-sm opacity-80">{s.summary}</div>}
+            </li>
+          ))}
+        </ul>
+        {open && (
+          <div className="fixed inset-0 bg-black/40 flex items-center justify-center">
+            <div className="bg-[var(--surface)] p-6 rounded-xl w-full max-w-md space-y-4">
+              <M3FloatingInput type="datetime-local" label="Time" value={time} onChange={(e: any) => setTime(e.target.value)} />
+              <M3FloatingInput label="Location" value={location} onChange={(e: any) => setLocation(e.target.value)} />
+              <M3FloatingInput label="Summary" value={summary} onChange={(e: any) => setSummary(e.target.value)} />
+              <div className="flex justify-end gap-2">
+                <button onClick={() => setOpen(false)} className="px-4 py-2 rounded-lg">
+                  Cancel
+                </button>
+                <button
+                  onClick={handleCreate}
+                  className="px-4 py-2 rounded-lg bg-[var(--primary)] text-[var(--primary-foreground)]"
+                >
+                  Save
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/frontend/src/app/tables/page.tsx
+++ b/frontend/src/app/tables/page.tsx
@@ -1,0 +1,71 @@
+"use client";
+import { useState } from "react";
+import DashboardLayout from "@/app/components/DashboardLayout";
+import { useTables } from "@/app/lib/useTables";
+import { useAuth } from "@/app/components/auth/AuthProvider";
+import { createTable } from "@/app/lib/tableAPI";
+import M3FloatingInput from "@/app/components/template/M3FloatingInput";
+
+export default function TablesPage() {
+  const { tables, mutate } = useTables();
+  const { token } = useAuth();
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [worldId, setWorldId] = useState("");
+  const [crest, setCrest] = useState("");
+
+  async function handleCreate() {
+    await createTable({ world_id: Number(worldId), name, crest_url: crest, member_ids: [] }, token);
+    setOpen(false);
+    setName("");
+    setWorldId("");
+    setCrest("");
+    mutate();
+  }
+
+  return (
+    <DashboardLayout>
+      <div className="w-full max-w-4xl mx-auto p-4">
+        <div className="flex justify-between items-center mb-4">
+          <h1 className="text-2xl font-bold">Party Tables</h1>
+          <button
+            className="px-4 py-2 rounded-lg bg-[var(--primary)] text-[var(--primary-foreground)]"
+            onClick={() => setOpen(true)}
+          >
+            Create
+          </button>
+        </div>
+        <ul className="space-y-2">
+          {tables.map((t: any) => (
+            <li key={t.id} className="p-4 rounded-xl bg-[var(--surface-variant)] flex justify-between">
+              <span className="font-semibold">{t.name}</span>
+              <a href={`/tables/${t.id}/sessions`} className="text-sm text-[var(--primary)]">
+                Sessions
+              </a>
+            </li>
+          ))}
+        </ul>
+        {open && (
+          <div className="fixed inset-0 bg-black/40 flex items-center justify-center">
+            <div className="bg-[var(--surface)] p-6 rounded-xl w-full max-w-md space-y-4">
+              <M3FloatingInput label="Name" value={name} onChange={(e: any) => setName(e.target.value)} />
+              <M3FloatingInput label="World ID" value={worldId} onChange={(e: any) => setWorldId(e.target.value)} />
+              <M3FloatingInput label="Crest URL" value={crest} onChange={(e: any) => setCrest(e.target.value)} />
+              <div className="flex justify-end gap-2">
+                <button onClick={() => setOpen(false)} className="px-4 py-2 rounded-lg">
+                  Cancel
+                </button>
+                <button
+                  onClick={handleCreate}
+                  className="px-4 py-2 rounded-lg bg-[var(--primary)] text-[var(--primary-foreground)]"
+                >
+                  Save
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </DashboardLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- add Table and Session backend models with News integration
- expose table and session management API routes
- build responsive UI pages and hooks for tables and sessions

## Testing
- `pytest` *(fails: {"detail":"Not Found"} for existing tests)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: multiple lint errors across frontend)*

------
https://chatgpt.com/codex/tasks/task_e_688e3182eb548322b1aca327acf7570e