### PR TITLE
fix: allow session polls without scheduled time and removable options

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -44,12 +44,38 @@ def _migrate(conn):
         conn.execute(text("ALTER TABLE user ADD COLUMN timezone TEXT"))
 
     # -- Session table migrations --
-    columns = [c["name"] for c in inspector.get_columns("session")]
-    if "name" not in columns:
+    session_cols = inspector.get_columns("session")
+    column_names = [c["name"] for c in session_cols]
+    if "name" not in column_names:
         # Existing rows may exist, so add with a default value
         conn.execute(text("ALTER TABLE session ADD COLUMN name TEXT DEFAULT ''"))
-    if "timezone" not in columns:
+    if "timezone" not in column_names:
         conn.execute(text("ALTER TABLE session ADD COLUMN timezone TEXT DEFAULT 'UTC'"))
+    if "scheduled_time" in column_names:
+        sched_col = next(c for c in session_cols if c["name"] == "scheduled_time")
+        if not sched_col["nullable"]:
+            conn.execute(text("ALTER TABLE session RENAME TO session_old"))
+            conn.execute(
+                text(
+                    "CREATE TABLE session ("
+                    "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                    "table_id INTEGER NOT NULL REFERENCES table(id), "
+                    "name TEXT NOT NULL, "
+                    "scheduled_time DATETIME, "
+                    "summary TEXT, "
+                    "location TEXT, "
+                    "timezone TEXT NOT NULL DEFAULT 'UTC', "
+                    "created_by INTEGER NOT NULL REFERENCES user(id), "
+                    "created_at DATETIME NOT NULL)"
+                )
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO session (id, table_id, name, scheduled_time, summary, location, timezone, created_by, created_at) "
+                    "SELECT id, table_id, name, scheduled_time, summary, location, timezone, created_by, created_at FROM session_old"
+                )
+            )
+            conn.execute(text("DROP TABLE session_old"))
 
     # -- Page table migrations --
     columns = [c["name"] for c in inspector.get_columns("page")]

--- a/frontend/src/app/tables/[id]/sessions/page.tsx
+++ b/frontend/src/app/tables/[id]/sessions/page.tsx
@@ -15,7 +15,7 @@ import { M3FloatingInput } from "@/app/components/template/M3FloatingInput";
 import PageRefSelectorMD3 from "@/app/components/create_page/PageRefSelectorMD3";
 import { getPages } from "@/app/lib/pagesAPI";
 import { useUsers } from "@/app/lib/useUsers";
-import { CalendarDays } from "lucide-react";
+import { CalendarDays, Trash2 } from "lucide-react";
 
 export default function TableSessionsPage() {
   const params = useParams();
@@ -250,9 +250,20 @@ export default function TableSessionsPage() {
               )}
               {usePoll && (
                 <>
-                  {proposed.map((p) => (
-                    <div key={p} className="text-sm">
+                  {proposed.map((p, i) => (
+                    <div
+                      key={i}
+                      className="text-sm flex items-center justify-between"
+                    >
                       {new Date(p).toLocaleString()}
+                      <Trash2
+                        className="w-4 h-4 cursor-pointer"
+                        onClick={() =>
+                          setProposed((prev) =>
+                            prev.filter((_, idx) => idx !== i),
+                          )
+                        }
+                      />
                     </div>
                   ))}
                   <div className="flex gap-2 items-center">
@@ -323,9 +334,18 @@ export default function TableSessionsPage() {
           <div className="fixed inset-0 bg-black/40 flex items-center justify-center">
             <div className="bg-[var(--surface)] p-6 rounded-xl w-full max-w-md space-y-4">
               <h2 className="text-xl font-semibold">Create Poll</h2>
-              {proposed.map((p) => (
-                <div key={p} className="text-sm">
+              {proposed.map((p, i) => (
+                <div
+                  key={i}
+                  className="text-sm flex items-center justify-between"
+                >
                   {new Date(p).toLocaleString()}
+                  <Trash2
+                    className="w-4 h-4 cursor-pointer"
+                    onClick={() =>
+                      setProposed((prev) => prev.filter((_, idx) => idx !== i))
+                    }
+                  />
                 </div>
               ))}
               <div className="flex gap-2 items-center">


### PR DESCRIPTION
## Summary
- allow existing databases to store `scheduled_time` as nullable
- add delete icons to proposed poll options in session UI

## Testing
- `npm test` (fails: Missing script: "test")
- `pip install -r requirements.txt` (fails: dependency conflict)
- `pytest` (fails: ModuleNotFoundError: No module named 'httpx')

------
https://chatgpt.com/codex/tasks/task_e_688fa232a70c832284e2de8dea329a3b