### PR TITLE
fix: remove sidebar gap in dashboard layout

### DIFF
--- a/frontend/src/app/components/DashboardLayout.tsx
+++ b/frontend/src/app/components/DashboardLayout.tsx
@@ -7,12 +7,15 @@ import { FaBars } from "react-icons/fa";
 export default function DashboardLayout({ children }: PropsWithChildren) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [chatOpen, setChatOpen] = useState(false);
-  const [chatDefaultAgentId, setChatDefaultAgentId] = useState<number | null>(null);
+  const [chatDefaultAgentId, setChatDefaultAgentId] = useState<number | null>(
+    null,
+  );
   const [chatDefaultInput, setChatDefaultInput] = useState<string>("");
 
   useEffect(() => {
     function handleOpen(e: any) {
-      if (e.detail?.agentId !== undefined) setChatDefaultAgentId(e.detail.agentId);
+      if (e.detail?.agentId !== undefined)
+        setChatDefaultAgentId(e.detail.agentId);
       if (e.detail?.input !== undefined) setChatDefaultInput(e.detail.input);
       setChatOpen(true);
     }
@@ -21,7 +24,7 @@ export default function DashboardLayout({ children }: PropsWithChildren) {
   }, []);
 
   return (
-   <div className="relative bg-[var(--background)] min-h-screen w-full flex">
+    <div className="relative bg-[var(--background)] min-h-screen w-full flex">
       {/* Hamburger menu (mobile only) */}
       <button
         className="fixed top-5 right-5 z-50 md:hidden bg-[var(--primary)] text-white p-2 rounded-full shadow-lg"
@@ -32,13 +35,10 @@ export default function DashboardLayout({ children }: PropsWithChildren) {
       </button>
 
       {/* Sidebar (hidden on mobile unless open) */}
-      <Sidebar
-        mobileOpen={sidebarOpen}
-        setMobileOpen={setSidebarOpen}
-      />
+      <Sidebar mobileOpen={sidebarOpen} setMobileOpen={setSidebarOpen} />
 
       {/* Main content */}
-      <div className="flex-1 flex flex-col min-h-screen bg-[var(--background)] transition-colors duration-300 pr-0 md:pl-64">
+      <div className="flex-1 flex flex-col min-h-screen bg-[var(--background)] transition-colors duration-300 pr-0">
         <TopBar onSidebarToggle={() => setSidebarOpen(true)} />
         <main className="flex-1 px-2 sm:px-6 py-6 mt-[64px] overflow-y-auto">
           {children}


### PR DESCRIPTION
## Summary
- align dashboard content flush with sidebar by removing unnecessary left padding

## Testing
- `npm run lint` (fails: various lint errors)
- `npm test` (fails: missing script: test)


------
https://chatgpt.com/codex/tasks/task_e_688fad4baed08322bdfa755bae9536a8