### PR TITLE
fix(db): add timezone columns migration

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -38,11 +38,18 @@ def _migrate(conn):
             text("ALTER TABLE agent ADD COLUMN specialist_update_date DATETIME")
         )
 
+    # -- User table migrations --
+    columns = [c["name"] for c in inspector.get_columns("user")]
+    if "timezone" not in columns:
+        conn.execute(text("ALTER TABLE user ADD COLUMN timezone TEXT"))
+
     # -- Session table migrations --
     columns = [c["name"] for c in inspector.get_columns("session")]
     if "name" not in columns:
         # Existing rows may exist, so add with a default value
         conn.execute(text("ALTER TABLE session ADD COLUMN name TEXT DEFAULT ''"))
+    if "timezone" not in columns:
+        conn.execute(text("ALTER TABLE session ADD COLUMN timezone TEXT DEFAULT 'UTC'"))
 
     # -- Page table migrations --
     columns = [c["name"] for c in inspector.get_columns("page")]


### PR DESCRIPTION
## Summary
- ensure database migration adds timezone columns for users and sessions

## Testing
- `pytest` *(fails: No module named 'more_itertools')*


------
https://chatgpt.com/codex/tasks/task_e_688f61aabc5c832289d8464de616e9ca