### PR TITLE
fix: handle naive session times

### DIFF
--- a/backend/app/api/api_table.py
+++ b/backend/app/api/api_table.py
@@ -69,11 +69,17 @@ async def list_tables_endpoint(
         latest_time = None
         next_up_time = None
         for s_time in session_times:
-            if s_time <= now:
-                if not latest_time or s_time > latest_time:
-                    latest_time = s_time
-            elif not next_up_time or s_time < next_up_time:
-                next_up_time = s_time
+            # Ensure we compare timezone-aware datetimes. Some stored
+            # session times may be naive (no timezone info), so default
+            # them to UTC for comparison.
+            s_time_aware = (
+                s_time.replace(tzinfo=timezone.utc) if s_time.tzinfo is None else s_time
+            )
+            if s_time_aware <= now:
+                if not latest_time or s_time_aware > latest_time:
+                    latest_time = s_time_aware
+            elif not next_up_time or s_time_aware < next_up_time:
+                next_up_time = s_time_aware
 
         results.append(
             TableListRead(

--- a/backend/tests/test_table.py
+++ b/backend/tests/test_table.py
@@ -1,5 +1,5 @@
 import pytest
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 
 WORLD_BUILDER = {
     "nickname": "gm",
@@ -63,3 +63,66 @@ async def test_delete_table_removes_sessions(async_client):
     resp = await async_client.get(f"/tables/{table_id}/sessions", headers=headers)
     assert resp.status_code == 200
     assert resp.json() == []
+
+
+@pytest.mark.anyio
+async def test_list_tables_handles_naive_session_times(async_client):
+    user_payload = {
+        "nickname": "gm2",
+        "email": "gm2@example.com",
+        "password": "secret123",
+        "role": "world builder",
+        "image_url": "no image",
+    }
+    resp = await async_client.post("/user/", json=user_payload)
+    assert resp.status_code == 200, resp.text
+    login = await async_client.post(
+        "/user/login",
+        data={
+            "username": user_payload["email"],
+            "password": user_payload["password"],
+        },
+    )
+    assert login.status_code == 200, login.text
+    token = login.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    gw_payload = {"name": "TestWorld", "system": "dnd", "description": "", "logo": ""}
+    resp = await async_client.post("/gameworlds/", json=gw_payload, headers=headers)
+    assert resp.status_code == 200, resp.text
+    world_id = resp.json()["id"]
+
+    resp = await async_client.post(
+        "/tables/",
+        json={"world_id": world_id, "name": "Party", "member_ids": []},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    table_id = resp.json()["id"]
+
+    past_time = (datetime.utcnow() - timedelta(days=1)).isoformat()
+    future_time = (datetime.utcnow() + timedelta(days=1)).isoformat()
+
+    for sched in (past_time, future_time):
+        sess_payload = {
+            "name": "Session",
+            "scheduled_time": sched,
+            "summary": "",
+            "location": "",
+            "table_id": table_id,
+            "timezone": "UTC",
+            "attendee_ids": [],
+            "page_ids": [],
+        }
+        resp = await async_client.post(
+            f"/tables/{table_id}/sessions", json=sess_payload, headers=headers
+        )
+        assert resp.status_code == 200, resp.text
+
+    resp = await async_client.get("/tables/", headers=headers)
+    assert resp.status_code == 200, resp.text
+    tables = resp.json()
+    assert len(tables) == 1
+    table_info = tables[0]
+    assert table_info["latest_session"] is not None
+    assert table_info["next_session"] is not None


### PR DESCRIPTION
## Summary
- ensure session timestamps are timezone aware when listing tables
- test listing tables with naive session times

## Testing
- `pytest tests/test_table.py::test_list_tables_handles_naive_session_times -q` *(fails: MissingGreenlet)*

------
https://chatgpt.com/codex/tasks/task_e_688f6502f66883228fe10aa97b40fd94