### PR TITLE
feat: support targeted news recipients

### DIFF
--- a/backend/alembic/versions/20240930_01_news_targets.py
+++ b/backend/alembic/versions/20240930_01_news_targets.py
@@ -1,0 +1,36 @@
+"""Add news targets table and remove user_id from news
+
+Revision ID: 20240930_01
+Revises: 20240910_01
+Create Date: 2024-09-30
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "20240930_01"
+down_revision = "20240910_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create news target table and drop user_id column."""
+    with op.batch_alter_table("news") as batch_op:
+        batch_op.drop_column("user_id")
+    op.create_table(
+        "newstarget",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("news_id", sa.Integer(), sa.ForeignKey("news.id"), nullable=False),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("user.id"), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    """Drop news target table and restore user_id column."""
+    op.drop_table("newstarget")
+    with op.batch_alter_table("news") as batch_op:
+        batch_op.add_column(
+            sa.Column("user_id", sa.Integer(), sa.ForeignKey("user.id"), nullable=True)
+        )

--- a/backend/app/crud/crud_news.py
+++ b/backend/app/crud/crud_news.py
@@ -1,21 +1,32 @@
 from typing import List
-from sqlalchemy import select
+from sqlalchemy import select, or_
 from sqlalchemy.ext.asyncio import AsyncSession
-from app.models.model_news import News, NewsView
+from app.models.model_news import News, NewsView, NewsTarget
 from app.schemas.schema_news import NewsCreate, NewsRead
 
 
 async def create_news(session: AsyncSession, news_in: NewsCreate) -> News:
-    news = News(**news_in.model_dump())
+    news_data = news_in.model_dump(exclude={"user_ids"})
+    news = News(**news_data)
     session.add(news)
     await session.commit()
     await session.refresh(news)
+
+    if news_in.user_ids:
+        targets = [NewsTarget(news_id=news.id, user_id=uid) for uid in news_in.user_ids]
+        session.add_all(targets)
+        await session.commit()
+
     return news
 
 
 async def get_news_for_user(session: AsyncSession, user_id: int) -> List[NewsRead]:
+    targeted_subq = select(NewsTarget.news_id).where(NewsTarget.user_id == user_id)
+    no_target_exists = (
+        ~select(NewsTarget.id).where(NewsTarget.news_id == News.id).exists()
+    )
     result = await session.execute(
-        select(News).where((News.user_id == None) | (News.user_id == user_id))
+        select(News).where(or_(News.id.in_(targeted_subq), no_target_exists))
     )
     news_items = result.scalars().all()
     seen_ids_result = await session.execute(
@@ -28,7 +39,6 @@ async def get_news_for_user(session: AsyncSession, user_id: int) -> List[NewsRea
             title=n.title,
             type=n.type,
             description=n.description,
-            user_id=n.user_id,
             created_at=n.created_at,
             seen=n.id in seen_ids,
         )

--- a/backend/app/crud/crud_session.py
+++ b/backend/app/crud/crud_session.py
@@ -76,7 +76,7 @@ async def create_session(
     date_info = (
         sess.scheduled_time.isoformat() if sess.scheduled_time else "unscheduled"
     )
-    for uid in attendee_ids:
+    if attendee_ids:
         news = NewsCreate(
             title="Session Created",
             type="gaming_session",
@@ -84,7 +84,7 @@ async def create_session(
                 f"Session '{sess.name}' for table '{table.name}' scheduled on {date_info}. "
                 f"View: /tables/{table.id}"
             ),
-            user_id=uid,
+            user_ids=list(attendee_ids),
         )
         await create_news(session, news)
     return sess

--- a/backend/app/crud/crud_session_poll.py
+++ b/backend/app/crud/crud_session_poll.py
@@ -36,8 +36,8 @@ async def create_poll(
         result = await session.execute(
             select(TableMember.user_id).where(TableMember.table_id == table.id)
         )
-        member_ids = result.scalars().all()
-        for uid in member_ids:
+        member_ids = list(result.scalars().all())
+        if member_ids:
             news = NewsCreate(
                 title="Poll Created",
                 type="gaming_session",
@@ -45,7 +45,7 @@ async def create_poll(
                     f"Poll created for session '{sess.name}' in table '{table.name}'. "
                     f"Please vote! View: /tables/{table.id}"
                 ),
-                user_id=uid,
+                user_ids=member_ids,
             )
             await create_news(session, news)
     return poll

--- a/backend/app/crud/crud_table.py
+++ b/backend/app/crud/crud_table.py
@@ -36,15 +36,15 @@ async def create_table(
         )
     await session.commit()
 
-    for uid in member_ids:
-        if uid != creator_id:
-            news = NewsCreate(
-                title="Added to Table",
-                type="gaming_session",
-                description=f"You were added to table '{table.name}'. View: /tables/{table.id}",
-                user_id=uid,
-            )
-            await create_news(session, news)
+    target_ids = [uid for uid in member_ids if uid != creator_id]
+    if target_ids:
+        news = NewsCreate(
+            title="Added to Table",
+            type="gaming_session",
+            description=f"You were added to table '{table.name}'. View: /tables/{table.id}",
+            user_ids=target_ids,
+        )
+        await create_news(session, news)
     return table
 
 
@@ -93,12 +93,12 @@ async def update_table(
     await session.commit()
     await session.refresh(table)
 
-    for uid in added_ids:
+    if added_ids:
         news = NewsCreate(
             title="Added to Table",
             type="gaming_session",
             description=f"You were added to table '{table.name}'. View: /tables/{table.id}",
-            user_id=uid,
+            user_ids=list(added_ids),
         )
         await create_news(session, news)
     return table

--- a/backend/app/models/model_news.py
+++ b/backend/app/models/model_news.py
@@ -8,8 +8,13 @@ class News(SQLModel, table=True):
     title: str
     type: str
     description: str
-    user_id: Optional[int] = Field(default=None, foreign_key="user.id")
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class NewsTarget(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    news_id: int = Field(foreign_key="news.id")
+    user_id: int = Field(foreign_key="user.id")
 
 
 class NewsView(SQLModel, table=True):

--- a/backend/app/schemas/schema_news.py
+++ b/backend/app/schemas/schema_news.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Optional
+from typing import List, Optional
 from sqlmodel import SQLModel
 
 
@@ -7,11 +7,10 @@ class NewsBase(SQLModel):
     title: str
     type: str
     description: str
-    user_id: Optional[int] = None
 
 
 class NewsCreate(NewsBase):
-    pass
+    user_ids: List[int] = []
 
 
 class NewsRead(NewsBase):

--- a/backend/tests/test_news.py
+++ b/backend/tests/test_news.py
@@ -4,7 +4,7 @@ import pytest
 @pytest.mark.asyncio
 async def test_news_flow(async_client, create_user, login_and_get_token):
     await create_user(email="admin@test.com", password="pass", role="system admin")
-    await create_user(email="user@test.com", password="pass", role="player")
+    user = await create_user(email="user@test.com", password="pass", role="player")
     admin_token = await login_and_get_token("admin@test.com", "pass", "system admin")
     user_token = await login_and_get_token("user@test.com", "pass", "player")
 
@@ -23,7 +23,6 @@ async def test_news_flow(async_client, create_user, login_and_get_token):
     data = resp.json()
     assert len(data) == 1
     assert data[0]["seen"] is False
-    assert data[0]["user_id"] is None
 
     resp = await async_client.post(
         f"/news/{news_id}/seen",
@@ -36,3 +35,29 @@ async def test_news_flow(async_client, create_user, login_and_get_token):
     )
     assert resp.status_code == 200
     assert resp.json()[0]["seen"] is True
+
+    resp = await async_client.post(
+        "/news/",
+        json={
+            "title": "Private",
+            "type": "feature",
+            "description": "secret",
+            "user_ids": [user["id"]],
+        },
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 200
+
+    resp = await async_client.get(
+        "/news/", headers={"Authorization": f"Bearer {user_token}"}
+    )
+    assert resp.status_code == 200
+    titles = [n["title"] for n in resp.json()]
+    assert "Private" in titles
+
+    resp = await async_client.get(
+        "/news/", headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert resp.status_code == 200
+    titles_admin = [n["title"] for n in resp.json()]
+    assert "Private" not in titles_admin


### PR DESCRIPTION
## Summary
- allow News items to target multiple users via new `NewsTarget` table
- accept `user_ids` when creating news and deliver to specified users
- update table/session/poll creation to send a single news item to all relevant members
- add migration and tests for targeted news delivery

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'langchain_text_splitters')*


------
https://chatgpt.com/codex/tasks/task_e_688fbd6e2704832289f2baec60b6173a