### PR TITLE
fix: add user id to news table

### DIFF
--- a/backend/alembic/versions/20240910_01_add_user_id_to_news.py
+++ b/backend/alembic/versions/20240910_01_add_user_id_to_news.py
@@ -1,0 +1,28 @@
+"""Add user_id column to news table
+
+Revision ID: 20240910_01
+Revises: 20240905_01
+Create Date: 2024-09-10
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "20240910_01"
+down_revision = "20240905_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add the optional user_id column to the news table."""
+    op.add_column(
+        "news",
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("user.id"), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Remove the user_id column from the news table."""
+    op.drop_column("news", "user_id")


### PR DESCRIPTION
## Summary
- add migration adding user id column to news

## Testing
- `pytest` *(fails: AssertionError: {"detail":"Not Found"})*


------
https://chatgpt.com/codex/tasks/task_e_688fb63ee870832289de20fd7e0f1ddb