### PR TITLE
feat: add gaming session notifications

### DIFF
--- a/backend/app/crud/crud_news.py
+++ b/backend/app/crud/crud_news.py
@@ -4,6 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.model_news import News, NewsView
 from app.schemas.schema_news import NewsCreate, NewsRead
 
+
 async def create_news(session: AsyncSession, news_in: NewsCreate) -> News:
     news = News(**news_in.model_dump())
     session.add(news)
@@ -11,8 +12,11 @@ async def create_news(session: AsyncSession, news_in: NewsCreate) -> News:
     await session.refresh(news)
     return news
 
+
 async def get_news_for_user(session: AsyncSession, user_id: int) -> List[NewsRead]:
-    result = await session.execute(select(News))
+    result = await session.execute(
+        select(News).where((News.user_id == None) | (News.user_id == user_id))
+    )
     news_items = result.scalars().all()
     seen_ids_result = await session.execute(
         select(NewsView.news_id).where(NewsView.user_id == user_id)
@@ -24,11 +28,13 @@ async def get_news_for_user(session: AsyncSession, user_id: int) -> List[NewsRea
             title=n.title,
             type=n.type,
             description=n.description,
+            user_id=n.user_id,
             created_at=n.created_at,
             seen=n.id in seen_ids,
         )
         for n in news_items
     ]
