### PR TITLE
feat: enable session poll voting for members

### DIFF
--- a/backend/app/api/api_session.py
+++ b/backend/app/api/api_session.py
@@ -9,6 +9,7 @@ from app.schemas.schema_session_poll import (
     SessionPollCreate,
     SessionPollRead,
     SessionPollVoteCreate,
+    SessionPollSelect,
 )
 from app.crud.crud_session import (
     create_session,
@@ -55,10 +56,13 @@ async def create_session_endpoint(
 @router.get("/{table_id}/sessions", response_model=List[SessionRead])
 async def list_sessions_endpoint(
     table_id: int,
+    joined: bool = False,
     session: AsyncSession = Depends(get_session),
     user: User = Depends(get_current_user),
 ):
-    sessions = await get_sessions_for_table(session, table_id)
+    sessions = await get_sessions_for_table(
+        session, table_id, user.id if joined else None
+    )
     return [
         SessionRead(
             id=s.id,
@@ -164,12 +168,12 @@ async def vote_poll_endpoint(
 async def finalize_poll_endpoint(
     table_id: int,
     session_id: int,
-    vote: SessionPollVoteCreate,
+    selection: SessionPollSelect,
     session: AsyncSession = Depends(get_session),
     user: User = Depends(get_current_user),
 ):
     poll = await get_poll(session, session_id)
     if not poll:
         raise HTTPException(status_code=404, detail="Poll not found")
-    poll = await finalize_poll(session, poll, vote.option_id)
+    poll = await finalize_poll(session, poll, selection.option_id)
     return await poll_to_read(session, poll)

--- a/backend/app/crud/crud_session.py
+++ b/backend/app/crud/crud_session.py
@@ -83,12 +83,23 @@ async def create_session(
     return sess
 
 
-async def get_sessions_for_table(session: AsyncSession, table_id: int) -> List[Session]:
-    result = await session.execute(
+async def get_sessions_for_table(
+    session: AsyncSession, table_id: int, user_id: int | None = None
+) -> List[Session]:
+    """Return sessions for a table.
+
+    If ``user_id`` is provided, only sessions where the user has an attendance
+    record are returned.
+    """
+
+    stmt = (
         select(Session)
         .where(Session.table_id == table_id)
         .options(selectinload(Session.pages))
     )
+    if user_id is not None:
+        stmt = stmt.join(SessionAttendance).where(SessionAttendance.user_id == user_id)
+    result = await session.execute(stmt)
     return result.scalars().all()
 
 

--- a/backend/app/crud/crud_session_poll.py
+++ b/backend/app/crud/crud_session_poll.py
@@ -48,9 +48,8 @@ async def cast_vote(
             (SessionPollVote.poll_id == poll.id) & (SessionPollVote.user_id == user_id)
         )
     )
-    session.add(
-        SessionPollVote(poll_id=poll.id, option_id=vote_in.option_id, user_id=user_id)
-    )
+    for oid in vote_in.option_ids:
+        session.add(SessionPollVote(poll_id=poll.id, option_id=oid, user_id=user_id))
     await session.commit()
 
 

--- a/backend/app/schemas/schema_session_poll.py
+++ b/backend/app/schemas/schema_session_poll.py
@@ -8,6 +8,10 @@ class SessionPollCreate(SQLModel):
 
 
 class SessionPollVoteCreate(SQLModel):
+    option_ids: List[int] = []
+
+
+class SessionPollSelect(SQLModel):
     option_id: int
 
 
@@ -27,5 +31,6 @@ class SessionPollRead(SQLModel):
 
 SessionPollCreate.model_rebuild()
 SessionPollVoteCreate.model_rebuild()
+SessionPollSelect.model_rebuild()
 SessionPollOptionRead.model_rebuild()
 SessionPollRead.model_rebuild()

--- a/backend/tests/test_session_poll.py
+++ b/backend/tests/test_session_poll.py
@@ -75,3 +75,82 @@ async def test_session_poll_sets_session_date(async_client):
     sessions = resp.json()
     session_info = next(s for s in sessions if s["id"] == session_id)
     assert session_info["scheduled_time"] == times[0]
+
+
+@pytest.mark.anyio
+async def test_session_poll_multi_vote(async_client):
+    user = {
+        "nickname": "player",
+        "email": "player@example.com",
+        "password": "secret123",
+        "role": "world builder",
+        "image_url": "no image",
+    }
+    resp = await async_client.post("/user/", json=user)
+    player_id = resp.json()["id"]
+    assert resp.status_code == 200, resp.text
+    login = await async_client.post(
+        "/user/login",
+        data={"username": user["email"], "password": user["password"]},
+    )
+    token = login.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    gw_payload = {"name": "World", "system": "dnd", "description": "", "logo": ""}
+    resp = await async_client.post("/gameworlds/", json=gw_payload, headers=headers)
+    world_id = resp.json()["id"]
+
+    resp = await async_client.post(
+        "/tables/",
+        json={"world_id": world_id, "name": "Party", "member_ids": []},
+        headers=headers,
+    )
+    table_id = resp.json()["id"]
+
+    sess_payload = {
+        "name": "Session",
+        "scheduled_time": None,
+        "summary": "",
+        "location": "",
+        "table_id": table_id,
+        "timezone": "UTC",
+        "attendee_ids": [],
+        "page_ids": [],
+    }
+    resp = await async_client.post(
+        f"/tables/{table_id}/sessions", json=sess_payload, headers=headers
+    )
+    session_id = resp.json()["id"]
+
+    times = [
+        datetime.now(timezone.utc).isoformat(),
+        (datetime.now(timezone.utc) + timedelta(days=1)).isoformat(),
+    ]
+    resp = await async_client.post(
+        f"/tables/{table_id}/sessions/{session_id}/poll",
+        json={"proposed_times": times},
+        headers=headers,
+    )
+    poll = resp.json()
+    opt_ids = [opt["id"] for opt in poll["options"]]
+
+    resp = await async_client.post(
+        f"/tables/{table_id}/sessions/{session_id}/poll/vote",
+        json={"option_ids": opt_ids},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    poll_data = resp.json()
+    for option in poll_data["options"]:
+        assert option["votes"] == [player_id]
+
+    # Change vote to only second option
+    resp = await async_client.post(
+        f"/tables/{table_id}/sessions/{session_id}/poll/vote",
+        json={"option_ids": [opt_ids[1]]},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    poll_data = resp.json()
+    assert poll_data["options"][0]["votes"] == []
+    assert poll_data["options"][1]["votes"] == [player_id]

--- a/frontend/src/app/lib/sessionAPI.ts
+++ b/frontend/src/app/lib/sessionAPI.ts
@@ -1,7 +1,14 @@
 import { API_URL } from "./config";
 
-export async function getSessions(tableId: number, token: string) {
-  const res = await fetch(`${API_URL}/tables/${tableId}/sessions`, {
+export async function getSessions(
+  tableId: number,
+  token: string,
+  joined = false,
+) {
+  const url = joined
+    ? `${API_URL}/tables/${tableId}/sessions?joined=true`
+    : `${API_URL}/tables/${tableId}/sessions`;
+  const res = await fetch(url, {
     headers: { Authorization: `Bearer ${token}` },
   });
   if (!res.ok) throw new Error("Failed to fetch sessions");
@@ -64,7 +71,7 @@ export async function createSessionPoll(
 export async function voteSessionPoll(
   tableId: number,
   sessionId: number,
-  optionId: number,
+  optionIds: number[],
   token: string,
 ) {
   const res = await fetch(
@@ -75,7 +82,7 @@ export async function voteSessionPoll(
         Authorization: `Bearer ${token}`,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ option_id: optionId }),
+      body: JSON.stringify({ option_ids: optionIds }),
     },
   );
   if (!res.ok) throw await res.json();

--- a/frontend/src/app/lib/useSessions.ts
+++ b/frontend/src/app/lib/useSessions.ts
@@ -2,12 +2,12 @@ import useSWR from "swr";
 import { getSessions } from "./sessionAPI";
 import { useAuth } from "../components/auth/AuthProvider";
 
-export function useSessions(tableId: number) {
+export function useSessions(tableId: number, joined = false) {
   const { token } = useAuth();
-  const fetcher = (id: number, t: string) => getSessions(id, t);
+  const fetcher = (id: number, t: string, j: boolean) => getSessions(id, t, j);
   const { data, error, mutate, isLoading } = useSWR(
-    tableId && token ? ["sessions", tableId, token] : null,
-    () => fetcher(tableId, token)
+    tableId && token ? ["sessions", tableId, token, joined] : null,
+    () => fetcher(tableId, token, joined),
   );
   return { sessions: data || [], error, mutate, isLoading };
 }

--- a/frontend/src/app/user_table/sessions/[id]/page.tsx
+++ b/frontend/src/app/user_table/sessions/[id]/page.tsx
@@ -1,7 +1,11 @@
 "use client";
 import { useParams } from "next/navigation";
+import { useEffect, useState } from "react";
 import DashboardLayout from "@/app/components/DashboardLayout";
 import { useSessions } from "@/app/lib/useSessions";
+import { getSessionPoll, voteSessionPoll } from "@/app/lib/sessionAPI";
+import { useAuth } from "@/app/components/auth/AuthProvider";
+import { useUsers } from "@/app/lib/useUsers";
 
 interface SessionItem {
   id: number;
@@ -14,7 +18,78 @@ interface SessionItem {
 export default function UserTableSessionsPage() {
   const params = useParams();
   const tableId = Number(params?.id);
-  const { sessions } = useSessions(tableId);
+  const { token, user } = useAuth();
+  const { sessions } = useSessions(tableId, true);
+  const { users } = useUsers();
+  const [polls, setPolls] = useState<Record<number, any>>({});
+  const [selections, setSelections] = useState<Record<number, number[]>>({});
+
+  useEffect(() => {
+    async function loadPolls() {
+      if (!token || !user) return;
+      const res: Record<number, any> = {};
+      const sel: Record<number, number[]> = {};
+      for (const s of sessions) {
+        try {
+          const p = await getSessionPoll(tableId, s.id, token);
+          res[s.id] = p;
+          sel[s.id] = p.options
+            .filter((o: any) => o.votes.includes(user.id))
+            .map((o: any) => o.id);
+        } catch {
+          /* no poll */
+        }
+      }
+      setPolls(res);
+      setSelections(sel);
+    }
+    loadPolls();
+  }, [sessions, token, tableId, user]);
+
+  function toggleOption(sessionId: number, optionId: number) {
+    setSelections((prev) => {
+      const current = prev[sessionId] || [];
+      return current.includes(optionId)
+        ? { ...prev, [sessionId]: current.filter((id) => id !== optionId) }
+        : { ...prev, [sessionId]: [...current, optionId] };
+    });
+  }
+
+  async function refreshPoll(sessionId: number) {
+    if (!token || !user) return;
+    try {
+      const p = await getSessionPoll(tableId, sessionId, token);
+      setPolls((prev) => ({ ...prev, [sessionId]: p }));
+      setSelections((prev) => ({
+        ...prev,
+        [sessionId]: p.options
+          .filter((o: any) => o.votes.includes(user.id))
+          .map((o: any) => o.id),
+      }));
+    } catch {
+      setPolls((prev) => {
+        const copy = { ...prev };
+        delete copy[sessionId];
+        return copy;
+      });
+      setSelections((prev) => {
+        const copy = { ...prev };
+        delete copy[sessionId];
+        return copy;
+      });
+    }
+  }
+
+  async function submitVote(sessionId: number) {
+    if (!token) return;
+    await voteSessionPoll(
+      tableId,
+      sessionId,
+      selections[sessionId] || [],
+      token,
+    );
+    await refreshPoll(sessionId);
+  }
 
   return (
     <DashboardLayout>
@@ -39,6 +114,52 @@ export default function UserTableSessionsPage() {
               {s.location && <div className="text-sm">{s.location}</div>}
               {s.summary && (
                 <div className="text-sm opacity-80">{s.summary}</div>
+              )}
+              {polls[s.id] && (
+                <div className="mt-2">
+                  <div className="text-xs font-semibold mb-1">
+                    Session Date Poll:
+                  </div>
+                  <div className="flex flex-wrap gap-2 mb-2">
+                    {polls[s.id].options.map((opt: any) => (
+                      <label
+                        key={opt.id}
+                        className="flex items-center gap-2 px-3 py-2 rounded-xl border bg-yellow-50 border-yellow-200"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={(selections[s.id] || []).includes(opt.id)}
+                          onChange={() => toggleOption(s.id, opt.id)}
+                        />
+                        <span className="text-xs font-semibold">
+                          {new Date(opt.proposed_time).toLocaleString()}
+                        </span>
+                        <div className="flex -space-x-2">
+                          {opt.votes.map((uid: number) => {
+                            const u = users.find((usr: any) => usr.id === uid);
+                            return (
+                              <img
+                                key={uid}
+                                src={
+                                  u?.image_url || "/images/avatars/default.png"
+                                }
+                                alt={u?.nickname || "?"}
+                                className="w-5 h-5 rounded-full border border-white bg-white shadow"
+                                title={u?.nickname}
+                              />
+                            );
+                          })}
+                        </div>
+                      </label>
+                    ))}
+                  </div>
+                  <button
+                    className="px-2 py-1 bg-[var(--primary)] text-white rounded text-xs"
+                    onClick={() => submitVote(s.id)}
+                  >
+                    Save Vote
+                  </button>
+                </div>
               )}
             </li>
           ))}


### PR DESCRIPTION
## Summary
- filter sessions by current user membership
- allow players to vote on session polls with multi-option support
- show and update poll votes in user session view

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*
- `pip install -r requirements.txt` *(fails: conflicting dependencies)*
- `npx prettier frontend/src/app/lib/sessionAPI.ts frontend/src/app/lib/useSessions.ts frontend/src/app/user_table/sessions/[id]/page.tsx --write`
- `npx eslint -c frontend/eslint.config.mjs frontend/src/app/lib/sessionAPI.ts frontend/src/app/lib/useSessions.ts frontend/src/app/user_table/sessions/[id]/page.tsx` *(fails: Cannot read config file)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688fb340bd00832282def1df5f7a38af