### PR TITLE
feat: integrate polls into session scheduling

### DIFF
--- a/backend/app/crud/crud_session.py
+++ b/backend/app/crud/crud_session.py
@@ -50,12 +50,13 @@ async def create_session(
     # session is still active.
     await session.refresh(sess, attribute_names=["pages"])
 
-    news = NewsCreate(
-        title="Session Scheduled",
-        type="session",
-        description=f"Session for table {session_in.table_id} on {sess.scheduled_time.isoformat()}",
-    )
-    await create_news(session, news)
+    if sess.scheduled_time:
+        news = NewsCreate(
+            title="Session Scheduled",
+            type="session",
+            description=f"Session for table {session_in.table_id} on {sess.scheduled_time.isoformat()}",
+        )
+        await create_news(session, news)
     return sess
 
 

--- a/backend/app/crud/crud_session_poll.py
+++ b/backend/app/crud/crud_session_poll.py
@@ -2,6 +2,7 @@ from typing import List, Optional
 from sqlalchemy import select, delete
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.model_session import (
+    Session,
     SessionPoll,
     SessionPollOption,
     SessionPollVote,
@@ -14,7 +15,9 @@ from app.schemas.schema_session_poll import (
 )
 
 
-async def create_poll(session: AsyncSession, session_id: int, poll_in: SessionPollCreate) -> SessionPoll:
+async def create_poll(
+    session: AsyncSession, session_id: int, poll_in: SessionPollCreate
+) -> SessionPoll:
     poll = SessionPoll(session_id=session_id)
     session.add(poll)
     await session.commit()
@@ -28,11 +31,18 @@ async def create_poll(session: AsyncSession, session_id: int, poll_in: SessionPo
 
 
 async def get_poll(session: AsyncSession, session_id: int) -> Optional[SessionPoll]:
-    result = await session.execute(select(SessionPoll).where(SessionPoll.session_id == session_id))
+    result = await session.execute(
+        select(SessionPoll).where(SessionPoll.session_id == session_id)
+    )
     return result.scalar_one_or_none()
 
 
-async def cast_vote(session: AsyncSession, poll: SessionPoll, user_id: int, vote_in: SessionPollVoteCreate) -> None:
+async def cast_vote(
+    session: AsyncSession,
+    poll: SessionPoll,
+    user_id: int,
+    vote_in: SessionPollVoteCreate,
+) -> None:
     await session.execute(
         delete(SessionPollVote).where(
             (SessionPollVote.poll_id == poll.id) & (SessionPollVote.user_id == user_id)
@@ -44,8 +54,14 @@ async def cast_vote(session: AsyncSession, poll: SessionPoll, user_id: int, vote
     await session.commit()
 
 
-async def finalize_poll(session: AsyncSession, poll: SessionPoll, option_id: int) -> SessionPoll:
+async def finalize_poll(
+    session: AsyncSession, poll: SessionPoll, option_id: int
+) -> SessionPoll:
     poll.final_option_id = option_id
+    option = await session.get(SessionPollOption, option_id)
+    sess = await session.get(Session, poll.session_id)
+    if option and sess:
+        sess.scheduled_time = option.proposed_time
     await session.commit()
     await session.refresh(poll)
     return poll
@@ -59,11 +75,15 @@ async def poll_to_read(session: AsyncSession, poll: SessionPoll) -> SessionPollR
     options_read: List[SessionPollOptionRead] = []
     for option in options:
         vote_result = await session.execute(
-            select(SessionPollVote.user_id).where(SessionPollVote.option_id == option.id)
+            select(SessionPollVote.user_id).where(
+                SessionPollVote.option_id == option.id
+            )
         )
         votes = list(vote_result.scalars().all())
         options_read.append(
-            SessionPollOptionRead(id=option.id, proposed_time=option.proposed_time, votes=votes)
+            SessionPollOptionRead(
+                id=option.id, proposed_time=option.proposed_time, votes=votes
+            )
         )
     return SessionPollRead(
         id=poll.id,
@@ -72,4 +92,3 @@ async def poll_to_read(session: AsyncSession, poll: SessionPoll) -> SessionPollR
         options=options_read,
         created_at=poll.created_at,
     )
-

--- a/backend/app/models/model_session.py
+++ b/backend/app/models/model_session.py
@@ -7,7 +7,7 @@ class Session(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     table_id: int = Field(foreign_key="table.id")
     name: str
-    scheduled_time: datetime
+    scheduled_time: Optional[datetime] = Field(default=None, nullable=True)
     summary: Optional[str] = None
     location: Optional[str] = None
     timezone: str = Field(default="UTC")

--- a/backend/app/schemas/schema_session.py
+++ b/backend/app/schemas/schema_session.py
@@ -5,7 +5,7 @@ from sqlmodel import SQLModel
 
 class SessionBase(SQLModel):
     name: str
-    scheduled_time: datetime
+    scheduled_time: Optional[datetime] = None
     summary: Optional[str] = None
     location: Optional[str] = None
     timezone: str

--- a/backend/tests/test_session_poll.py
+++ b/backend/tests/test_session_poll.py
@@ -1,0 +1,77 @@
+import pytest
+from datetime import datetime, timezone, timedelta
+
+
+@pytest.mark.anyio
+async def test_session_poll_sets_session_date(async_client):
+    user = {
+        "nickname": "gm3",
+        "email": "gm3@example.com",
+        "password": "secret123",
+        "role": "world builder",
+        "image_url": "no image",
+    }
+    resp = await async_client.post("/user/", json=user)
+    assert resp.status_code == 200, resp.text
+    login = await async_client.post(
+        "/user/login",
+        data={"username": user["email"], "password": user["password"]},
+    )
+    assert login.status_code == 200, login.text
+    token = login.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    gw_payload = {"name": "World", "system": "dnd", "description": "", "logo": ""}
+    resp = await async_client.post("/gameworlds/", json=gw_payload, headers=headers)
+    assert resp.status_code == 200, resp.text
+    world_id = resp.json()["id"]
+
+    resp = await async_client.post(
+        "/tables/",
+        json={"world_id": world_id, "name": "Party", "member_ids": []},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    table_id = resp.json()["id"]
+
+    sess_payload = {
+        "name": "Session",
+        "scheduled_time": None,
+        "summary": "",
+        "location": "",
+        "table_id": table_id,
+        "timezone": "UTC",
+        "attendee_ids": [],
+        "page_ids": [],
+    }
+    resp = await async_client.post(
+        f"/tables/{table_id}/sessions", json=sess_payload, headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    session_id = resp.json()["id"]
+
+    times = [
+        datetime.now(timezone.utc).isoformat(),
+        (datetime.now(timezone.utc) + timedelta(days=1)).isoformat(),
+    ]
+    resp = await async_client.post(
+        f"/tables/{table_id}/sessions/{session_id}/poll",
+        json={"proposed_times": times},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    poll = resp.json()
+    option_id = poll["options"][0]["id"]
+
+    resp = await async_client.post(
+        f"/tables/{table_id}/sessions/{session_id}/poll/finalize",
+        json={"option_id": option_id},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    resp = await async_client.get(f"/tables/{table_id}/sessions", headers=headers)
+    assert resp.status_code == 200, resp.text
+    sessions = resp.json()
+    session_info = next(s for s in sessions if s["id"] == session_id)
+    assert session_info["scheduled_time"] == times[0]

--- a/frontend/src/app/tables/[id]/sessions/page.tsx
+++ b/frontend/src/app/tables/[id]/sessions/page.tsx
@@ -7,6 +7,7 @@ import { useSessions } from "@/app/lib/useSessions";
 import {
   createSession,
   createSessionPoll,
+  getSessionPoll,
   finalizeSessionPoll,
 } from "@/app/lib/sessionAPI";
 import { useAuth } from "@/app/components/auth/AuthProvider";
@@ -14,7 +15,6 @@ import { M3FloatingInput } from "@/app/components/template/M3FloatingInput";
 import PageRefSelectorMD3 from "@/app/components/create_page/PageRefSelectorMD3";
 import { getPages } from "@/app/lib/pagesAPI";
 import { useUsers } from "@/app/lib/useUsers";
-import { useSessionPoll } from "@/app/lib/useSessionPoll";
 import { CalendarDays } from "lucide-react";
 
 export default function TableSessionsPage() {
@@ -31,13 +31,10 @@ export default function TableSessionsPage() {
   const [pageOptions, setPageOptions] = useState<any[]>([]);
   const { users } = useUsers();
   const [pollSession, setPollSession] = useState<number | null>(null);
-  const { poll, mutate: mutatePoll } = useSessionPoll(
-    tableId,
-    pollSession || 0,
-  );
   const [proposed, setProposed] = useState<string[]>([]);
   const [newProposal, setNewProposal] = useState("");
-  const sessionDetail = sessions.find((s: any) => s.id === pollSession);
+  const [usePoll, setUsePoll] = useState(false);
+  const [polls, setPolls] = useState<Record<number, any>>({});
 
   useEffect(() => {
     if (token) {
@@ -47,12 +44,43 @@ export default function TableSessionsPage() {
     }
   }, [token]);
 
+  useEffect(() => {
+    async function loadPolls() {
+      if (!token) return;
+      const res: Record<number, any> = {};
+      for (const s of sessions) {
+        try {
+          const p = await getSessionPoll(tableId, s.id, token);
+          res[s.id] = p;
+        } catch {
+          // no poll
+        }
+      }
+      setPolls(res);
+    }
+    loadPolls();
+  }, [sessions, token, tableId]);
+
+  async function refreshPoll(sessionId: number) {
+    if (!token) return;
+    try {
+      const p = await getSessionPoll(tableId, sessionId, token);
+      setPolls((prev) => ({ ...prev, [sessionId]: p }));
+    } catch {
+      setPolls((prev) => {
+        const updated = { ...prev };
+        delete updated[sessionId];
+        return updated;
+      });
+    }
+  }
+
   async function handleCreate() {
-    await createSession(
+    const sess = await createSession(
       tableId,
       {
         name,
-        scheduled_time: time,
+        scheduled_time: usePoll ? null : time,
         location,
         summary,
         page_ids: pages.map((p) => Number(p)),
@@ -66,16 +94,23 @@ export default function TableSessionsPage() {
     setLocation("");
     setSummary("");
     setPages([]);
+    setUsePoll(false);
     mutate();
+    if (usePoll) {
+      setPollSession(sess.id);
+    }
   }
 
   const now = new Date();
   const upcoming = sessions.filter(
-    (s: any) => new Date(s.scheduled_time) >= now,
+    (s: any) => !s.scheduled_time || new Date(s.scheduled_time) >= now,
   );
-  const past = sessions.filter((s: any) => new Date(s.scheduled_time) < now);
+  const past = sessions.filter(
+    (s: any) => s.scheduled_time && new Date(s.scheduled_time) < now,
+  );
 
   function renderSession(s: any) {
+    const pollData = polls[s.id];
     return (
       <li
         key={s.id}
@@ -90,15 +125,64 @@ export default function TableSessionsPage() {
                 : "Not scheduled"}
             </div>
           </div>
-          <button
-            className="text-sm text-[var(--primary)] flex items-center gap-1"
-            onClick={() => setPollSession(s.id)}
-          >
-            <CalendarDays className="w-4 h-4" /> Poll
-          </button>
+          {!pollData && (
+            <button
+              className="text-sm text-[var(--primary)] flex items-center gap-1"
+              onClick={() => setPollSession(s.id)}
+            >
+              <CalendarDays className="w-4 h-4" /> Create Poll
+            </button>
+          )}
         </div>
         {s.location && <div className="text-sm">{s.location}</div>}
         {s.summary && <div className="text-sm opacity-80">{s.summary}</div>}
+        {pollData && (
+          <div className="mt-2 space-y-2">
+            {pollData.options.map((opt: any) => (
+              <div key={opt.id} className="border p-2 rounded">
+                <div className="flex justify-between items-center">
+                  <div>{new Date(opt.proposed_time).toLocaleString()}</div>
+                  {pollData.final_option_id === null && (
+                    <button
+                      className="text-sm text-[var(--primary)]"
+                      onClick={async () => {
+                        await finalizeSessionPoll(tableId, s.id, opt.id, token);
+                        await mutate();
+                        refreshPoll(s.id);
+                      }}
+                    >
+                      Select date
+                    </button>
+                  )}
+                </div>
+                {opt.votes.length ? (
+                  <div className="flex flex-wrap gap-2 mt-1">
+                    {opt.votes.map((id: number) => {
+                      const u = users.find((usr: any) => usr.id === id);
+                      return (
+                        <div
+                          key={id}
+                          className="flex items-center gap-1 text-xs"
+                        >
+                          {u?.image_url && (
+                            <img
+                              src={u.image_url}
+                              alt={u.nickname}
+                              className="w-4 h-4 rounded-full"
+                            />
+                          )}
+                          <span>{u?.nickname || id}</span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <div className="text-xs opacity-80 mt-1">No votes</div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
       </li>
     );
   }
@@ -135,12 +219,32 @@ export default function TableSessionsPage() {
                 value={name}
                 onChange={(e: any) => setName(e.target.value)}
               />
-              <M3FloatingInput
-                type="datetime-local"
-                label="Time"
-                value={time}
-                onChange={(e: any) => setTime(e.target.value)}
-              />
+              <div className="flex gap-4">
+                <label className="flex items-center gap-1 text-sm">
+                  <input
+                    type="radio"
+                    checked={!usePoll}
+                    onChange={() => setUsePoll(false)}
+                  />
+                  Set date
+                </label>
+                <label className="flex items-center gap-1 text-sm">
+                  <input
+                    type="radio"
+                    checked={usePoll}
+                    onChange={() => setUsePoll(true)}
+                  />
+                  Propose poll
+                </label>
+              </div>
+              {!usePoll && (
+                <M3FloatingInput
+                  type="datetime-local"
+                  label="Time"
+                  value={time}
+                  onChange={(e: any) => setTime(e.target.value)}
+                />
+              )}
               <M3FloatingInput
                 label="Location"
                 value={location}
@@ -163,7 +267,10 @@ export default function TableSessionsPage() {
               />
               <div className="flex justify-end gap-2">
                 <button
-                  onClick={() => setOpen(false)}
+                  onClick={() => {
+                    setOpen(false);
+                    setUsePoll(false);
+                  }}
                   className="px-4 py-2 rounded-lg"
                 >
                   Cancel
@@ -182,127 +289,60 @@ export default function TableSessionsPage() {
         {pollSession && (
           <div className="fixed inset-0 bg-black/40 flex items-center justify-center">
             <div className="bg-[var(--surface)] p-6 rounded-xl w-full max-w-md space-y-4">
-              {poll ? (
-                <div className="space-y-4">
-                  <h2 className="text-xl font-semibold">Session Poll</h2>
-                  {sessionDetail?.scheduled_time && (
-                    <div className="text-sm">
-                      Session date:{" "}
-                      {new Date(sessionDetail.scheduled_time).toLocaleString()}
-                    </div>
-                  )}
-                  {poll.options.map((opt: any) => (
-                    <div key={opt.id} className="border p-2 rounded">
-                      <div className="flex justify-between items-center">
-                        <div>
-                          {new Date(opt.proposed_time).toLocaleString()}
-                        </div>
-                        {poll.final_option_id === null && (
-                          <button
-                            className="text-sm text-[var(--primary)]"
-                            onClick={async () => {
-                              await finalizeSessionPoll(
-                                tableId,
-                                pollSession,
-                                opt.id,
-                                token,
-                              );
-                              mutatePoll();
-                              mutate();
-                            }}
-                          >
-                            Finalize
-                          </button>
-                        )}
-                      </div>
-                      {opt.votes.length ? (
-                        <div className="flex flex-wrap gap-2 mt-1">
-                          {opt.votes.map((id: number) => {
-                            const u = users.find((usr: any) => usr.id === id);
-                            return (
-                              <div
-                                key={id}
-                                className="flex items-center gap-1 text-xs"
-                              >
-                                {u?.image_url && (
-                                  <img
-                                    src={u.image_url}
-                                    alt={u.nickname}
-                                    className="w-4 h-4 rounded-full"
-                                  />
-                                )}
-                                <span>{u?.nickname || id}</span>
-                              </div>
-                            );
-                          })}
-                        </div>
-                      ) : (
-                        <div className="text-xs opacity-80 mt-1">No votes</div>
-                      )}
-                    </div>
-                  ))}
-                  <button
-                    className="btn-outline w-full"
-                    onClick={() => {
-                      setPollSession(null);
-                      mutatePoll();
-                    }}
-                  >
-                    Close
-                  </button>
+              <h2 className="text-xl font-semibold">Create Poll</h2>
+              {proposed.map((p) => (
+                <div key={p} className="text-sm">
+                  {new Date(p).toLocaleString()}
                 </div>
-              ) : (
-                <div className="space-y-4">
-                  <h2 className="text-xl font-semibold">Create Poll</h2>
-                  {proposed.map((p) => (
-                    <div key={p} className="text-sm">
-                      {new Date(p).toLocaleString()}
-                    </div>
-                  ))}
-                  <div className="flex gap-2 items-center">
-                    <M3FloatingInput
-                      type="datetime-local"
-                      label="Proposed Time"
-                      value={newProposal}
-                      onChange={(e: any) => setNewProposal(e.target.value)}
-                    />
-                    <button
-                      className="btn-primary mt-6"
-                      onClick={() => {
-                        if (newProposal) {
-                          setProposed([...proposed, newProposal]);
-                          setNewProposal("");
-                        }
-                      }}
-                    >
-                      Add
-                    </button>
-                  </div>
-                  <div className="flex justify-end gap-2">
-                    <button
-                      onClick={() => setPollSession(null)}
-                      className="px-4 py-2 rounded-lg"
-                    >
-                      Cancel
-                    </button>
-                    <button
-                      onClick={async () => {
-                        await createSessionPoll(
-                          tableId,
-                          pollSession,
-                          proposed,
-                          token,
-                        );
-                        setProposed([]);
-                        mutatePoll();
-                      }}
-                      className="px-4 py-2 rounded-lg bg-[var(--primary)] text-[var(--primary-foreground)]"
-                    >
-                      Save
-                    </button>
-                  </div>
-                </div>
-              )}
+              ))}
+              <div className="flex gap-2 items-center">
+                <M3FloatingInput
+                  type="datetime-local"
+                  label="Proposed Time"
+                  value={newProposal}
+                  onChange={(e: any) => setNewProposal(e.target.value)}
+                />
+                <button
+                  className="btn-primary mt-6"
+                  onClick={() => {
+                    if (newProposal) {
+                      setProposed([...proposed, newProposal]);
+                      setNewProposal("");
+                    }
+                  }}
+                >
+                  Add
+                </button>
+              </div>
+              <div className="flex justify-end gap-2">
+                <button
+                  onClick={() => {
+                    setPollSession(null);
+                    setProposed([]);
+                    setNewProposal("");
+                  }}
+                  className="px-4 py-2 rounded-lg"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={async () => {
+                    await createSessionPoll(
+                      tableId,
+                      pollSession!,
+                      proposed,
+                      token,
+                    );
+                    setProposed([]);
+                    await refreshPoll(pollSession!);
+                    setPollSession(null);
+                    mutate();
+                  }}
+                  className="px-4 py-2 rounded-lg bg-[var(--primary)] text-[var(--primary-foreground)]"
+                >
+                  Save
+                </button>
+              </div>
             </div>
           </div>
         )}

--- a/frontend/src/app/user_table/sessions/[id]/page.tsx
+++ b/frontend/src/app/user_table/sessions/[id]/page.tsx
@@ -6,7 +6,7 @@ import { useSessions } from "@/app/lib/useSessions";
 interface SessionItem {
   id: number;
   name: string;
-  scheduled_time: string;
+  scheduled_time: string | null;
   location?: string | null;
   summary?: string | null;
 }
@@ -30,7 +30,9 @@ export default function UserTableSessionsPage() {
                 <div>
                   <div className="font-semibold">{s.name}</div>
                   <div className="text-sm">
-                    {new Date(s.scheduled_time).toLocaleString()}
+                    {s.scheduled_time
+                      ? new Date(s.scheduled_time).toLocaleString()
+                      : "Not scheduled"}
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- allow creating sessions without a date and attach poll options
- show poll options and voting directly on session cards with finalize ability
- support optional session dates in backend models and APIs

## Testing
- `black app/models/model_session.py app/schemas/schema_session.py app/crud/crud_session.py app/crud/crud_session_poll.py tests/test_session_poll.py`
- `pytest` *(fails: ImportError while importing tests/test_generate_pages_embedding.py)*
- `npx eslint src/app/tables/[id]/sessions/page.tsx src/app/user_table/sessions/[id]/page.tsx`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f6cb0f1388322b653360ceac6623c