### PR TITLE
fix: skip unscheduled sessions when listing tables

### DIFF
--- a/backend/app/api/api_table.py
+++ b/backend/app/api/api_table.py
@@ -69,6 +69,10 @@ async def list_tables_endpoint(
         latest_time = None
         next_up_time = None
         for s_time in session_times:
+            if s_time is None:
+                # Skip sessions without a scheduled time
+                continue
+
             # Ensure we compare timezone-aware datetimes. Some stored
             # session times may be naive (no timezone info), so default
             # them to UTC for comparison.

--- a/backend/tests/test_table.py
+++ b/backend/tests/test_table.py
@@ -126,3 +126,62 @@ async def test_list_tables_handles_naive_session_times(async_client):
     table_info = tables[0]
     assert table_info["latest_session"] is not None
     assert table_info["next_session"] is not None
+
+
+@pytest.mark.anyio
+async def test_list_tables_handles_null_session_times(async_client):
+    user_payload = {
+        "nickname": "gm3",
+        "email": "gm3@example.com",
+        "password": "secret123",
+        "role": "world builder",
+        "image_url": "no image",
+    }
+    resp = await async_client.post("/user/", json=user_payload)
+    assert resp.status_code == 200, resp.text
+    login = await async_client.post(
+        "/user/login",
+        data={
+            "username": user_payload["email"],
+            "password": user_payload["password"],
+        },
+    )
+    assert login.status_code == 200, login.text
+    token = login.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    gw_payload = {"name": "TestWorld", "system": "dnd", "description": "", "logo": ""}
+    resp = await async_client.post("/gameworlds/", json=gw_payload, headers=headers)
+    assert resp.status_code == 200, resp.text
+    world_id = resp.json()["id"]
+
+    resp = await async_client.post(
+        "/tables/",
+        json={"world_id": world_id, "name": "Party", "member_ids": []},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    table_id = resp.json()["id"]
+
+    sess_payload = {
+        "name": "Unscheduled",
+        "scheduled_time": None,
+        "summary": "",
+        "location": "",
+        "table_id": table_id,
+        "timezone": "UTC",
+        "attendee_ids": [],
+        "page_ids": [],
+    }
+    resp = await async_client.post(
+        f"/tables/{table_id}/sessions", json=sess_payload, headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+
+    resp = await async_client.get("/tables/", headers=headers)
+    assert resp.status_code == 200, resp.text
+    tables = resp.json()
+    assert len(tables) == 1
+    table_info = tables[0]
+    assert table_info["latest_session"] is None
+    assert table_info["next_session"] is None


### PR DESCRIPTION
## Summary
- avoid error when session lacks a scheduled_time when listing tables
- add regression test for tables with unscheduled sessions

## Testing
- `pytest` *(fails: many `Not Found` errors)*

------
https://chatgpt.com/codex/tasks/task_e_688fa893b3488322aa84e67d93edcbdf