### PR TITLE
fix: delete sessions by id with related cleanup

### DIFF
--- a/backend/app/crud/crud_session.py
+++ b/backend/app/crud/crud_session.py
@@ -1,10 +1,17 @@
 from typing import List, Optional, Set
 
-from sqlalchemy import select
+from sqlalchemy import select, delete
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.models.model_session import Session, SessionAttendance, SessionPage
+from app.models.model_session import (
+    Session,
+    SessionAttendance,
+    SessionPage,
+    SessionPoll,
+    SessionPollOption,
+    SessionPollVote,
+)
 from app.models.model_table import TableMember
 from app.schemas.schema_session import SessionCreate
 from app.crud.crud_news import create_news
@@ -120,6 +127,27 @@ async def delete_session(session: AsyncSession, session_id: int) -> bool:
     sess = await get_session(session, session_id)
     if not sess:
         return False
+    # Remove related attendance records
+    await session.execute(
+        delete(SessionAttendance).where(SessionAttendance.session_id == session_id)
+    )
+    # Remove related page links
+    await session.execute(
+        delete(SessionPage).where(SessionPage.session_id == session_id)
+    )
+    # Clean up poll information if present
+    result = await session.execute(
+        select(SessionPoll).where(SessionPoll.session_id == session_id)
+    )
+    poll = result.scalar_one_or_none()
+    if poll:
+        await session.execute(
+            delete(SessionPollVote).where(SessionPollVote.poll_id == poll.id)
+        )
+        await session.execute(
+            delete(SessionPollOption).where(SessionPollOption.poll_id == poll.id)
+        )
+        await session.delete(poll)
     await session.delete(sess)
     await session.commit()
     return True

--- a/backend/tests/test_session_crud.py
+++ b/backend/tests/test_session_crud.py
@@ -14,6 +14,7 @@ WORLD_BUILDER = {
 async def test_update_and_delete_session(async_client):
     resp = await async_client.post("/user/", json=WORLD_BUILDER)
     assert resp.status_code == 200
+    builder_id = resp.json()["id"]
     login = await async_client.post(
         "/user/login",
         data={
@@ -31,7 +32,7 @@ async def test_update_and_delete_session(async_client):
 
     resp = await async_client.post(
         "/tables/",
-        json={"world_id": world_id, "name": "Party", "member_ids": []},
+        json={"world_id": world_id, "name": "Party", "member_ids": [builder_id]},
         headers=headers,
     )
     table_id = resp.json()["id"]
@@ -43,6 +44,7 @@ async def test_update_and_delete_session(async_client):
         "location": "",
         "table_id": table_id,
         "timezone": "UTC",
+        # Leave attendee_ids empty so table members are automatically added
         "attendee_ids": [],
         "page_ids": [],
     }


### PR DESCRIPTION
## Summary
- remove session attendance, page links, and polls before deleting a session by id
- add session attendee setup in test to verify deletion succeeds

## Testing
- `pytest` *(fails: 32 failed)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688fada6fd48832290bd22325f6ab732