### PR TITLE
docs: add agent flow diagrams

### DIFF
--- a/docs/conversational_agent.md
+++ b/docs/conversational_agent.md
@@ -1,27 +1,28 @@
 # Conversational Agent Flow
 
-This diagram outlines the flow of a chat request through the backend conversational agent, showing which functions and classes are invoked.
+This diagram outlines the flow of a chat request through the backend conversational agent and highlights the primary classes involved.
 
 ```mermaid
 sequenceDiagram
     participant User
     participant API as FastAPI /agents/{id}/chat
-    participant Chat as chat_with_agent
-    participant Workers as agentic_worker_* modules
-    participant LLM as ChatOpenAI
+    participant Chat as crud_agent_conversational.chat_with_agent
+    participant Shrecknet as agentic_worker_shrecknet
+    participant LLMWorker as agentic_worker_llm
+    participant LLM as LangGraph\n(ChatPromptTemplate → ChatOpenAI)
     User->>API: POST message
     API->>Chat: chat_with_agent(messages)
-    Chat->>Workers: decompose_question(query)
-    Workers-->>Chat: sub-questions
-    Chat->>Workers: query_world_embeddings(sub-questions)
-    Workers-->>Chat: annotated results
-    Chat->>Workers: aggregate_prune_and_dedup(results)
-    Workers-->>Chat: context & sources
+    Chat->>Shrecknet: decompose_question(query)
+    Shrecknet-->>Chat: sub-questions
+    Chat->>Shrecknet: query_world_embeddings(sub-questions)
+    Shrecknet-->>Chat: annotated results
+    Chat->>LLMWorker: aggregate_prune_and_dedup(results)
+    LLMWorker-->>Chat: context & sources
     Chat->>Chat: ensure_personality_prompts()
-    Chat->>LLM: LangGraph Graph\n(ChatPromptTemplate + ChatOpenAI)
+    Chat->>LLM: invoke graph
     LLM-->>Chat: answer
-    Chat->>Workers: validate_response(query, answer)
-    Workers-->>Chat: pass/fail
+    Chat->>LLMWorker: validate_response(query, answer)
+    LLMWorker-->>Chat: pass/fail
     alt needs retry
         Chat->>LLM: fallback prompt
         LLM-->>Chat: revised answer
@@ -30,6 +31,6 @@ sequenceDiagram
     API-->>User: JSON response
 ```
 
-* **chat_with_agent** orchestrates the conversation pipeline.
-* **agentic_worker_llm** and **agentic_worker_shrecknet** modules provide `decompose_question`, `query_world_embeddings`, `aggregate_prune_and_dedup`, and `validate_response` helpers.
-* **ChatPromptTemplate**, **ChatOpenAI**, and **LangGraph Graph** compose the LLM call.
+* **crud_agent_conversational.chat_with_agent** orchestrates the conversation pipeline.
+* **agentic_worker_shrecknet** resolves context from the world and **agentic_worker_llm** refines results and validates the model output.
+* **ChatPromptTemplate**, **ChatOpenAI**, and **LangGraph** compose the LLM call.

--- a/docs/writer_agent.md
+++ b/docs/writer_agent.md
@@ -1,0 +1,55 @@
+# Writer Agent Flow
+
+These diagrams outline how the writer agent analyzes existing pages and generates new or updated pages within a world.
+
+## Analyze Pages Job
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant API as POST /agents/{id}/pages/{page_id}/analyze_job
+    participant Celery as task_analyze_pages_job
+    participant WriterCRUD as crud_agent_writer.analyze_pages
+    participant Shrecknet as agentic_worker_shrecknet
+    participant LLMWorker as agentic_worker_llm
+    User->>API: request analysis
+    API->>Celery: enqueue job + job.json
+    Celery->>WriterCRUD: analyze_pages(agent, pages)
+    WriterCRUD->>Shrecknet: load_context_and_data_worker
+    Shrecknet-->>WriterCRUD: context
+    WriterCRUD->>Shrecknet: extract_metadata_and_chunks_worker
+    Shrecknet-->>WriterCRUD: metadata & chunks
+    WriterCRUD->>LLMWorker: process_chunks_worker
+    LLMWorker-->>WriterCRUD: pairs
+    WriterCRUD->>LLMWorker: merge_and_deduplicate_worker
+    LLMWorker-->>WriterCRUD: suggestions
+    WriterCRUD-->>Celery: suggestions
+    Celery-->>API: write analysis.json
+    API-->>User: job status
+```
+
+## Generate Pages Job
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant API as POST /agents/{id}/pages/{page_id}/generate_job
+    participant Celery as task_generate_pages_job
+    participant WriterCRUD as crud_agent_writer.generate_pages
+    participant LLM as ChatOpenAI
+    participant DB as crud_page
+    User->>API: request page generation
+    API->>Celery: enqueue job + request data
+    Celery->>WriterCRUD: generate_pages(agent, page, specs)
+    WriterCRUD->>LLM: prompts via ChatPromptTemplate
+    LLM-->>WriterCRUD: new or updated content
+    WriterCRUD->>DB: create/update pages
+    DB-->>WriterCRUD: saved pages
+    WriterCRUD-->>Celery: result summary
+    Celery-->>API: write generated.json
+    API-->>User: job status
+```
+
+* **task_analyze_pages_job** and **task_generate_pages_job** run in Celery workers and call into `crud_agent_writer`.
+* **agentic_worker_shrecknet** and **agentic_worker_llm** provide context extraction and LLM utilities.
+* **ChatOpenAI** produces page text which is persisted via `crud_page`.


### PR DESCRIPTION
## Summary
- expand conversational agent diagram with explicit module references
- document writer agent flows for analysis and page generation

## Testing
- `pytest` *(fails: Not Found errors)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688e580dfc948322afd74490f0acc593