### PR TITLE
Add sessions navigation to sidebar and dashboard

### DIFF
--- a/frontend/src/app/components/template/Sidebar.tsx
+++ b/frontend/src/app/components/template/Sidebar.tsx
@@ -16,7 +16,7 @@ import SettingsRoundedIcon from "@mui/icons-material/SettingsRounded";
 import HomeIcon from "@mui/icons-material/HomeRounded";
 import PersonEditAlt1RoundedIcon from "@mui/icons-material/EditRounded";
 import NotificationsIcon from "@mui/icons-material/NotificationsRounded";
-import { Bot, BookOpenText, FileText, PenLine, Sparkles } from "lucide-react";
+import { Bot, BookOpenText, FileText, PenLine, Sparkles, ScrollText } from "lucide-react";
 import NewsDialog from "../news/NewsDialog";
 import { getNews, markNewsSeen } from "../../lib/newsAPI";
 
@@ -107,6 +107,13 @@ export default function Sidebar({ mobileOpen = false, setMobileOpen = () => {} }
       label: t("notes"),
       icon: <FileText fontSize="medium" />,
       href: "/user_notes",
+      external: false,
+      show: true,
+    },
+    {
+      label: t("sessions"),
+      icon: <ScrollText fontSize="medium" />,
+      href: "/tables",
       external: false,
       show: true,
     },

--- a/frontend/src/app/locales/en.json
+++ b/frontend/src/app/locales/en.json
@@ -40,6 +40,8 @@
   "system_settings": "System Settings",
   "library": "Library",
   "notes": "Notes",
+  "sessions": "Sessions",
+  "sessions_desc": "Track and manage your play sessions.",
   "worlds": "Worlds",
   "hi": "Hi!",
   "personalize": "Personalize",

--- a/frontend/src/app/locales/it.json
+++ b/frontend/src/app/locales/it.json
@@ -40,6 +40,8 @@
   "system_settings": "Impostazioni di Sistema",
   "library": "Libreria",
   "notes": "Note",
+  "sessions": "Sessioni",
+  "sessions_desc": "Tieni traccia e gestisci le tue sessioni di gioco.",
   "worlds": "Mondi",
   "hi": "Ciao!",
   "personalize": "Personalizza",

--- a/frontend/src/app/main/page.tsx
+++ b/frontend/src/app/main/page.tsx
@@ -14,6 +14,7 @@ import {
   Hammer,
   Settings,
   StickyNote,
+  ScrollText,
 } from "lucide-react";
 import { Suspense } from "react";
 
@@ -119,6 +120,16 @@ export default function MainPage() {
       group: "worldcraft",
       color: "bg-gradient-to-br from-rose-50 to-transparent",
       iconColor: "bg-rose-400",
+    },
+    {
+      title: t("sessions"),
+      description: t("sessions_desc"),
+      icon: <ScrollText className="w-6 h-6" />,
+      href: "/tables",
+      show: !!user,
+      group: "worldcraft",
+      color: "bg-gradient-to-br from-green-50 to-transparent",
+      iconColor: "bg-green-400",
     },
     {
       title: t("ai_world_elders"),


### PR DESCRIPTION
## Summary
- add Sessions item to sidebar menu
- expose Sessions via a dashboard card with icon and translation

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: many lint errors)


------
https://chatgpt.com/codex/tasks/task_e_688e4d1732c48322b9fee3bd9eed2aab