### PR TITLE
feat: enable editing and deleting table sessions

### DIFF
--- a/backend/app/api/api_session.py
+++ b/backend/app/api/api_session.py
@@ -4,13 +4,18 @@ from typing import List
 from app.database import get_session
 from app.models.model_user import User
 from app.dependencies import get_current_user
-from app.schemas.schema_session import SessionCreate, SessionRead
+from app.schemas.schema_session import SessionCreate, SessionRead, SessionUpdate
 from app.schemas.schema_session_poll import (
     SessionPollCreate,
     SessionPollRead,
     SessionPollVoteCreate,
 )
-from app.crud.crud_session import create_session, get_sessions_for_table
+from app.crud.crud_session import (
+    create_session,
+    delete_session,
+    get_sessions_for_table,
+    update_session,
+)
 from app.crud.crud_session_poll import (
     create_poll,
     get_poll,
@@ -69,6 +74,46 @@ async def list_sessions_endpoint(
         )
         for s in sessions
     ]
+
+
+@router.patch("/{table_id}/sessions/{session_id}", response_model=SessionRead)
+async def update_session_endpoint(
+    table_id: int,
+    session_id: int,
+    updates: SessionUpdate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(get_current_user),
+):
+    sess = await update_session(
+        session, session_id, updates.model_dump(exclude_unset=True)
+    )
+    if not sess:
+        raise HTTPException(status_code=404, detail="Session not found")
+    return SessionRead(
+        id=sess.id,
+        table_id=sess.table_id,
+        name=sess.name,
+        scheduled_time=sess.scheduled_time,
+        summary=sess.summary,
+        location=sess.location,
+        timezone=sess.timezone,
+        created_by=sess.created_by,
+        created_at=sess.created_at,
+        page_ids=[p.page_id for p in sess.pages],
+    )
+
+
+@router.delete("/{table_id}/sessions/{session_id}")
+async def delete_session_endpoint(
+    table_id: int,
+    session_id: int,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(get_current_user),
+):
+    ok = await delete_session(session, session_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Session not found")
+    return {"ok": True}
 
 
 @router.post("/{table_id}/sessions/{session_id}/poll", response_model=SessionPollRead)

--- a/backend/app/crud/crud_session.py
+++ b/backend/app/crud/crud_session.py
@@ -1,4 +1,4 @@
-from typing import List, Set
+from typing import List, Optional, Set
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -67,3 +67,43 @@ async def get_sessions_for_table(session: AsyncSession, table_id: int) -> List[S
         .options(selectinload(Session.pages))
     )
     return result.scalars().all()
+
+
+async def get_session(session: AsyncSession, session_id: int) -> Optional[Session]:
+    result = await session.execute(
+        select(Session)
+        .where(Session.id == session_id)
+        .options(selectinload(Session.pages))
+    )
+    return result.scalars().first()
+
+
+async def update_session(
+    session: AsyncSession, session_id: int, updates: dict
+) -> Optional[Session]:
+    sess = await get_session(session, session_id)
+    if not sess:
+        return None
+    page_ids = updates.pop("page_ids", None)
+    for k, v in updates.items():
+        setattr(sess, k, v)
+    if page_ids is not None:
+        result = await session.execute(
+            select(SessionPage).where(SessionPage.session_id == session_id)
+        )
+        for sp in result.scalars().all():
+            await session.delete(sp)
+        for pid in page_ids:
+            session.add(SessionPage(session_id=session_id, page_id=pid))
+    await session.commit()
+    await session.refresh(sess, attribute_names=["pages"])
+    return sess
+
+
+async def delete_session(session: AsyncSession, session_id: int) -> bool:
+    sess = await get_session(session, session_id)
+    if not sess:
+        return False
+    await session.delete(sess)
+    await session.commit()
+    return True

--- a/backend/app/schemas/schema_session.py
+++ b/backend/app/schemas/schema_session.py
@@ -25,5 +25,16 @@ class SessionRead(SessionBase):
     page_ids: List[int] = []
 
 
+class SessionUpdate(SQLModel):
+    name: Optional[str] = None
+    scheduled_time: Optional[datetime] = None
+    summary: Optional[str] = None
+    location: Optional[str] = None
+    timezone: Optional[str] = None
+    attendee_ids: Optional[List[int]] = None
+    page_ids: Optional[List[int]] = None
+
+
 SessionCreate.model_rebuild()
 SessionRead.model_rebuild()
+SessionUpdate.model_rebuild()

--- a/backend/tests/test_session_crud.py
+++ b/backend/tests/test_session_crud.py
@@ -1,0 +1,74 @@
+import pytest
+from datetime import datetime, timezone
+
+WORLD_BUILDER = {
+    "nickname": "gm",
+    "email": "gm_crud@example.com",
+    "password": "secret123",
+    "role": "world builder",
+    "image_url": "no image",
+}
+
+
+@pytest.mark.anyio
+async def test_update_and_delete_session(async_client):
+    resp = await async_client.post("/user/", json=WORLD_BUILDER)
+    assert resp.status_code == 200
+    login = await async_client.post(
+        "/user/login",
+        data={
+            "username": WORLD_BUILDER["email"],
+            "password": WORLD_BUILDER["password"],
+        },
+    )
+    assert login.status_code == 200
+    token = login.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    gw_payload = {"name": "TestWorld", "system": "dnd", "description": "", "logo": ""}
+    resp = await async_client.post("/gameworlds/", json=gw_payload, headers=headers)
+    world_id = resp.json()["id"]
+
+    resp = await async_client.post(
+        "/tables/",
+        json={"world_id": world_id, "name": "Party", "member_ids": []},
+        headers=headers,
+    )
+    table_id = resp.json()["id"]
+
+    sess_payload = {
+        "name": "First",
+        "scheduled_time": datetime.now(timezone.utc).isoformat(),
+        "summary": "",
+        "location": "",
+        "table_id": table_id,
+        "timezone": "UTC",
+        "attendee_ids": [],
+        "page_ids": [],
+    }
+    resp = await async_client.post(
+        f"/tables/{table_id}/sessions", json=sess_payload, headers=headers
+    )
+    assert resp.status_code == 200
+    session_id = resp.json()["id"]
+
+    update_payload = {"name": "Updated", "location": "There"}
+    resp = await async_client.patch(
+        f"/tables/{table_id}/sessions/{session_id}",
+        json=update_payload,
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["name"] == "Updated"
+    assert data["location"] == "There"
+
+    resp = await async_client.delete(
+        f"/tables/{table_id}/sessions/{session_id}", headers=headers
+    )
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+
+    resp = await async_client.get(f"/tables/{table_id}/sessions", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json() == []

--- a/frontend/src/app/lib/sessionAPI.ts
+++ b/frontend/src/app/lib/sessionAPI.ts
@@ -102,3 +102,40 @@ export async function finalizeSessionPoll(
   if (!res.ok) throw await res.json();
   return await res.json();
 }
+
+export async function updateSession(
+  tableId: number,
+  sessionId: number,
+  data: unknown,
+  token: string,
+) {
+  const res = await fetch(
+    `${API_URL}/tables/${tableId}/sessions/${sessionId}`,
+    {
+      method: "PATCH",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(data),
+    },
+  );
+  if (!res.ok) throw await res.json();
+  return await res.json();
+}
+
+export async function deleteSession(
+  tableId: number,
+  sessionId: number,
+  token: string,
+) {
+  const res = await fetch(
+    `${API_URL}/tables/${tableId}/sessions/${sessionId}`,
+    {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  );
+  if (!res.ok) throw await res.json();
+  return await res.json();
+}

--- a/frontend/src/app/tables/[id]/sessions/page.tsx
+++ b/frontend/src/app/tables/[id]/sessions/page.tsx
@@ -9,13 +9,15 @@ import {
   createSessionPoll,
   getSessionPoll,
   finalizeSessionPoll,
+  updateSession,
+  deleteSession,
 } from "@/app/lib/sessionAPI";
 import { useAuth } from "@/app/components/auth/AuthProvider";
 import { M3FloatingInput } from "@/app/components/template/M3FloatingInput";
 import PageRefSelectorMD3 from "@/app/components/create_page/PageRefSelectorMD3";
 import { getPages } from "@/app/lib/pagesAPI";
 import { useUsers } from "@/app/lib/useUsers";
-import { CalendarDays, Trash2 } from "lucide-react";
+import { CalendarDays, Trash2, Pencil } from "lucide-react";
 
 export default function TableSessionsPage() {
   const params = useParams();
@@ -23,6 +25,7 @@ export default function TableSessionsPage() {
   const { token } = useAuth();
   const { sessions, mutate } = useSessions(tableId);
   const [open, setOpen] = useState(false);
+  const [editSession, setEditSession] = useState<any | null>(null);
   const [name, setName] = useState("");
   const [time, setTime] = useState("");
   const [location, setLocation] = useState("");
@@ -104,6 +107,49 @@ export default function TableSessionsPage() {
     mutate();
   }
 
+  async function handleUpdate() {
+    await updateSession(
+      tableId,
+      editSession!.id,
+      {
+        name,
+        scheduled_time: time,
+        location,
+        summary,
+        page_ids: pages.map((p) => Number(p)),
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      },
+      token,
+    );
+    setOpen(false);
+    setEditSession(null);
+    setName("");
+    setTime("");
+    setLocation("");
+    setSummary("");
+    setPages([]);
+    mutate();
+  }
+
+  async function handleDelete(id: number) {
+    if (!confirm("Delete this session?")) return;
+    await deleteSession(tableId, id, token);
+    mutate();
+  }
+
+  function startEdit(s: any) {
+    setEditSession(s);
+    setName(s.name || "");
+    setTime(s.scheduled_time ? s.scheduled_time.slice(0, 16) : "");
+    setLocation(s.location || "");
+    setSummary(s.summary || "");
+    setPages((s.page_ids || []).map(String));
+    setUsePoll(false);
+    setProposed([]);
+    setNewProposal("");
+    setOpen(true);
+  }
+
   const now = new Date();
   const upcoming = sessions.filter(
     (s: any) => !s.scheduled_time || new Date(s.scheduled_time) >= now,
@@ -128,14 +174,24 @@ export default function TableSessionsPage() {
                 : "Not scheduled"}
             </div>
           </div>
-          {!pollData && (
-            <button
-              className="text-sm text-[var(--primary)] flex items-center gap-1"
-              onClick={() => setPollSession(s.id)}
-            >
-              <CalendarDays className="w-4 h-4" /> Create Poll
-            </button>
-          )}
+          <div className="flex items-center gap-2">
+            {!pollData && (
+              <button
+                className="text-sm text-[var(--primary)] flex items-center gap-1"
+                onClick={() => setPollSession(s.id)}
+              >
+                <CalendarDays className="w-4 h-4" /> Create Poll
+              </button>
+            )}
+            <Pencil
+              className="w-4 h-4 cursor-pointer"
+              onClick={() => startEdit(s)}
+            />
+            <Trash2
+              className="w-4 h-4 cursor-pointer"
+              onClick={() => handleDelete(s.id)}
+            />
+          </div>
         </div>
         {s.location && <div className="text-sm">{s.location}</div>}
         {s.summary && <div className="text-sm opacity-80">{s.summary}</div>}
@@ -197,7 +253,18 @@ export default function TableSessionsPage() {
           <h1 className="text-2xl font-bold">Sessions</h1>
           <button
             className="px-4 py-2 rounded-lg bg-[var(--primary)] text-[var(--primary-foreground)]"
-            onClick={() => setOpen(true)}
+            onClick={() => {
+              setEditSession(null);
+              setName("");
+              setTime("");
+              setLocation("");
+              setSummary("");
+              setPages([]);
+              setUsePoll(false);
+              setProposed([]);
+              setNewProposal("");
+              setOpen(true);
+            }}
           >
             Schedule
           </button>
@@ -222,25 +289,27 @@ export default function TableSessionsPage() {
                 value={name}
                 onChange={(e: any) => setName(e.target.value)}
               />
-              <div className="flex gap-4">
-                <label className="flex items-center gap-1 text-sm">
-                  <input
-                    type="radio"
-                    checked={!usePoll}
-                    onChange={() => setUsePoll(false)}
-                  />
-                  Set date
-                </label>
-                <label className="flex items-center gap-1 text-sm">
-                  <input
-                    type="radio"
-                    checked={usePoll}
-                    onChange={() => setUsePoll(true)}
-                  />
-                  Propose poll
-                </label>
-              </div>
-              {!usePoll && (
+              {!editSession && (
+                <div className="flex gap-4">
+                  <label className="flex items-center gap-1 text-sm">
+                    <input
+                      type="radio"
+                      checked={!usePoll}
+                      onChange={() => setUsePoll(false)}
+                    />
+                    Set date
+                  </label>
+                  <label className="flex items-center gap-1 text-sm">
+                    <input
+                      type="radio"
+                      checked={usePoll}
+                      onChange={() => setUsePoll(true)}
+                    />
+                    Propose poll
+                  </label>
+                </div>
+              )}
+              {(!usePoll || editSession) && (
                 <M3FloatingInput
                   type="datetime-local"
                   label="Time"
@@ -248,7 +317,7 @@ export default function TableSessionsPage() {
                   onChange={(e: any) => setTime(e.target.value)}
                 />
               )}
-              {usePoll && (
+              {usePoll && !editSession && (
                 <>
                   {proposed.map((p, i) => (
                     <div
@@ -311,6 +380,7 @@ export default function TableSessionsPage() {
                 <button
                   onClick={() => {
                     setOpen(false);
+                    setEditSession(null);
                     setUsePoll(false);
                     setProposed([]);
                     setNewProposal("");
@@ -320,7 +390,7 @@ export default function TableSessionsPage() {
                   Cancel
                 </button>
                 <button
-                  onClick={handleCreate}
+                  onClick={editSession ? handleUpdate : handleCreate}
                   className="px-4 py-2 rounded-lg bg-[var(--primary)] text-[var(--primary-foreground)]"
                 >
                   Save


### PR DESCRIPTION
## Summary
- support updating and deleting sessions in backend API
- add frontend UI for editing and deleting sessions with icons
- add tests for session update and delete

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'langchain_text_splitters')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688fa4c722488322a49232fb37df7854