+
 
 async def mark_news_seen(session: AsyncSession, user_id: int, news_id: int) -> None:
     result = await session.execute(

--- a/backend/app/crud/crud_session.py
+++ b/backend/app/crud/crud_session.py
@@ -12,7 +12,7 @@ from app.models.model_session import (
     SessionPollOption,
     SessionPollVote,
 )
-from app.models.model_table import TableMember
+from app.models.model_table import TableMember, Table
 from app.schemas.schema_session import SessionCreate
 from app.crud.crud_news import create_news
 from app.schemas.schema_news import NewsCreate
@@ -72,12 +72,19 @@ async def create_session(
     # error. By refreshing here we eagerly load the relationship while the
     # session is still active.
     await session.refresh(sess, attribute_names=["pages"])
-
-    if sess.scheduled_time:
+    table = await session.get(Table, session_in.table_id)
+    date_info = (
+        sess.scheduled_time.isoformat() if sess.scheduled_time else "unscheduled"
+    )
+    for uid in attendee_ids:
         news = NewsCreate(
-            title="Session Scheduled",
-            type="session",
-            description=f"Session for table {session_in.table_id} on {sess.scheduled_time.isoformat()}",
+            title="Session Created",
+            type="gaming_session",
+            description=(
+                f"Session '{sess.name}' for table '{table.name}' scheduled on {date_info}. "
+                f"View: /tables/{table.id}"
+            ),
+            user_id=uid,
         )
         await create_news(session, news)
     return sess

--- a/backend/app/crud/crud_session_poll.py
+++ b/backend/app/crud/crud_session_poll.py
@@ -7,12 +7,15 @@ from app.models.model_session import (
     SessionPollOption,
     SessionPollVote,
 )
+from app.models.model_table import TableMember, Table
 from app.schemas.schema_session_poll import (
     SessionPollCreate,
     SessionPollVoteCreate,
     SessionPollRead,
     SessionPollOptionRead,
 )
+from app.crud.crud_news import create_news
+from app.schemas.schema_news import NewsCreate
 
 
 async def create_poll(
@@ -27,6 +30,24 @@ async def create_poll(
         session.add(SessionPollOption(poll_id=poll.id, proposed_time=dt))
     await session.commit()
     await session.refresh(poll)
+    sess = await session.get(Session, session_id)
+    table = await session.get(Table, sess.table_id) if sess else None
+    if sess and table:
+        result = await session.execute(
+            select(TableMember.user_id).where(TableMember.table_id == table.id)
+        )
+        member_ids = result.scalars().all()
+        for uid in member_ids:
+            news = NewsCreate(
+                title="Poll Created",
+                type="gaming_session",
+                description=(
+                    f"Poll created for session '{sess.name}' in table '{table.name}'. "
+                    f"Please vote! View: /tables/{table.id}"
+                ),
+                user_id=uid,
+            )
+            await create_news(session, news)
     return poll
 
 

--- a/backend/app/crud/crud_table.py
+++ b/backend/app/crud/crud_table.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Set
 from sqlalchemy import select, delete
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.model_table import Table, TableMember
@@ -11,6 +11,8 @@ from app.models.model_session import (
     SessionPollVote,
 )
 from app.schemas.schema_table import TableCreate, TableUpdate
+from app.crud.crud_news import create_news
+from app.schemas.schema_news import NewsCreate
 
 
 async def create_table(
@@ -33,6 +35,16 @@ async def create_table(
             TableMember(table_id=table.id, user_id=uid, is_gm=(uid == creator_id))
         )
     await session.commit()
+
+    for uid in member_ids:
+        if uid != creator_id:
+            news = NewsCreate(
+                title="Added to Table",
+                type="gaming_session",
+                description=f"You were added to table '{table.name}'. View: /tables/{table.id}",
+                user_id=uid,
+            )
+            await create_news(session, news)
     return table
 
 
@@ -56,7 +68,7 @@ async def update_table(
         setattr(table, field, value)
 
     session.add(table)
-
+    added_ids: Set[int] = set()
     if member_ids is not None:
         existing_members = (
             (
@@ -70,7 +82,8 @@ async def update_table(
         existing_ids = {m.user_id for m in existing_members}
         new_ids = set(member_ids)
 
-        for uid in new_ids - existing_ids:
+        added_ids = new_ids - existing_ids
+        for uid in added_ids:
             session.add(TableMember(table_id=table_id, user_id=uid, is_gm=False))
 
         for member in existing_members:
@@ -79,6 +92,15 @@ async def update_table(
 
     await session.commit()
     await session.refresh(table)
+
+    for uid in added_ids:
+        news = NewsCreate(
+            title="Added to Table",
+            type="gaming_session",
+            description=f"You were added to table '{table.name}'. View: /tables/{table.id}",
+            user_id=uid,
+        )
+        await create_news(session, news)
     return table
 
 

--- a/backend/app/models/model_news.py
+++ b/backend/app/models/model_news.py
@@ -2,12 +2,15 @@ from typing import Optional
 from sqlmodel import SQLModel, Field
 from datetime import datetime, timezone
 
+
 class News(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     title: str
     type: str
     description: str
+    user_id: Optional[int] = Field(default=None, foreign_key="user.id")
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
 
 class NewsView(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)

--- a/backend/app/schemas/schema_news.py
+++ b/backend/app/schemas/schema_news.py
@@ -2,18 +2,23 @@ from datetime import datetime
 from typing import Optional
 from sqlmodel import SQLModel
 
+
 class NewsBase(SQLModel):
     title: str
     type: str
     description: str
+    user_id: Optional[int] = None
+
 
 class NewsCreate(NewsBase):
     pass
+
 
 class NewsRead(NewsBase):
     id: int
     created_at: datetime
     seen: Optional[bool] = False
+
 
 NewsCreate.model_rebuild()
 NewsRead.model_rebuild()

--- a/backend/tests/test_gaming_notifications.py
+++ b/backend/tests/test_gaming_notifications.py
@@ -1,0 +1,83 @@
+import pytest
+from datetime import datetime, timezone
+
+
+@pytest.mark.asyncio
+async def test_gaming_session_notifications(
+    async_client, create_user, login_and_get_token
+):
+    # Create users
+    builder = await create_user(
+        email="builder@example.com", password="pass", role="world builder"
+    )
+    player = await create_user(
+        email="player@example.com", password="pass", role="player"
+    )
+    builder_token = await login_and_get_token(
+        "builder@example.com", "pass", "world builder"
+    )
+    player_token = await login_and_get_token("player@example.com", "pass", "player")
+
+    headers = {"Authorization": f"Bearer {builder_token}"}
+
+    # Create game world and table with player
+    gw_payload = {"name": "World", "system": "dnd", "description": "", "logo": ""}
+    resp = await async_client.post("/gameworlds/", json=gw_payload, headers=headers)
+    assert resp.status_code == 200
+    world_id = resp.json()["id"]
+
+    resp = await async_client.post(
+        "/tables/",
+        json={"world_id": world_id, "name": "Party", "member_ids": [player["id"]]},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    table_id = resp.json()["id"]
+
+    # Player should receive notification about being added to table
+    resp = await async_client.get(
+        "/news/", headers={"Authorization": f"Bearer {player_token}"}
+    )
+    data = resp.json()
+    assert any(n["title"] == "Added to Table" for n in data)
+
+    # Create session for table
+    sess_payload = {
+        "name": "First Session",
+        "scheduled_time": datetime.now(timezone.utc).isoformat(),
+        "summary": "",
+        "location": "",
+        "table_id": table_id,
+        "timezone": "UTC",
+        "attendee_ids": [],
+        "page_ids": [],
+    }
+    resp = await async_client.post(
+        f"/tables/{table_id}/sessions", json=sess_payload, headers=headers
+    )
+    assert resp.status_code == 200
+    session_id = resp.json()["id"]
+
+    resp = await async_client.get(
+        "/news/", headers={"Authorization": f"Bearer {player_token}"}
+    )
+    data = resp.json()
+    assert any(
+        n["title"] == "Session Created" and "First Session" in n["description"]
+        for n in data
+    )
+
+    # Create poll for the session
+    times = [datetime.now(timezone.utc).isoformat()]
+    resp = await async_client.post(
+        f"/tables/{table_id}/sessions/{session_id}/poll",
+        json={"proposed_times": times},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+
+    resp = await async_client.get(
+        "/news/", headers={"Authorization": f"Bearer {player_token}"}
+    )
+    data = resp.json()
+    assert any(n["title"] == "Poll Created" for n in data)

--- a/backend/tests/test_news.py
+++ b/backend/tests/test_news.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 @pytest.mark.asyncio
 async def test_news_flow(async_client, create_user, login_and_get_token):
     await create_user(email="admin@test.com", password="pass", role="system admin")
@@ -15,11 +16,14 @@ async def test_news_flow(async_client, create_user, login_and_get_token):
     assert resp.status_code == 200, resp.text
     news_id = resp.json()["id"]
 
-    resp = await async_client.get("/news/", headers={"Authorization": f"Bearer {user_token}"})
+    resp = await async_client.get(
+        "/news/", headers={"Authorization": f"Bearer {user_token}"}
+    )
     assert resp.status_code == 200
     data = resp.json()
     assert len(data) == 1
     assert data[0]["seen"] is False
+    assert data[0]["user_id"] is None
 
     resp = await async_client.post(
         f"/news/{news_id}/seen",
@@ -27,6 +31,8 @@ async def test_news_flow(async_client, create_user, login_and_get_token):
     )
     assert resp.status_code == 200
 
-    resp = await async_client.get("/news/", headers={"Authorization": f"Bearer {user_token}"})
+    resp = await async_client.get(
+        "/news/", headers={"Authorization": f"Bearer {user_token}"}
+    )
     assert resp.status_code == 200
     assert resp.json()[0]["seen"] is True


### PR DESCRIPTION
## Summary
- notify users when added to a table, when sessions and polls are created
- add targeted news retrieval and tests for gaming notifications

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'langchain_text_splitters')*


------
https://chatgpt.com/codex/tasks/task_e_688fb1dc2b408322a26163b1cc588e9a