### PR TITLE
Fix SQLModel relationship annotations

### DIFF
--- a/backend/app/models/model_session.py
+++ b/backend/app/models/model_session.py
@@ -1,7 +1,6 @@
-from __future__ import annotations
 from typing import Optional, List
-from sqlmodel import SQLModel, Field, Relationship
 from datetime import datetime, timezone
+from sqlmodel import SQLModel, Field, Relationship
 
 class Session(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)

--- a/backend/app/models/model_table.py
+++ b/backend/app/models/model_table.py
@@ -1,7 +1,6 @@
-from __future__ import annotations
 from typing import Optional, List
-from sqlmodel import SQLModel, Field, Relationship
 from datetime import datetime, timezone
+from sqlmodel import SQLModel, Field, Relationship
 
 class Table(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)


### PR DESCRIPTION
## Summary
- Remove postponed annotation imports causing SQLAlchemy to misinterpret relationship targets
- Clean up imports in table and session models

## Testing
- `pytest` *(fails: Not Found errors, 26 failed)*

------
https://chatgpt.com/codex/tasks/task_e_688e4a4f3e78832297cb6c737a962d11