### PR TITLE
feat: add read-only user table pages

### DIFF
--- a/frontend/src/app/components/template/Sidebar.tsx
+++ b/frontend/src/app/components/template/Sidebar.tsx
@@ -16,34 +16,53 @@ import SettingsRoundedIcon from "@mui/icons-material/SettingsRounded";
 import HomeIcon from "@mui/icons-material/HomeRounded";
 import PersonEditAlt1RoundedIcon from "@mui/icons-material/EditRounded";
 import NotificationsIcon from "@mui/icons-material/NotificationsRounded";
-import { Bot, BookOpenText, FileText, PenLine, Sparkles, ScrollText } from "lucide-react";
+import {
+  Bot,
+  BookOpenText,
+  FileText,
+  PenLine,
+  Sparkles,
+  ScrollText,
+} from "lucide-react";
 import NewsDialog from "../news/NewsDialog";
 import { getNews, markNewsSeen } from "../../lib/newsAPI";
 
-export default function Sidebar({ mobileOpen = false, setMobileOpen = () => {} }) {
+interface NewsItem {
+  id: number;
+  seen: boolean;
+  [key: string]: unknown;
+}
+
+export default function Sidebar({
+  mobileOpen = false,
+  setMobileOpen = () => {},
+}) {
   const { user, token, isLoading: authLoading, refreshUser } = useAuth();
   const { t } = useTranslation();
   const [profileModalOpen, setProfileModalOpen] = useState(false);
   const [profileSuccess, setProfileSuccess] = useState("");
   const [profileError, setProfileError] = useState("");
   const [newsOpen, setNewsOpen] = useState(false);
-  const [newsItems, setNewsItems] = useState([]);
+  const [newsItems, setNewsItems] = useState<NewsItem[]>([]);
 
   const pathname = usePathname();
 
   useEffect(() => {
     if (!token) return;
     getNews(token)
-      .then((items) => {
+      .then((items: NewsItem[]) => {
         setNewsItems(items);
-        const unseen = items.filter((n: any) => !n.seen);
+        const unseen = items.filter((n) => !n.seen);
         const today = new Date().toDateString();
-        const last = typeof window !== "undefined" ? localStorage.getItem("news_last_seen") : null;
+        const last =
+          typeof window !== "undefined"
+            ? localStorage.getItem("news_last_seen")
+            : null;
         if (last !== today && unseen.length > 0) {
           setNewsOpen(true);
           localStorage.setItem("news_last_seen", today);
-          unseen.forEach((n: any) => markNewsSeen(n.id, token));
-          setNewsItems(items.map((n: any) => ({ ...n, seen: true })));
+          unseen.forEach((n) => markNewsSeen(n.id, token));
+          setNewsItems(items.map((n) => ({ ...n, seen: true })));
         }
       })
       .catch(() => {});
@@ -51,10 +70,10 @@ export default function Sidebar({ mobileOpen = false, setMobileOpen = () => {} }
 
   function handleOpenNews() {
     setNewsOpen(true);
-    const unseen = newsItems.filter((n: any) => !n.seen);
+    const unseen = newsItems.filter((n) => !n.seen);
     if (unseen.length > 0) {
-      unseen.forEach((n: any) => markNewsSeen(n.id, token));
-      setNewsItems(newsItems.map((n: any) => ({ ...n, seen: true })));
+      unseen.forEach((n) => markNewsSeen(n.id, token));
+      setNewsItems(newsItems.map((n) => ({ ...n, seen: true })));
       if (typeof window !== "undefined") {
         localStorage.setItem("news_last_seen", new Date().toDateString());
       }
@@ -95,7 +114,7 @@ export default function Sidebar({ mobileOpen = false, setMobileOpen = () => {} }
       external: false,
       show: true,
     },
-    
+
     {
       label: t("library"),
       icon: <BookOpenText fontSize="medium" />,
@@ -113,7 +132,7 @@ export default function Sidebar({ mobileOpen = false, setMobileOpen = () => {} }
     {
       label: t("sessions"),
       icon: <ScrollText fontSize="medium" />,
-      href: "/tables",
+      href: "/user_table",
       external: false,
       show: true,
     },
@@ -166,9 +185,6 @@ export default function Sidebar({ mobileOpen = false, setMobileOpen = () => {} }
       show: user && ["world builder", "system admin"].includes(user.role),
     },
 
-
- 
-  
     {
       label: t("system_settings"),
       icon: <SettingsRoundedIcon fontSize="medium" />,
@@ -192,7 +208,9 @@ export default function Sidebar({ mobileOpen = false, setMobileOpen = () => {} }
       {/* Mobile overlay */}
       <div
         className={`fixed inset-0 z-40 bg-black/50 backdrop-blur-sm transition-opacity duration-300 md:hidden ${
-          mobileOpen ? "opacity-100 pointer-events-auto" : "opacity-0 pointer-events-none"
+          mobileOpen
+            ? "opacity-100 pointer-events-auto"
+            : "opacity-0 pointer-events-none"
         }`}
         onClick={() => setMobileOpen(false)}
         aria-hidden="true"
@@ -213,16 +231,14 @@ export default function Sidebar({ mobileOpen = false, setMobileOpen = () => {} }
       >
         {/* Logo only, fills width, with shadow/contrast */}
         <div className="flex items-center justify-center h-24 bg-transparent p-3 border-b border-[var(--border)]">
-          
-            <Image
-              src="/images/logo_dark.png"
-              alt="Shrecknet logo"
-              width={400}
-              height={400}
-              className="w-full h-auto max-w-[300px] object-contain drop-shadow-lg"
-              priority
-            />
-          
+          <Image
+            src="/images/logo_dark.png"
+            alt="Shrecknet logo"
+            width={400}
+            height={400}
+            className="w-full h-auto max-w-[300px] object-contain drop-shadow-lg"
+            priority
+          />
         </div>
 
         <div className="flex justify-end px-4 mt-2">
@@ -232,7 +248,7 @@ export default function Sidebar({ mobileOpen = false, setMobileOpen = () => {} }
             aria-label={t("news")}
           >
             <NotificationsIcon />
-            {newsItems.some((n: any) => !n.seen) && (
+            {newsItems.some((n) => !n.seen) && (
               <span className="absolute -top-1 -right-1 w-2 h-2 bg-red-600 rounded-full" />
             )}
           </button>
@@ -240,14 +256,16 @@ export default function Sidebar({ mobileOpen = false, setMobileOpen = () => {} }
 
         {/* Menu Items */}
         <nav className="flex-1 flex flex-col gap-1 py-6">
-          {menu.filter((m) => m.show).map((m) => (
-            m.external ? (
-              <a
-                key={m.label}
-                href={m.href}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={`
+          {menu
+            .filter((m) => m.show)
+            .map((m) =>
+              m.external ? (
+                <a
+                  key={m.label}
+                  href={m.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={`
                   flex items-center gap-3 px-5 py-3
                   rounded-md font-semibold
                   text-base text-[var(--foreground)]
@@ -255,25 +273,23 @@ export default function Sidebar({ mobileOpen = false, setMobileOpen = () => {} }
                   transition
                   border-r-4 border-transparent
                 `}
-                style={{ outline: "none" }}
-              >
-                <span className="text-2xl">{m.icon}</span>
-                <span className="flex items-center gap-1">
-                  {m.label}
-                  {m.ai && (
-                    <span
-                      className="ml-1 text-[10px] font-bold border rounded px-1 border-[var(--primary)] text-[var(--primary)]"
-                    >
-                      AI
-                    </span>
-                  )}
-                </span>
-              </a>
-            ) : (
-              <Link
-                key={m.label}
-                href={m.href}
-                className={`
+                  style={{ outline: "none" }}
+                >
+                  <span className="text-2xl">{m.icon}</span>
+                  <span className="flex items-center gap-1">
+                    {m.label}
+                    {m.ai && (
+                      <span className="ml-1 text-[10px] font-bold border rounded px-1 border-[var(--primary)] text-[var(--primary)]">
+                        AI
+                      </span>
+                    )}
+                  </span>
+                </a>
+              ) : (
+                <Link
+                  key={m.label}
+                  href={m.href}
+                  className={`
                   flex items-center gap-3 px-5 py-3
                   rounded-md font-semibold
                   text-base text-[var(--foreground)]
@@ -285,22 +301,20 @@ export default function Sidebar({ mobileOpen = false, setMobileOpen = () => {} }
                       : "border-transparent"
                   }
                 `}
-                style={{ outline: "none" }}
-              >
-                <span className="text-2xl">{m.icon}</span>
-                <span className="flex items-center gap-1">
-                  {m.label}
-                  {m.ai && (
-                    <span
-                      className="ml-1 text-[10px] font-bold border rounded px-1 border-[var(--primary)] text-[var(--primary)]"
-                    >
-                      AI
-                    </span>
-                  )}
-                </span>
-              </Link>
-            )
-          ))}
+                  style={{ outline: "none" }}
+                >
+                  <span className="text-2xl">{m.icon}</span>
+                  <span className="flex items-center gap-1">
+                    {m.label}
+                    {m.ai && (
+                      <span className="ml-1 text-[10px] font-bold border rounded px-1 border-[var(--primary)] text-[var(--primary)]">
+                        AI
+                      </span>
+                    )}
+                  </span>
+                </Link>
+              ),
+            )}
         </nav>
 
         {/* User Info at the bottom */}
@@ -347,7 +361,11 @@ export default function Sidebar({ mobileOpen = false, setMobileOpen = () => {} }
           />
         )}
       </aside>
-      <NewsDialog open={newsOpen} onClose={() => setNewsOpen(false)} news={newsItems} />
+      <NewsDialog
+        open={newsOpen}
+        onClose={() => setNewsOpen(false)}
+        news={newsItems}
+      />
     </>
   );
 }

--- a/frontend/src/app/main/page.tsx
+++ b/frontend/src/app/main/page.tsx
@@ -36,7 +36,15 @@ function ErrorBannerClient() {
   return null;
 }
 
-function HomeCard({ href, icon, title, description, isAI = false, color, iconColor }) {
+function HomeCard({
+  href,
+  icon,
+  title,
+  description,
+  isAI = false,
+  color,
+  iconColor,
+}) {
   return (
     <Link
       href={href}
@@ -54,7 +62,9 @@ function HomeCard({ href, icon, title, description, isAI = false, color, iconCol
 
       {/* Icon + Title */}
       <div className="relative z-10 flex flex-col items-center gap-4 mb-4">
-        <div className={`w-16 h-16 rounded-2xl flex items-center justify-center text-white shadow-md ${iconColor}`}>
+        <div
+          className={`w-16 h-16 rounded-2xl flex items-center justify-center text-white shadow-md ${iconColor}`}
+        >
           {icon}
         </div>
         <div>
@@ -86,7 +96,7 @@ export default function MainPage() {
       title: t("sessions"),
       description: t("sessions_desc"),
       icon: <ScrollText className="w-6 h-6" />,
-      href: "/tables",
+      href: "/user_table",
       show: !!user,
       group: "game",
       color: "bg-gradient-to-br from-green-50 to-transparent",
@@ -231,7 +241,8 @@ export default function MainPage() {
               🧭 Choose Your Path
             </h1>
             <p className="text-[var(--foreground)]/80 text-base mt-1">
-              Welcome to your world-building portal. Where would you like to begin?
+              Welcome to your world-building portal. Where would you like to
+              begin?
             </p>
           </div>
 
@@ -242,9 +253,11 @@ export default function MainPage() {
                 {label}
               </h2>
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-                {cards.filter((c) => c.group === groupKey && c.show).map((c) => (
-                  <HomeCard key={c.title} {...c} />
-                ))}
+                {cards
+                  .filter((c) => c.group === groupKey && c.show)
+                  .map((c) => (
+                    <HomeCard key={c.title} {...c} />
+                  ))}
               </div>
             </div>
           ))}

--- a/frontend/src/app/user_table/page.tsx
+++ b/frontend/src/app/user_table/page.tsx
@@ -1,0 +1,130 @@
+"use client";
+import Image from "next/image";
+import DashboardLayout from "@/app/components/DashboardLayout";
+import { useTables } from "@/app/lib/useTables";
+import Link from "next/link";
+import { Users2, Book, Calendar, ArrowRight } from "lucide-react";
+
+interface TableMember {
+  id: number;
+  nickname: string;
+  image_url?: string | null;
+}
+
+interface TableItem {
+  id: number;
+  name: string;
+  world_name: string;
+  crest_url?: string | null;
+  members: TableMember[];
+  latest_session?: string | null;
+  next_session?: string | null;
+}
+
+export default function UserTablesPage() {
+  const { tables } = useTables();
+
+  return (
+    <DashboardLayout>
+      <div className="w-full max-w-5xl mx-auto px-2 py-10 min-h-screen relative">
+        <div className="flex justify-between items-center mb-8">
+          <h1 className="text-3xl font-extrabold font-serif text-[var(--primary)] tracking-wider flex items-center gap-2">
+            <Users2 className="w-7 h-7 text-[var(--primary)]" />
+            My Adventuring Parties
+          </h1>
+        </div>
+
+        <ul className="grid gap-7 sm:grid-cols-1">
+          {tables.map((t: TableItem) => (
+            <li
+              key={t.id}
+              className="relative flex flex-col min-h-[154px] rounded-3xl border-0 border-[var(--primary)] bg-[var(--surface-variant)] shadow-lg overflow-hidden group hover:shadow-2xl hover:border-[var(--primary-dark)] transition"
+              style={{
+                background: `linear-gradient(120deg, #f7f3fe 88%, #ece7ff 100%)`,
+              }}
+            >
+              <div className="flex items-center gap-4 px-5 pt-5 pb-2">
+                <Image
+                  src={t.crest_url || "/images/worlds/new_game.png"}
+                  alt={t.name}
+                  width={72}
+                  height={72}
+                  className="w-16 h-16 rounded-xl object-cover border-4 border-[var(--primary)] bg-white shadow-md"
+                />
+                <div className="flex-1 min-w-0">
+                  <Link
+                    href={`/user_table/sessions/${t.id}`}
+                    className="block text-xl font-serif font-bold truncate text-[var(--primary)] hover:underline transition"
+                  >
+                    {t.name}
+                  </Link>
+                  <span className="inline-flex items-center gap-1 text-xs font-semibold bg-[var(--primary)]/10 text-[var(--primary)] rounded px-2 py-0.5 mt-1 mr-2">
+                    <Book className="w-4 h-4 inline" /> {t.world_name}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <ArrowRight className="w-5 h-5 text-[var(--primary)]" />
+                  <Link
+                    href={`/user_table/sessions/${t.id}`}
+                    className="text-xs font-semibold text-[var(--primary)] underline"
+                  >
+                    Sessions
+                  </Link>
+                </div>
+              </div>
+              <div className="flex flex-wrap items-center gap-3 px-5 pb-2">
+                {t.members.map((m: TableMember) => (
+                  <div
+                    key={m.id}
+                    className="flex items-center gap-2 bg-[var(--primary)]/5 rounded-full px-2 py-1 shadow text-xs"
+                  >
+                    <Image
+                      src={m.image_url || "/images/avatars/default.png"}
+                      alt={m.nickname}
+                      width={28}
+                      height={28}
+                      className="w-7 h-7 rounded-full object-cover border-2 border-[var(--primary)]"
+                    />
+                    <span className="font-semibold text-[var(--primary-dark)]">
+                      {m.nickname}
+                    </span>
+                  </div>
+                ))}
+              </div>
+              <div className="flex flex-wrap justify-between items-center px-5 pb-3 pt-2 border-t border-[var(--primary)] bg-[var(--primary)]/5 mt-3">
+                <div className="flex items-center gap-2 text-xs text-[var(--primary-dark)]">
+                  <Calendar className="w-4 h-4" />
+                  {t.latest_session ? (
+                    <span>
+                      Last: {new Date(t.latest_session).toLocaleDateString()} (
+                      {Math.floor(
+                        (Date.now() - new Date(t.latest_session).getTime()) /
+                          (1000 * 60 * 60 * 24),
+                      )}{" "}
+                      days ago)
+                    </span>
+                  ) : (
+                    <span>No sessions yet</span>
+                  )}
+                </div>
+                {t.next_session && (
+                  <div className="flex items-center gap-2 text-xs text-[var(--primary)] font-semibold">
+                    <Calendar className="w-4 h-4" />
+                    Next: {new Date(
+                      t.next_session,
+                    ).toLocaleDateString()} (in{" "}
+                    {Math.ceil(
+                      (new Date(t.next_session).getTime() - Date.now()) /
+                        (1000 * 60 * 60 * 24),
+                    )}{" "}
+                    days)
+                  </div>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/frontend/src/app/user_table/sessions/[id]/page.tsx
+++ b/frontend/src/app/user_table/sessions/[id]/page.tsx
@@ -1,0 +1,47 @@
+"use client";
+import { useParams } from "next/navigation";
+import DashboardLayout from "@/app/components/DashboardLayout";
+import { useSessions } from "@/app/lib/useSessions";
+
+interface SessionItem {
+  id: number;
+  name: string;
+  scheduled_time: string;
+  location?: string | null;
+  summary?: string | null;
+}
+
+export default function UserTableSessionsPage() {
+  const params = useParams();
+  const tableId = Number(params?.id);
+  const { sessions } = useSessions(tableId);
+
+  return (
+    <DashboardLayout>
+      <div className="w-full max-w-4xl mx-auto p-4">
+        <h1 className="text-2xl font-bold mb-4">Sessions</h1>
+        <ul className="space-y-2">
+          {sessions.map((s: SessionItem) => (
+            <li
+              key={s.id}
+              className="p-4 rounded-xl bg-[var(--surface-variant)] space-y-1"
+            >
+              <div className="flex justify-between items-center">
+                <div>
+                  <div className="font-semibold">{s.name}</div>
+                  <div className="text-sm">
+                    {new Date(s.scheduled_time).toLocaleString()}
+                  </div>
+                </div>
+              </div>
+              {s.location && <div className="text-sm">{s.location}</div>}
+              {s.summary && (
+                <div className="text-sm opacity-80">{s.summary}</div>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </DashboardLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- add read-only user table overview and sessions pages
- route session links on dashboard and sidebar to new user table view
- type NewsItem in Sidebar to satisfy linter

## Testing
- `npx prettier --write src/app/components/template/Sidebar.tsx src/app/user_table/sessions/[id]/page.tsx src/app/main/page.tsx src/app/user_table/page.tsx`
- `npx eslint src/app/main/page.tsx src/app/components/template/Sidebar.tsx src/app/user_table/page.tsx src/app/user_table/sessions/[id]/page.tsx`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f5f04ebb48322b273a32c13f4a570