### PR TITLE
feat: enable table editing and cascade deletions

### DIFF
--- a/backend/app/crud/crud_table.py
+++ b/backend/app/crud/crud_table.py
@@ -51,10 +51,32 @@ async def update_table(
         raise ValueError("Table not found")
 
     update_data = table_in.model_dump(exclude_unset=True)
+    member_ids = update_data.pop("member_ids", None)
     for field, value in update_data.items():
         setattr(table, field, value)
 
     session.add(table)
+
+    if member_ids is not None:
+        existing_members = (
+            (
+                await session.execute(
+                    select(TableMember).where(TableMember.table_id == table_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        existing_ids = {m.user_id for m in existing_members}
+        new_ids = set(member_ids)
+
+        for uid in new_ids - existing_ids:
+            session.add(TableMember(table_id=table_id, user_id=uid, is_gm=False))
+
+        for member in existing_members:
+            if member.user_id not in new_ids:
+                await session.delete(member)
+
     await session.commit()
     await session.refresh(table)
     return table

--- a/backend/app/schemas/schema_table.py
+++ b/backend/app/schemas/schema_table.py
@@ -25,6 +25,7 @@ class TableUpdate(SQLModel):
     world_id: Optional[int] = None
     name: Optional[str] = None
     crest_url: Optional[str] = None
+    member_ids: Optional[List[int]] = None
 
 
 class TableMemberRead(SQLModel):

--- a/backend/tests/test_table.py
+++ b/backend/tests/test_table.py
@@ -11,7 +11,7 @@ WORLD_BUILDER = {
 
 
 @pytest.mark.anyio
-async def test_delete_table_removes_sessions(async_client):
+async def test_delete_table_removes_sessions_and_polls(async_client):
     resp = await async_client.post("/user/", json=WORLD_BUILDER)
     assert resp.status_code == 200, resp.text
     login = await async_client.post(
@@ -51,6 +51,17 @@ async def test_delete_table_removes_sessions(async_client):
         f"/tables/{table_id}/sessions", json=sess_payload, headers=headers
     )
     assert resp.status_code == 200, resp.text
+    session_id = resp.json()["id"]
+
+    poll_payload = {
+        "proposed_times": [datetime.now(timezone.utc).isoformat()],
+    }
+    resp = await async_client.post(
+        f"/tables/{table_id}/sessions/{session_id}/poll",
+        json=poll_payload,
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
 
     resp = await async_client.get(f"/tables/{table_id}/sessions", headers=headers)
     assert resp.status_code == 200
@@ -63,6 +74,75 @@ async def test_delete_table_removes_sessions(async_client):
     resp = await async_client.get(f"/tables/{table_id}/sessions", headers=headers)
     assert resp.status_code == 200
     assert resp.json() == []
+
+    resp = await async_client.get(
+        f"/tables/{table_id}/sessions/{session_id}/poll", headers=headers
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_update_table_members(async_client):
+    gm_payload = {
+        "nickname": "gm_member",
+        "email": "gm_member@example.com",
+        "password": "secret123",
+        "role": "world builder",
+        "image_url": "no image",
+    }
+    resp = await async_client.post("/user/", json=gm_payload)
+    assert resp.status_code == 200, resp.text
+    gm_id = resp.json()["id"]
+    login = await async_client.post(
+        "/user/login",
+        data={"username": gm_payload["email"], "password": gm_payload["password"]},
+    )
+    token = login.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    player1 = {
+        "nickname": "player1",
+        "email": "player1@example.com",
+        "password": "secret123",
+        "role": "world builder",
+        "image_url": "no image",
+    }
+    resp = await async_client.post("/user/", json=player1)
+    player1_id = resp.json()["id"]
+
+    player2 = {
+        "nickname": "player2",
+        "email": "player2@example.com",
+        "password": "secret123",
+        "role": "world builder",
+        "image_url": "no image",
+    }
+    resp = await async_client.post("/user/", json=player2)
+    player2_id = resp.json()["id"]
+
+    gw_payload = {"name": "World", "system": "dnd", "description": "", "logo": ""}
+    resp = await async_client.post("/gameworlds/", json=gw_payload, headers=headers)
+    world_id = resp.json()["id"]
+
+    resp = await async_client.post(
+        "/tables/",
+        json={"world_id": world_id, "name": "Party", "member_ids": [player1_id]},
+        headers=headers,
+    )
+    table_id = resp.json()["id"]
+
+    resp = await async_client.patch(
+        f"/tables/{table_id}",
+        json={"member_ids": [gm_id, player2_id]},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    resp = await async_client.get("/tables/", headers=headers)
+    members = {m["id"] for m in resp.json()[0]["members"]}
+    assert gm_id in members
+    assert player2_id in members
+    assert player1_id not in members
 
 
 @pytest.mark.anyio

--- a/frontend/src/app/tables/page.tsx
+++ b/frontend/src/app/tables/page.tsx
@@ -43,7 +43,15 @@ export default function TablesPage() {
   const [members, setMembers] = useState<string[]>([]);
   async function handleSave() {
     if (editing) {
-      await updateTable(editing.id, { world_id: Number(worldId), name }, token);
+      await updateTable(
+        editing.id,
+        {
+          world_id: Number(worldId),
+          name,
+          member_ids: members.map((m) => Number(m)),
+        },
+        token,
+      );
       if (logo) {
         const url = await uploadTableLogo(logo, editing.id);
         await updateTable(editing.id, { crest_url: url }, token);
@@ -76,7 +84,7 @@ export default function TablesPage() {
     setName(t.name);
     setWorldId(String(t.world_id));
     setLogo(null);
-    setMembers([]);
+    setMembers(t.members.map((m) => String(m.id)));
     setOpen(true);
   }
 
@@ -262,26 +270,24 @@ export default function TablesPage() {
                   className="w-full"
                 />
               </div>
-              {!editing && (
-                <div className="mt-3">
-                  <PageRefSelectorMD3
-                    options={users.map(
-                      (u: {
-                        id: number;
-                        nickname: string;
-                        image_url?: string | null;
-                      }) => ({
-                        id: u.id,
-                        name: u.nickname,
-                        logo: u.image_url,
-                      }),
-                    )}
-                    value={members}
-                    onChange={setMembers}
-                    label="Party Members"
-                  />
-                </div>
-              )}
+              <div className="mt-3">
+                <PageRefSelectorMD3
+                  options={users.map(
+                    (u: {
+                      id: number;
+                      nickname: string;
+                      image_url?: string | null;
+                    }) => ({
+                      id: u.id,
+                      name: u.nickname,
+                      logo: u.image_url,
+                    }),
+                  )}
+                  value={members}
+                  onChange={setMembers}
+                  label="Party Members"
+                />
+              </div>
               <div className="flex justify-end gap-2 mt-5">
                 <button
                   onClick={() => setOpen(false)}


### PR DESCRIPTION
## Summary
- allow updating table members via API and UI
- ensure table deletion removes sessions and polls
- cover table membership and deletion in tests

## Testing
- `npm run lint` *(fails: 'useEffect' is defined but never used ...)*
- `npm test` *(fails: Missing script: "test")*
- `pytest` *(fails: ModuleNotFoundError: No module named 'langchain_text_splitters')*

------
https://chatgpt.com/codex/tasks/task_e_688faafa9284832287062ea63c13caf3