### PR TITLE
fix: avoid duplicate session attendance

### DIFF
--- a/backend/app/crud/crud_session.py
+++ b/backend/app/crud/crud_session.py
@@ -35,7 +35,23 @@ async def create_session(
             )
         )
         attendee_ids = set(result.scalars().all())
-    for uid in attendee_ids:
+
+    # Avoid inserting duplicate attendance records which would violate the
+    # uniqueness constraint on (session_id, user_id). This can happen if
+    # records from a previous run remain in the database or if duplicate
+    # attendee IDs are provided.
+    if attendee_ids:
+        existing_result = await session.execute(
+            select(SessionAttendance.user_id).where(
+                (SessionAttendance.session_id == sess.id)
+                & (SessionAttendance.user_id.in_(attendee_ids))
+            )
+        )
+        existing_ids = set(existing_result.scalars().all())
+    else:
+        existing_ids = set()
+
+    for uid in attendee_ids - existing_ids:
         session.add(SessionAttendance(session_id=sess.id, user_id=uid, attending=True))
 
     for pid in session_in.page_ids or []:


### PR DESCRIPTION
## Summary
- skip inserting existing session attendances to prevent unique constraint errors

## Testing
- `pytest` *(fails: Not Found errors for user creation and others)*

------
https://chatgpt.com/codex/tasks/task_e_688fa70c64108322bb995b84bc753d00