### PR TITLE
feat: enhance tables page with session insights

### DIFF
--- a/backend/app/api/api_table.py
+++ b/backend/app/api/api_table.py
@@ -1,13 +1,27 @@
+from datetime import datetime, timezone
 from fastapi import APIRouter, Depends
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing import List
 from app.database import get_session
 from app.models.model_user import User, UserRole
+from app.models.model_table import TableMember
+from app.models.model_gameworld import GameWorld
+from app.models.model_session import Session
 from app.dependencies import get_current_user, require_role
-from app.schemas.schema_table import TableCreate, TableRead
-from app.crud.crud_table import create_table, get_tables_for_user
+from app.schemas.schema_table import (
+    TableCreate,
+    TableListRead,
+    TableMemberInfo,
+    TableRead,
+    TableUpdate,
+)
+from app.crud.crud_table import create_table, get_tables_for_user, update_table
 
-router = APIRouter(prefix="/tables", tags=["tables"], dependencies=[Depends(get_current_user)])
+router = APIRouter(
+    prefix="/tables", tags=["tables"], dependencies=[Depends(get_current_user)]
+)
+
 
 @router.post("/", response_model=TableRead)
 async def create_table_endpoint(
@@ -17,20 +31,67 @@ async def create_table_endpoint(
 ):
     return await create_table(session, table, user.id)
 
-@router.get("/", response_model=List[TableRead])
+
+@router.get("/", response_model=List[TableListRead])
 async def list_tables_endpoint(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(get_current_user),
 ):
     tables = await get_tables_for_user(session, user.id)
-    return [
-        TableRead(
-            id=t.id,
-            world_id=t.world_id,
-            name=t.name,
-            crest_url=t.crest_url,
-            created_by=t.created_by,
-            created_at=t.created_at,
+    now = datetime.now(timezone.utc)
+    results: List[TableListRead] = []
+    for t in tables:
+        # World information
+        world = await session.get(GameWorld, t.world_id)
+        world_name = world.name if world else ""
+
+        # Table members
+        member_rows = await session.execute(
+            select(User.id, User.nickname, User.image_url)
+            .join(TableMember, TableMember.user_id == User.id)
+            .where(TableMember.table_id == t.id)
         )
-        for t in tables
-    ]
+        members = [
+            TableMemberInfo(id=mid, nickname=nick, image_url=img)
+            for mid, nick, img in member_rows.all()
+        ]
+
+        # Sessions
+        session_rows = await session.execute(
+            select(Session).where(Session.table_id == t.id)
+        )
+        sessions = session_rows.scalars().all()
+        latest = None
+        next_up = None
+        for s in sessions:
+            if s.scheduled_time <= now:
+                if not latest or s.scheduled_time > latest.scheduled_time:
+                    latest = s
+            elif not next_up or s.scheduled_time < next_up.scheduled_time:
+                next_up = s
+
+        results.append(
+            TableListRead(
+                id=t.id,
+                world_id=t.world_id,
+                name=t.name,
+                crest_url=t.crest_url,
+                created_by=t.created_by,
+                created_at=t.created_at,
+                world_name=world_name,
+                members=members,
+                latest_session=latest.scheduled_time if latest else None,
+                next_session=next_up.scheduled_time if next_up else None,
+            )
+        )
+    return results
+
+
+@router.patch("/{table_id}", response_model=TableRead)
+async def update_table_endpoint(
+    table_id: int,
+    table: TableUpdate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_role(UserRole.world_builder)),
+):
+    return await update_table(session, table_id, table)

--- a/backend/app/crud/crud_table.py
+++ b/backend/app/crud/crud_table.py
@@ -2,9 +2,12 @@ from typing import List
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.model_table import Table, TableMember
-from app.schemas.schema_table import TableCreate
+from app.schemas.schema_table import TableCreate, TableUpdate
 
-async def create_table(session: AsyncSession, table_in: TableCreate, creator_id: int) -> Table:
+
+async def create_table(
+    session: AsyncSession, table_in: TableCreate, creator_id: int
+) -> Table:
     table = Table(
         world_id=table_in.world_id,
         name=table_in.name,
@@ -18,12 +21,32 @@ async def create_table(session: AsyncSession, table_in: TableCreate, creator_id:
     member_ids = set(table_in.member_ids or [])
     member_ids.add(creator_id)
     for uid in member_ids:
-        session.add(TableMember(table_id=table.id, user_id=uid, is_gm=(uid == creator_id)))
+        session.add(
+            TableMember(table_id=table.id, user_id=uid, is_gm=(uid == creator_id))
+        )
     await session.commit()
     return table
+
 
 async def get_tables_for_user(session: AsyncSession, user_id: int) -> List[Table]:
     result = await session.execute(
         select(Table).join(TableMember).where(TableMember.user_id == user_id)
     )
     return result.scalars().all()
+
+
+async def update_table(
+    session: AsyncSession, table_id: int, table_in: TableUpdate
+) -> Table:
+    table = await session.get(Table, table_id)
+    if not table:
+        raise ValueError("Table not found")
+
+    update_data = table_in.model_dump(exclude_unset=True)
+    for field, value in update_data.items():
+        setattr(table, field, value)
+
+    session.add(table)
+    await session.commit()
+    await session.refresh(table)
+    return table

--- a/backend/app/schemas/schema_table.py
+++ b/backend/app/schemas/schema_table.py
@@ -2,24 +2,57 @@ from typing import Optional, List
 from datetime import datetime
 from sqlmodel import SQLModel
 
+
 class TableBase(SQLModel):
     world_id: int
     name: str
     crest_url: Optional[str] = None
 
+
 class TableCreate(TableBase):
     member_ids: List[int] = []
+
 
 class TableRead(TableBase):
     id: int
     created_by: int
     created_at: datetime
 
+
+class TableUpdate(SQLModel):
+    """Fields allowed for table updates."""
+
+    world_id: Optional[int] = None
+    name: Optional[str] = None
+    crest_url: Optional[str] = None
+
+
 class TableMemberRead(SQLModel):
     table_id: int
     user_id: int
     is_gm: bool = False
 
+
+class TableMemberInfo(SQLModel):
+    """Simplified member info for table listings."""
+
+    id: int
+    nickname: str
+    image_url: Optional[str] = None
+
+
+class TableListRead(TableRead):
+    """Table representation for list views with related data."""
+
+    world_name: str
+    members: List[TableMemberInfo] = []
+    latest_session: Optional[datetime] = None
+    next_session: Optional[datetime] = None
+
+
 TableCreate.model_rebuild()
 TableRead.model_rebuild()
 TableMemberRead.model_rebuild()
+TableUpdate.model_rebuild()
+TableMemberInfo.model_rebuild()
+TableListRead.model_rebuild()

--- a/frontend/src/app/lib/tableAPI.ts
+++ b/frontend/src/app/lib/tableAPI.ts
@@ -11,7 +11,23 @@ export async function getTables(token: string) {
 export async function createTable(data: unknown, token: string) {
   const res = await fetch(`${API_URL}/tables/`, {
     method: "POST",
-    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw await res.json();
+  return await res.json();
+}
+
+export async function updateTable(id: number, data: unknown, token: string) {
+  const res = await fetch(`${API_URL}/tables/${id}`, {
+    method: "PATCH",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
     body: JSON.stringify(data),
   });
   if (!res.ok) throw await res.json();

--- a/frontend/src/app/lib/uploadTableLogo.ts
+++ b/frontend/src/app/lib/uploadTableLogo.ts
@@ -1,0 +1,5 @@
+import { uploadImage } from "./uploadImage";
+
+export async function uploadTableLogo(file: File, tableId: number) {
+  return uploadImage(file, "tables", `${tableId}/logo`, "logo");
+}

--- a/frontend/src/app/tables/page.tsx
+++ b/frontend/src/app/tables/page.tsx
@@ -1,14 +1,31 @@
 "use client";
-import { useState } from "react";
+import { useState, ChangeEvent } from "react";
+import Image from "next/image";
 import DashboardLayout from "@/app/components/DashboardLayout";
 import { useTables } from "@/app/lib/useTables";
 import { useAuth } from "@/app/components/auth/AuthProvider";
-import { createTable } from "@/app/lib/tableAPI";
+import { createTable, updateTable } from "@/app/lib/tableAPI";
+import { uploadTableLogo } from "@/app/lib/uploadTableLogo";
 import PageRefSelectorMD3 from "@/app/components/create_page/PageRefSelectorMD3";
 import { useWorlds } from "@/app/lib/userWorlds";
 import { useUsers } from "@/app/lib/useUsers";
 import { M3FloatingInput } from "../components/template/M3FloatingInput";
 
+interface TableMember {
+  id: number;
+  nickname: string;
+  image_url?: string | null;
+}
+
+interface TableItem {
+  id: number;
+  name: string;
+  world_name: string;
+  crest_url?: string | null;
+  members: TableMember[];
+  latest_session?: string | null;
+  next_session?: string | null;
+}
 
 export default function TablesPage() {
   const { tables, mutate } = useTables();
@@ -18,23 +35,28 @@ export default function TablesPage() {
   const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
   const [worldId, setWorldId] = useState("");
-  const [crest, setCrest] = useState("");
+  const [logo, setLogo] = useState<File | null>(null);
   const [members, setMembers] = useState<string[]>([]);
 
   async function handleCreate() {
-    await createTable(
+    const table = await createTable(
       {
         world_id: Number(worldId),
         name,
-        crest_url: crest,
         member_ids: members.map((m) => Number(m)),
       },
       token,
     );
+
+    if (logo) {
+      const url = await uploadTableLogo(logo, table.id);
+      await updateTable(table.id, { crest_url: url }, token);
+    }
+
     setOpen(false);
     setName("");
     setWorldId("");
-    setCrest("");
+    setLogo(null);
     setMembers([]);
     mutate();
   }
@@ -52,15 +74,65 @@ export default function TablesPage() {
           </button>
         </div>
         <ul className="space-y-2">
-          {tables.map((t: any) => (
+          {tables.map((t: TableItem) => (
             <li
               key={t.id}
-              className="p-4 rounded-xl bg-[var(--surface-variant)] flex justify-between"
+              className="p-4 rounded-xl bg-[var(--surface-variant)] flex gap-4"
             >
-              <span className="font-semibold">{t.name}</span>
+              <Image
+                src={t.crest_url || "/images/worlds/new_game.png"}
+                alt={t.name}
+                width={64}
+                height={64}
+                className="w-16 h-16 rounded object-cover"
+              />
+              <div className="flex-1 space-y-1">
+                <div className="flex justify-between">
+                  <span className="font-semibold">{t.name}</span>
+                  <span className="text-sm text-[var(--primary)]">
+                    {t.world_name}
+                  </span>
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  {t.members.map((m: TableMember) => (
+                    <div key={m.id} className="flex items-center gap-1 text-xs">
+                      <Image
+                        src={m.image_url || "/images/avatars/default.png"}
+                        alt={m.nickname}
+                        width={24}
+                        height={24}
+                        className="w-6 h-6 rounded-full object-cover"
+                      />
+                      <span>{m.nickname}</span>
+                    </div>
+                  ))}
+                </div>
+                <div className="text-xs">
+                  {t.latest_session && (
+                    <div>
+                      Last: {new Date(t.latest_session).toLocaleString()} (
+                      {Math.floor(
+                        (Date.now() - new Date(t.latest_session).getTime()) /
+                          (1000 * 60 * 60 * 24),
+                      )}{" "}
+                      days ago)
+                    </div>
+                  )}
+                  {t.next_session && (
+                    <div>
+                      Next: {new Date(t.next_session).toLocaleString()} (in{" "}
+                      {Math.ceil(
+                        (new Date(t.next_session).getTime() - Date.now()) /
+                          (1000 * 60 * 60 * 24),
+                      )}{" "}
+                      days)
+                    </div>
+                  )}
+                </div>
+              </div>
               <a
                 href={`/tables/${t.id}/sessions`}
-                className="text-sm text-[var(--primary)]"
+                className="text-sm text-[var(--primary)] self-start"
               >
                 Sessions
               </a>
@@ -73,7 +145,9 @@ export default function TablesPage() {
               <M3FloatingInput
                 label="Name"
                 value={name}
-                onChange={(e: any) => setName(e.target.value)}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  setName(e.target.value)
+                }
               />
               <div>
                 <label className="text-[var(--primary)] font-semibold text-sm mb-1 block">
@@ -81,28 +155,44 @@ export default function TablesPage() {
                 </label>
                 <select
                   value={worldId}
-                  onChange={(e: any) => setWorldId(e.target.value)}
+                  onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+                    setWorldId(e.target.value)
+                  }
                   className="w-full px-3 py-2 rounded-lg border border-[var(--border)] bg-[var(--surface)]"
                 >
                   <option value="">Select world</option>
-                  {worlds.map((w: any) => (
+                  {worlds.map((w: { id: number; name: string }) => (
                     <option key={w.id} value={w.id}>
                       {w.name}
                     </option>
                   ))}
                 </select>
               </div>
-              <M3FloatingInput
-                label="Crest URL"
-                value={crest}
-                onChange={(e: any) => setCrest(e.target.value)}
-              />
+              <div>
+                <label className="text-[var(--primary)] font-semibold text-sm mb-1 block">
+                  Logo
+                </label>
+                <input
+                  type="file"
+                  accept="image/*"
+                  onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                    setLogo(e.target.files?.[0] || null)
+                  }
+                  className="w-full"
+                />
+              </div>
               <PageRefSelectorMD3
-                options={users.map((u: any) => ({
-                  id: u.id,
-                  name: u.nickname,
-                  logo: u.image_url,
-                }))}
+                options={users.map(
+                  (u: {
+                    id: number;
+                    nickname: string;
+                    image_url?: string | null;
+                  }) => ({
+                    id: u.id,
+                    name: u.nickname,
+                    logo: u.image_url,
+                  }),
+                )}
                 value={members}
                 onChange={setMembers}
                 label="Members"

--- a/frontend/src/pages/api/uploadImage.ts
+++ b/frontend/src/pages/api/uploadImage.ts
@@ -21,8 +21,12 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     let file = files.file as formidable.File | formidable.File[] | undefined;
     if (Array.isArray(file)) file = file[0];
 
-    const pageType = Array.isArray(fields.pageType) ? fields.pageType[0] : fields.pageType || "misc";
-    const pageName = Array.isArray(fields.pageName) ? fields.pageName[0] : fields.pageName || "general";
+    const pageType = Array.isArray(fields.pageType)
+      ? fields.pageType[0]
+      : fields.pageType || "misc";
+    const pageName = Array.isArray(fields.pageName)
+      ? fields.pageName[0]
+      : fields.pageName || "general";
     const customFileName = Array.isArray(fields.customFileName)
       ? fields.customFileName[0]
       : fields.customFileName;
@@ -32,15 +36,22 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
       return;
     }
 
-    const dir = path.join(process.cwd(), "uploads/images", pageType, pageName);
+    const isTable = pageType === "tables";
+    const dir = isTable
+      ? path.join(process.cwd(), "uploads", "tables", pageName)
+      : path.join(process.cwd(), "uploads/images", pageType, pageName);
     fs.mkdirSync(dir, { recursive: true });
 
     // File extension
-    const fileExt = path.extname(file.originalFilename || file.name || "upload").toLowerCase();
+    const fileExt = path
+      .extname(file.originalFilename || file.name || "upload")
+      .toLowerCase();
 
     // Clean base name
-    const baseName =
-      (file.originalFilename || file.name || "upload").replace(/[^a-zA-Z0-9_.-]/g, "_");
+    const baseName = (file.originalFilename || file.name || "upload").replace(
+      /[^a-zA-Z0-9_.-]/g,
+      "_",
+    );
 
     // Use customFileName if present, otherwise use the base name so repeated
     // uploads replace the previous file
@@ -53,7 +64,9 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     if (fs.existsSync(dest)) fs.unlinkSync(dest);
 
     // Robust: check for filepath (formidable v3+), fallback to path (v2)
-    const tempPath = (file as any).filepath || (file as any).path;
+    const tempPath =
+      (file as formidable.File & { filepath?: string }).filepath ||
+      (file as formidable.File & { path?: string }).path;
     if (!tempPath) {
       res.status(400).json({ error: "File path not found for upload" });
       return;
@@ -69,8 +82,9 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     }
     // -------------------------------------------------
 
+    const urlBase = isTable ? "/uploads/tables" : "/uploads/images";
     res.status(200).json({
-      url: `/uploads/images/${pageType}/${pageName}/${fileName}`.replace(/\/+/g, "/"),
+      url: path.join(urlBase, pageName, fileName).replace(/\\+/g, "/"),
     });
   });
 }


### PR DESCRIPTION
## Summary
- show table logos, world, members, and session info on /tables
- allow uploading table logos via existing image hook
- support crest updates through new backend endpoint

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'email_validator')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f523b476c8322a904a98dfd0903f3