### PR TITLE
feat: add session polling

### DIFF
--- a/backend/app/api/api_session.py
+++ b/backend/app/api/api_session.py
@@ -1,11 +1,23 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing import List
 from app.database import get_session
 from app.models.model_user import User
 from app.dependencies import get_current_user
 from app.schemas.schema_session import SessionCreate, SessionRead
+from app.schemas.schema_session_poll import (
+    SessionPollCreate,
+    SessionPollRead,
+    SessionPollVoteCreate,
+)
 from app.crud.crud_session import create_session, get_sessions_for_table
+from app.crud.crud_session_poll import (
+    create_poll,
+    get_poll,
+    cast_vote,
+    finalize_poll,
+    poll_to_read,
+)
 
 router = APIRouter(prefix="/tables", tags=["sessions"], dependencies=[Depends(get_current_user)])
 
@@ -21,11 +33,13 @@ async def create_session_endpoint(
     return SessionRead(
         id=sess.id,
         table_id=sess.table_id,
+        name=sess.name,
         scheduled_time=sess.scheduled_time,
         summary=sess.summary,
         location=sess.location,
         created_by=sess.created_by,
         created_at=sess.created_at,
+        page_ids=[p.page_id for p in sess.pages],
     )
 
 @router.get("/{table_id}/sessions", response_model=List[SessionRead])
@@ -39,11 +53,68 @@ async def list_sessions_endpoint(
         SessionRead(
             id=s.id,
             table_id=s.table_id,
+            name=s.name,
             scheduled_time=s.scheduled_time,
             summary=s.summary,
             location=s.location,
             created_by=s.created_by,
             created_at=s.created_at,
+            page_ids=[p.page_id for p in s.pages],
         )
         for s in sessions
     ]
+
+
+@router.post("/{table_id}/sessions/{session_id}/poll", response_model=SessionPollRead)
+async def create_poll_endpoint(
+    table_id: int,
+    session_id: int,
+    poll_in: SessionPollCreate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(get_current_user),
+):
+    poll = await create_poll(session, session_id, poll_in)
+    return await poll_to_read(session, poll)
+
+
+@router.get("/{table_id}/sessions/{session_id}/poll", response_model=SessionPollRead)
+async def get_poll_endpoint(
+    table_id: int,
+    session_id: int,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(get_current_user),
+):
+    poll = await get_poll(session, session_id)
+    if not poll:
+        raise HTTPException(status_code=404, detail="Poll not found")
+    return await poll_to_read(session, poll)
+
+
+@router.post("/{table_id}/sessions/{session_id}/poll/vote", response_model=SessionPollRead)
+async def vote_poll_endpoint(
+    table_id: int,
+    session_id: int,
+    vote: SessionPollVoteCreate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(get_current_user),
+):
+    poll = await get_poll(session, session_id)
+    if not poll:
+        raise HTTPException(status_code=404, detail="Poll not found")
+    await cast_vote(session, poll, user.id, vote)
+    return await poll_to_read(session, poll)
+
+
+@router.post("/{table_id}/sessions/{session_id}/poll/finalize", response_model=SessionPollRead)
+async def finalize_poll_endpoint(
+    table_id: int,
+    session_id: int,
+    vote: SessionPollVoteCreate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(get_current_user),
+):
+    poll = await get_poll(session, session_id)
+    if not poll:
+        raise HTTPException(status_code=404, detail="Poll not found")
+    poll = await finalize_poll(session, poll, vote.option_id)
+    return await poll_to_read(session, poll)

--- a/backend/app/crud/crud_session.py
+++ b/backend/app/crud/crud_session.py
@@ -1,15 +1,17 @@
 from typing import List, Set
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from app.models.model_session import Session, SessionAttendance
+from app.models.model_session import Session, SessionAttendance, SessionPage
 from app.models.model_table import TableMember
 from app.schemas.schema_session import SessionCreate
 from app.crud.crud_news import create_news
 from app.schemas.schema_news import NewsCreate
 
+
 async def create_session(session: AsyncSession, session_in: SessionCreate, creator_id: int) -> Session:
     sess = Session(
         table_id=session_in.table_id,
+        name=session_in.name,
         scheduled_time=session_in.scheduled_time,
         summary=session_in.summary,
         location=session_in.location,
@@ -27,15 +29,20 @@ async def create_session(session: AsyncSession, session_in: SessionCreate, creat
         attendee_ids = set(result.scalars().all())
     for uid in attendee_ids:
         session.add(SessionAttendance(session_id=sess.id, user_id=uid, attending=True))
+
+    for pid in session_in.page_ids or []:
+        session.add(SessionPage(session_id=sess.id, page_id=pid))
+
     await session.commit()
 
     news = NewsCreate(
         title="Session Scheduled",
         type="session",
-        description=f"Session for table {session_in.table_id} on {sess.scheduled_time.isoformat()}"
+        description=f"Session for table {session_in.table_id} on {sess.scheduled_time.isoformat()}",
     )
     await create_news(session, news)
     return sess
+
 
 async def get_sessions_for_table(session: AsyncSession, table_id: int) -> List[Session]:
     result = await session.execute(select(Session).where(Session.table_id == table_id))

--- a/backend/app/crud/crud_session_poll.py
+++ b/backend/app/crud/crud_session_poll.py
@@ -1,0 +1,75 @@
+from typing import List, Optional
+from sqlalchemy import select, delete
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.models.model_session import (
+    SessionPoll,
+    SessionPollOption,
+    SessionPollVote,
+)
+from app.schemas.schema_session_poll import (
+    SessionPollCreate,
+    SessionPollVoteCreate,
+    SessionPollRead,
+    SessionPollOptionRead,
+)
+
+
+async def create_poll(session: AsyncSession, session_id: int, poll_in: SessionPollCreate) -> SessionPoll:
+    poll = SessionPoll(session_id=session_id)
+    session.add(poll)
+    await session.commit()
+    await session.refresh(poll)
+
+    for dt in poll_in.proposed_times:
+        session.add(SessionPollOption(poll_id=poll.id, proposed_time=dt))
+    await session.commit()
+    await session.refresh(poll)
+    return poll
+
+
+async def get_poll(session: AsyncSession, session_id: int) -> Optional[SessionPoll]:
+    result = await session.execute(select(SessionPoll).where(SessionPoll.session_id == session_id))
+    return result.scalar_one_or_none()
+
+
+async def cast_vote(session: AsyncSession, poll: SessionPoll, user_id: int, vote_in: SessionPollVoteCreate) -> None:
+    await session.execute(
+        delete(SessionPollVote).where(
+            (SessionPollVote.poll_id == poll.id) & (SessionPollVote.user_id == user_id)
+        )
+    )
+    session.add(
+        SessionPollVote(poll_id=poll.id, option_id=vote_in.option_id, user_id=user_id)
+    )
+    await session.commit()
+
+
+async def finalize_poll(session: AsyncSession, poll: SessionPoll, option_id: int) -> SessionPoll:
+    poll.final_option_id = option_id
+    await session.commit()
+    await session.refresh(poll)
+    return poll
+
+
+async def poll_to_read(session: AsyncSession, poll: SessionPoll) -> SessionPollRead:
+    result = await session.execute(
+        select(SessionPollOption).where(SessionPollOption.poll_id == poll.id)
+    )
+    options = result.scalars().all()
+    options_read: List[SessionPollOptionRead] = []
+    for option in options:
+        vote_result = await session.execute(
+            select(SessionPollVote.user_id).where(SessionPollVote.option_id == option.id)
+        )
+        votes = list(vote_result.scalars().all())
+        options_read.append(
+            SessionPollOptionRead(id=option.id, proposed_time=option.proposed_time, votes=votes)
+        )
+    return SessionPollRead(
+        id=poll.id,
+        session_id=poll.session_id,
+        final_option_id=poll.final_option_id,
+        options=options_read,
+        created_at=poll.created_at,
+    )
+

--- a/backend/app/models/model_session.py
+++ b/backend/app/models/model_session.py
@@ -2,9 +2,11 @@ from typing import Optional, List
 from datetime import datetime, timezone
 from sqlmodel import SQLModel, Field, Relationship
 
+
 class Session(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     table_id: int = Field(foreign_key="table.id")
+    name: str
     scheduled_time: datetime
     summary: Optional[str] = None
     location: Optional[str] = None
@@ -12,6 +14,9 @@ class Session(SQLModel, table=True):
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     attendances: List["SessionAttendance"] = Relationship(back_populates="session")
+    pages: List["SessionPage"] = Relationship(back_populates="session")
+    poll: Optional["SessionPoll"] = Relationship(back_populates="session")
+
 
 class SessionAttendance(SQLModel, table=True):
     session_id: int = Field(foreign_key="session.id", primary_key=True)
@@ -19,3 +24,39 @@ class SessionAttendance(SQLModel, table=True):
     attending: bool = Field(default=True)
 
     session: "Session" = Relationship(back_populates="attendances")
+
+
+class SessionPage(SQLModel, table=True):
+    session_id: int = Field(foreign_key="session.id", primary_key=True)
+    page_id: int = Field(foreign_key="page.id", primary_key=True)
+
+    session: "Session" = Relationship(back_populates="pages")
+
+
+class SessionPoll(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    session_id: int = Field(foreign_key="session.id")
+    final_option_id: Optional[int] = Field(default=None, foreign_key="sessionpolloption.id")
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+    session: "Session" = Relationship(back_populates="poll")
+    options: List["SessionPollOption"] = Relationship(back_populates="poll")
+    votes: List["SessionPollVote"] = Relationship(back_populates="poll")
+
+
+class SessionPollOption(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    poll_id: int = Field(foreign_key="sessionpoll.id")
+    proposed_time: datetime
+
+    poll: "SessionPoll" = Relationship(back_populates="options")
+    votes: List["SessionPollVote"] = Relationship(back_populates="option")
+
+
+class SessionPollVote(SQLModel, table=True):
+    poll_id: int = Field(foreign_key="sessionpoll.id", primary_key=True)
+    option_id: int = Field(foreign_key="sessionpolloption.id", primary_key=True)
+    user_id: int = Field(foreign_key="user.id", primary_key=True)
+
+    poll: "SessionPoll" = Relationship(back_populates="votes")
+    option: "SessionPollOption" = Relationship(back_populates="votes")

--- a/backend/app/schemas/schema_session.py
+++ b/backend/app/schemas/schema_session.py
@@ -2,20 +2,27 @@ from typing import Optional, List
 from datetime import datetime
 from sqlmodel import SQLModel
 
+
 class SessionBase(SQLModel):
+    name: str
     scheduled_time: datetime
     summary: Optional[str] = None
     location: Optional[str] = None
 
+
 class SessionCreate(SessionBase):
     table_id: int
     attendee_ids: List[int] = []
+    page_ids: List[int] = []
+
 
 class SessionRead(SessionBase):
     id: int
     table_id: int
     created_by: int
     created_at: datetime
+    page_ids: List[int] = []
+
 
 SessionCreate.model_rebuild()
 SessionRead.model_rebuild()

--- a/backend/app/schemas/schema_session_poll.py
+++ b/backend/app/schemas/schema_session_poll.py
@@ -1,0 +1,31 @@
+from typing import List, Optional
+from datetime import datetime
+from sqlmodel import SQLModel
+
+
+class SessionPollCreate(SQLModel):
+    proposed_times: List[datetime]
+
+
+class SessionPollVoteCreate(SQLModel):
+    option_id: int
+
+
+class SessionPollOptionRead(SQLModel):
+    id: int
+    proposed_time: datetime
+    votes: List[int] = []
+
+
+class SessionPollRead(SQLModel):
+    id: int
+    session_id: int
+    final_option_id: Optional[int] = None
+    options: List[SessionPollOptionRead] = []
+    created_at: datetime
+
+
+SessionPollCreate.model_rebuild()
+SessionPollVoteCreate.model_rebuild()
+SessionPollOptionRead.model_rebuild()
+SessionPollRead.model_rebuild()


### PR DESCRIPTION
## Summary
- allow sessions to include a name and associated pages
- add polling models and CRUD to propose dates and gather votes
- expose poll endpoints for creating, voting and finalizing session dates

## Testing
- `pytest` *(fails: ImportError and multiple 404 Not Found errors)*

------
https://chatgpt.com/codex/tasks/task_e_688e543216a883228218791f494ba61a