### PR TITLE
fix: allow sessions without scheduled time

### DIFF
--- a/backend/alembic/versions/20240905_01_allow_null_session_scheduled_time.py
+++ b/backend/alembic/versions/20240905_01_allow_null_session_scheduled_time.py
@@ -1,0 +1,28 @@
+"""Make session.scheduled_time nullable
+
+Revision ID: 20240905_01
+Revises: 20240720_01
+Create Date: 2024-09-05
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20240905_01"
+down_revision = "20240720_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("session", schema=None) as batch_op:
+        batch_op.alter_column(
+            "scheduled_time", existing_type=sa.DateTime(), nullable=True
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("session", schema=None) as batch_op:
+        batch_op.alter_column(
+            "scheduled_time", existing_type=sa.DateTime(), nullable=False
+        )


### PR DESCRIPTION
## Summary
- allow sessions to be created without a scheduled time by making `session.scheduled_time` nullable

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'more_itertools')*

------
https://chatgpt.com/codex/tasks/task_e_688f6fa059208322b0c0688d5260eb1b