### PR TITLE
fix: notify creators of gaming session news

### DIFF
--- a/backend/app/crud/crud_session.py
+++ b/backend/app/crud/crud_session.py
@@ -76,17 +76,18 @@ async def create_session(
     date_info = (
         sess.scheduled_time.isoformat() if sess.scheduled_time else "unscheduled"
     )
-    if attendee_ids:
-        news = NewsCreate(
-            title="Session Created",
-            type="gaming_session",
-            description=(
-                f"Session '{sess.name}' for table '{table.name}' scheduled on {date_info}. "
-                f"View: /tables/{table.id}"
-            ),
-            user_ids=list(attendee_ids),
-        )
-        await create_news(session, news)
+    news_user_ids = set(attendee_ids)
+    news_user_ids.add(creator_id)
+    news = NewsCreate(
+        title="Session Created",
+        type="gaming_session",
+        description=(
+            f"Session '{sess.name}' for table '{table.name}' scheduled on {date_info}. "
+            f"View: /tables/{table.id}"
+        ),
+        user_ids=list(news_user_ids),
+    )
+    await create_news(session, news)
     return sess
 
 

--- a/backend/tests/test_gaming_notifications.py
+++ b/backend/tests/test_gaming_notifications.py
@@ -67,6 +67,15 @@ async def test_gaming_session_notifications(
         for n in data
     )
 
+    resp = await async_client.get(
+        "/news/", headers={"Authorization": f"Bearer {builder_token}"}
+    )
+    data = resp.json()
+    assert any(
+        n["title"] == "Session Created" and "First Session" in n["description"]
+        for n in data
+    )
+
     # Create poll for the session
     times = [datetime.now(timezone.utc).isoformat()]
     resp = await async_client.post(


### PR DESCRIPTION
## Summary
- include session creator when generating gaming session news items
- test for creator visibility of gaming session news

## Testing
- `pytest backend/tests/test_gaming_notifications.py::test_gaming_session_notifications -vv` *(fails: {"detail":"Not Found"} assert 404 == 200)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6892462c45148322a8d169921a84bbd7