### PR TITLE
feat(notes): enable sharing and collaborative editing

### DIFF
--- a/backend/app/api/api_user_note.py
+++ b/backend/app/api/api_user_note.py
@@ -14,6 +14,7 @@ from app.crud.crud_user_note import (
     update_user_note,
     delete_user_note,
 )
+
 try:
     from app.task_queue import task_auto_crosslink_note_content
 except Exception:  # pragma: no cover - optional task queue
@@ -23,7 +24,10 @@ UserNoteRead.model_rebuild()
 UserNoteCreate.model_rebuild()
 UserNoteUpdate.model_rebuild()
 
-router = APIRouter(prefix="/user_notes", tags=["UserNotes"], dependencies=[Depends(get_current_user)])
+router = APIRouter(
+    prefix="/user_notes", tags=["UserNotes"], dependencies=[Depends(get_current_user)]
+)
+
 
 @router.post("/", response_model=UserNoteRead)
 async def create_note_endpoint(
@@ -31,11 +35,14 @@ async def create_note_endpoint(
     user: User = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),
 ):
-    db_note = UserNote(**note.model_dump(), user_id=user.id, created_at=datetime.utcnow())
+    db_note = UserNote(
+        **note.model_dump(), user_id=user.id, created_at=datetime.utcnow()
+    )
     db_note = await create_user_note(session, db_note)
     if task_auto_crosslink_note_content:
         task_auto_crosslink_note_content.delay(db_note.id)
     return db_note
+
 
 @router.get("/", response_model=List[UserNoteRead])
 async def list_notes(
@@ -45,22 +52,45 @@ async def list_notes(
     user: User = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),
 ):
-    notes = await get_user_notes(session, user_id=user.id, search=search, start_date=start_date, end_date=end_date)
+    notes = await get_user_notes(
+        session,
+        user_id=user.id,
+        search=search,
+        start_date=start_date,
+        end_date=end_date,
+    )
     return notes
 
+
 @router.get("/{note_id}", response_model=UserNoteRead)
-async def get_note(note_id: int, user: User = Depends(get_current_user), session: AsyncSession = Depends(get_session)):
+async def get_note(
+    note_id: int,
+    user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
     note = await get_user_note(session, note_id)
-    if not note or not (note.user_id == user.id or user.id in note.shared_with_user_ids):
+    if not note or not (
+        note.user_id == user.id or user.id in note.shared_with_user_ids
+    ):
         raise HTTPException(status_code=404, detail="Note not found")
     return note
 
+
 @router.patch("/{note_id}", response_model=UserNoteRead)
-async def update_note(note_id: int, updates: UserNoteUpdate, user: User = Depends(get_current_user), session: AsyncSession = Depends(get_session)):
+async def update_note(
+    note_id: int,
+    updates: UserNoteUpdate,
+    user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
     note = await get_user_note(session, note_id)
-    if not note or note.user_id != user.id:
+    if not note or not (
+        note.user_id == user.id or user.id in note.shared_with_user_ids
+    ):
         raise HTTPException(status_code=404, detail="Note not found")
     update_dict = updates.model_dump(exclude_unset=True)
+    if note.user_id != user.id and "shared_with_user_ids" in update_dict:
+        update_dict.pop("shared_with_user_ids")
     try:
         note = await update_user_note(session, note_id, update_dict, user.id)
     except PermissionError:
@@ -69,8 +99,13 @@ async def update_note(note_id: int, updates: UserNoteUpdate, user: User = Depend
         task_auto_crosslink_note_content.delay(note.id)
     return note
 
+
 @router.delete("/{note_id}")
-async def delete_note(note_id: int, user: User = Depends(get_current_user), session: AsyncSession = Depends(get_session)):
+async def delete_note(
+    note_id: int,
+    user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
     note = await get_user_note(session, note_id)
     if not note or note.user_id != user.id:
         raise HTTPException(status_code=404, detail="Note not found")

--- a/backend/tests/test_user_note.py
+++ b/backend/tests/test_user_note.py
@@ -16,8 +16,11 @@ USER2 = {
     "image_url": "no image",
 }
 
+
 @pytest.mark.anyio
-async def test_user_notes_crud_and_sharing(async_client, create_user, login_and_get_token):
+async def test_user_notes_crud_and_sharing(
+    async_client, create_user, login_and_get_token
+):
     user1 = await create_user(**USER1)
     user2 = await create_user(**USER2)
 
@@ -25,17 +28,25 @@ async def test_user_notes_crud_and_sharing(async_client, create_user, login_and_
     token2 = await login_and_get_token(USER2["email"], USER2["password"], USER2["role"])
 
     note_payload = {"title": "My Note", "content": "Hello", "tags": ["a", "b"]}
-    resp = await async_client.post("/user_notes/", json=note_payload, headers={"Authorization": f"Bearer {token1}"})
+    resp = await async_client.post(
+        "/user_notes/", json=note_payload, headers={"Authorization": f"Bearer {token1}"}
+    )
     assert resp.status_code == 200, resp.text
     note_id = resp.json()["id"]
 
-    resp = await async_client.get(f"/user_notes/{note_id}", headers={"Authorization": f"Bearer {token1}"})
+    resp = await async_client.get(
+        f"/user_notes/{note_id}", headers={"Authorization": f"Bearer {token1}"}
+    )
     assert resp.status_code == 200
 
-    resp = await async_client.get("/user_notes/", headers={"Authorization": f"Bearer {token1}"})
+    resp = await async_client.get(
+        "/user_notes/", headers={"Authorization": f"Bearer {token1}"}
+    )
     assert any(n["id"] == note_id for n in resp.json())
 
-    resp = await async_client.get(f"/user_notes/{note_id}", headers={"Authorization": f"Bearer {token2}"})
+    resp = await async_client.get(
+        f"/user_notes/{note_id}", headers={"Authorization": f"Bearer {token2}"}
+    )
     assert resp.status_code == 404
 
     resp = await async_client.patch(
@@ -45,20 +56,31 @@ async def test_user_notes_crud_and_sharing(async_client, create_user, login_and_
     )
     assert resp.status_code == 200
 
-    resp = await async_client.get(f"/user_notes/{note_id}", headers={"Authorization": f"Bearer {token2}"})
+    resp = await async_client.get(
+        f"/user_notes/{note_id}", headers={"Authorization": f"Bearer {token2}"}
+    )
     assert resp.status_code == 200
 
     resp = await async_client.patch(
         f"/user_notes/{note_id}",
-        json={"title": "fail"},
+        json={"title": "Updated by user2"},
         headers={"Authorization": f"Bearer {token2}"},
     )
-    assert resp.status_code == 404
+    assert resp.status_code == 200
+    assert resp.json()["title"] == "Updated by user2"
 
-    resp = await async_client.get("/user_notes/", params={"search": "Hello"}, headers={"Authorization": f"Bearer {token1}"})
+    resp = await async_client.get(
+        "/user_notes/",
+        params={"search": "Hello"},
+        headers={"Authorization": f"Bearer {token1}"},
+    )
     assert any(n["id"] == note_id for n in resp.json())
 
-    resp = await async_client.delete(f"/user_notes/{note_id}", headers={"Authorization": f"Bearer {token1}"})
+    resp = await async_client.delete(
+        f"/user_notes/{note_id}", headers={"Authorization": f"Bearer {token1}"}
+    )
     assert resp.status_code == 200
-    resp = await async_client.get(f"/user_notes/{note_id}", headers={"Authorization": f"Bearer {token1}"})
+    resp = await async_client.get(
+        f"/user_notes/{note_id}", headers={"Authorization": f"Bearer {token1}"}
+    )
     assert resp.status_code == 404

--- a/frontend/src/app/components/notes/NoteList.tsx
+++ b/frontend/src/app/components/notes/NoteList.tsx
@@ -2,40 +2,53 @@
 import { format } from "date-fns";
 import { useRouter } from "next/navigation";
 
-export default function NoteList({ notes }) {
+export default function NoteList({ notes, users = [], currentUserId }) {
   const router = useRouter();
-  if (!notes?.length) return <div className="text-center py-10 opacity-60">No notes.</div>;
+  if (!notes?.length)
+    return <div className="text-center py-10 opacity-60">No notes.</div>;
   return (
     <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
-      {notes.map((n) => (
-        <button
-          key={n.id}
-          className="flex flex-col items-start gap-1 p-4 rounded-xl border border-[var(--border)] bg-[var(--surface)] hover:bg-[var(--surface-variant)] text-left transition-shadow shadow-sm hover:shadow-md hover:border-[var(--primary)]/50"
-          onClick={() => router.push(`/user_notes/${n.id}`)}
-        >
-          <span className="font-bold text-[var(--primary)] text-lg mb-1 line-clamp-1">{n.title}</span>
-          <span className="text-xs text-[var(--foreground)]/70">
-            {n.note_date ? format(new Date(n.note_date), "PPpp") : "Undated"}
-          </span>
-          {n.tags && n.tags.length > 0 && (
-            <div className="mt-2 flex flex-wrap gap-1">
-              {n.tags.map((tag) => (
-                <span
-                  key={tag}
-                  className="px-2 py-0.5 rounded-full text-xs bg-[var(--muted)] text-[var(--muted-foreground)]"
-                >
-                  #{tag}
-                </span>
-              ))}
-            </div>
-          )}
-          {n.shared && (
-            <span className="mt-2 inline-block text-xs text-[var(--accent)] font-semibold">
-              📬 Shared with you
+      {notes.map((n) => {
+        const owner = users.find((u) => u.id === n.user_id);
+        return (
+          <button
+            key={n.id}
+            className="flex flex-col items-start gap-1 p-4 rounded-xl border border-[var(--border)] bg-[var(--surface)] hover:bg-[var(--surface-variant)] text-left transition-shadow shadow-sm hover:shadow-md hover:border-[var(--primary)]/50"
+            onClick={() => router.push(`/user_notes/${n.id}`)}
+          >
+            <span className="font-bold text-[var(--primary)] text-lg mb-1 line-clamp-1">
+              {n.title}
             </span>
-          )}
-        </button>
-      ))}
+            <span className="text-xs text-[var(--foreground)]/70">
+              {n.note_date ? format(new Date(n.note_date), "PPpp") : "Undated"}
+            </span>
+            {n.tags && n.tags.length > 0 && (
+              <div className="mt-2 flex flex-wrap gap-1">
+                {n.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="px-2 py-0.5 rounded-full text-xs bg-[var(--muted)] text-[var(--muted-foreground)]"
+                  >
+                    #{tag}
+                  </span>
+                ))}
+              </div>
+            )}
+            {currentUserId && n.user_id !== currentUserId && owner && (
+              <div className="mt-2 flex items-center text-xs text-[var(--foreground)]/70">
+                {owner.image_url && (
+                  <img
+                    src={owner.image_url}
+                    alt={owner.nickname || owner.email}
+                    className="w-4 h-4 rounded-full mr-1"
+                  />
+                )}
+                <span>Shared from {owner.nickname || owner.email}</span>
+              </div>
+            )}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/frontend/src/app/components/notes/UserShareSelect.tsx
+++ b/frontend/src/app/components/notes/UserShareSelect.tsx
@@ -1,0 +1,55 @@
+"use client";
+import Autocomplete from "@mui/material/Autocomplete";
+import TextField from "@mui/material/TextField";
+
+interface User {
+  id: number;
+  nickname?: string;
+  email: string;
+  image_url?: string;
+}
+
+interface Props {
+  users: User[];
+  selectedIds: number[];
+  onChange: (ids: number[]) => void;
+  currentUserId?: number;
+}
+
+export default function UserShareSelect({
+  users,
+  selectedIds,
+  onChange,
+  currentUserId,
+}: Props) {
+  const options = users.filter((u) => u.id !== currentUserId);
+  const value = options.filter((u) => selectedIds.includes(u.id));
+  return (
+    <Autocomplete
+      multiple
+      options={options}
+      value={value}
+      onChange={(e, newValue) => onChange(newValue.map((u) => u.id))}
+      getOptionLabel={(option) => option.nickname || option.email}
+      renderOption={(props, option) => (
+        <li {...props} className="flex items-center gap-2">
+          {option.image_url && (
+            <img
+              src={option.image_url}
+              alt={option.nickname || option.email}
+              className="w-6 h-6 rounded-full"
+            />
+          )}
+          <span>{option.nickname || option.email}</span>
+        </li>
+      )}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label="Share with users"
+          placeholder="Select users"
+        />
+      )}
+    />
+  );
+}

--- a/frontend/src/app/user_notes/[noteID]/page.tsx
+++ b/frontend/src/app/user_notes/[noteID]/page.tsx
@@ -10,6 +10,7 @@ import EditableContent from "../../components/editor/EditableContent";
 import { M3FloatingInput } from "../../components/template/M3FloatingInput";
 import { getPages } from "../../lib/pagesAPI";
 import { autoLinkWikiContent } from "../../components/editor/autoLinkWikiContent";
+import UserShareSelect from "../../components/notes/UserShareSelect";
 
 export default function NoteDetailPage() {
   const params = useParams();
@@ -20,11 +21,15 @@ export default function NoteDetailPage() {
   const { token, user } = useAuth();
 
   const [form, setForm] = useState({ title: "", content: "" });
+  const [sharedIds, setSharedIds] = useState<number[]>([]);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
 
   useEffect(() => {
-    if (note) setForm({ title: note.title, content: note.content || "" });
+    if (note) {
+      setForm({ title: note.title, content: note.content || "" });
+      setSharedIds(note.shared_with_user_ids || []);
+    }
   }, [note]);
 
   if (isLoading && !note) {
@@ -42,24 +47,41 @@ export default function NoteDetailPage() {
     );
   }
 
-  const creator = users.find(u => u.id === note.user_id);
-  const sharedUsers = users.filter(u => note.shared_with_user_ids?.includes(u.id));
-  const contributors = (note.contributors || []).map(c => ({
+  const creator = users.find((u) => u.id === note.user_id);
+  const sharedUsers = users.filter((u) => sharedIds.includes(u.id));
+  const contributors = (note.contributors || []).map((c) => ({
     ...c,
-    user: users.find(u => u.id === c.user_id),
+    user: users.find((u) => u.id === c.user_id),
   }));
 
-  async function handleSave(e: any) {
+  async function handleSave(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setSaving(true);
     setError("");
     try {
       const pages = await getPages(token || "");
-      const linkedContent = autoLinkWikiContent(form.content, pages, null, true);
-      await updateUserNote(noteID, { title: form.title, content: linkedContent }, token || "");
+      const linkedContent = autoLinkWikiContent(
+        form.content,
+        pages,
+        null,
+        true,
+      );
+      const payload: {
+        title: string;
+        content: string;
+        shared_with_user_ids?: number[];
+      } = {
+        title: form.title,
+        content: linkedContent,
+      };
+      if (user?.id === note.user_id) {
+        payload.shared_with_user_ids = sharedIds;
+      }
+      await updateUserNote(noteID, payload, token || "");
       mutate();
-    } catch (err: any) {
-      setError(err?.detail || err?.message || String(err));
+    } catch (err) {
+      const e = err as { detail?: string; message?: string };
+      setError(e?.detail || e?.message || String(err));
     }
     setSaving(false);
   }
@@ -69,8 +91,9 @@ export default function NoteDetailPage() {
     try {
       await deleteUserNote(noteID, token || "");
       router.push("/user_notes");
-    } catch (err: any) {
-      setError(err?.detail || err?.message || String(err));
+    } catch (err) {
+      const e = err as { detail?: string; message?: string };
+      setError(e?.detail || e?.message || String(err));
     }
     setSaving(false);
   }
@@ -81,36 +104,53 @@ export default function NoteDetailPage() {
         <div className="w-full flex flex-col gap-4">
           <button
             className="self-start px-4 py-2 rounded-xl font-bold bg-[var(--primary)] text-[var(--primary-foreground)] shadow hover:bg-[var(--accent)] hover:text-[var(--background)] transition"
-            onClick={() => router.push('/user_notes')}
+            onClick={() => router.push("/user_notes")}
           >
             Back to Notes
           </button>
           <form className="flex flex-col gap-4" onSubmit={handleSave}>
             {error && (
-              <div className="bg-red-100 text-red-700 rounded-lg px-3 py-2 text-sm">{error}</div>
+              <div className="bg-red-100 text-red-700 rounded-lg px-3 py-2 text-sm">
+                {error}
+              </div>
             )}
             <M3FloatingInput
               label="Title"
               value={form.title}
-              onChange={e => setForm({ ...form, title: e.target.value })}
+              onChange={(e) => setForm({ ...form, title: e.target.value })}
               required
             />
+            {user?.id === note.user_id && (
+              <UserShareSelect
+                users={users}
+                selectedIds={sharedIds}
+                onChange={setSharedIds}
+                currentUserId={user.id}
+              />
+            )}
             <div className="text-sm text-[var(--foreground)]/70 flex flex-col gap-1">
               <div>Creator: {creator?.nickname || note.user_id}</div>
               {sharedUsers.length > 0 && (
-                <div>Shared with: {sharedUsers.map(u => u.nickname).join(', ')}</div>
+                <div>
+                  Shared with: {sharedUsers.map((u) => u.nickname).join(", ")}
+                </div>
               )}
               {contributors.length > 0 && (
                 <div>
-                  Contributors:{' '}
-                  {contributors.map(c => ` ${c.user?.nickname || c.user_id} (${new Date(c.date).toLocaleDateString()})`).join(', ')}
+                  Contributors:{" "}
+                  {contributors
+                    .map(
+                      (c) =>
+                        ` ${c.user?.nickname || c.user_id} (${new Date(c.date).toLocaleDateString()})`,
+                    )
+                    .join(", ")}
                 </div>
               )}
             </div>
             <EditableContent
               content={form.content}
               canEdit
-              onSaveContent={html => setForm({ ...form, content: html })}
+              onSaveContent={(html) => setForm({ ...form, content: html })}
               pageType={`users/${user?.id}`}
               pageName={`${note.id}`}
               className="max-h-[400px] overflow-y-auto"
@@ -121,11 +161,11 @@ export default function NoteDetailPage() {
                 className="px-7 py-2 rounded-xl font-bold bg-[var(--primary)] text-[var(--primary-foreground)] shadow-md hover:bg-[var(--accent)] hover:text-[var(--primary)] border border-[var(--primary)]/30 transition-all"
                 disabled={saving}
               >
-                {saving ? 'Saving...' : 'Save'}
+                {saving ? "Saving..." : "Save"}
               </button>
               <button
                 type="button"
-                onClick={() => router.push('/user_notes')}
+                onClick={() => router.push("/user_notes")}
                 className="px-6 py-2 rounded-xl font-semibold bg-transparent border border-[var(--border)] text-[var(--primary)] hover:bg-[var(--surface-variant)] transition-all"
                 disabled={saving}
               >

--- a/frontend/src/app/user_notes/new/page.tsx
+++ b/frontend/src/app/user_notes/new/page.tsx
@@ -8,25 +8,46 @@ import { M3FloatingInput } from "@/app/components/template/M3FloatingInput";
 import { useAuth } from "@/app/components/auth/AuthProvider";
 import { getPages } from "@/app/lib/pagesAPI";
 import { autoLinkWikiContent } from "@/app/components/editor/autoLinkWikiContent";
+import { useUsers } from "@/app/lib/useUsers";
+import UserShareSelect from "@/app/components/notes/UserShareSelect";
 
 export default function NewNotePage() {
   const router = useRouter();
   const { token, user } = useAuth();
+  const { users } = useUsers();
   const [form, setForm] = useState({ title: "", content: "" });
+  const [sharedIds, setSharedIds] = useState<number[]>([]);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
 
-  async function handleSave(e: any) {
+  async function handleSave(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setSaving(true);
     setError("");
     try {
       const pages = await getPages(token || "");
-      const linkedContent = autoLinkWikiContent(form.content, pages, null, true);
-      const newNote = await createUserNote({ title: form.title, content: linkedContent }, token || "");
+      const linkedContent = autoLinkWikiContent(
+        form.content,
+        pages,
+        null,
+        true,
+      );
+      const payload: {
+        title: string;
+        content: string;
+        shared_with_user_ids?: number[];
+      } = {
+        title: form.title,
+        content: linkedContent,
+      };
+      if (sharedIds.length > 0) {
+        payload.shared_with_user_ids = sharedIds;
+      }
+      const newNote = await createUserNote(payload, token || "");
       router.push(`/user_notes/${newNote.id}`);
-    } catch (err: any) {
-      setError(err?.detail || err?.message || String(err));
+    } catch (err) {
+      const e = err as { detail?: string; message?: string };
+      setError(e?.detail || e?.message || String(err));
     }
     setSaving(false);
   }
@@ -37,24 +58,32 @@ export default function NewNotePage() {
         <div className="w-full flex flex-col gap-4">
           <button
             className="self-start px-4 py-2 rounded-xl font-bold bg-[var(--primary)] text-[var(--primary-foreground)] shadow hover:bg-[var(--accent)] hover:text-[var(--background)] transition"
-            onClick={() => router.push('/user_notes')}
+            onClick={() => router.push("/user_notes")}
           >
             Back to Notes
           </button>
           <form className="flex flex-col gap-4" onSubmit={handleSave}>
             {error && (
-              <div className="bg-red-100 text-red-700 rounded-lg px-3 py-2 text-sm">{error}</div>
+              <div className="bg-red-100 text-red-700 rounded-lg px-3 py-2 text-sm">
+                {error}
+              </div>
             )}
             <M3FloatingInput
               label="Title"
               value={form.title}
-              onChange={e => setForm({ ...form, title: e.target.value })}
+              onChange={(e) => setForm({ ...form, title: e.target.value })}
               required
+            />
+            <UserShareSelect
+              users={users}
+              selectedIds={sharedIds}
+              onChange={setSharedIds}
+              currentUserId={user?.id}
             />
             <EditableContent
               content={form.content}
               canEdit
-              onSaveContent={html => setForm({ ...form, content: html })}
+              onSaveContent={(html) => setForm({ ...form, content: html })}
               pageType={`users/${user?.id}`}
               pageName="temp"
               className="max-h-[400px] overflow-y-auto"
@@ -65,11 +94,11 @@ export default function NewNotePage() {
                 className="px-7 py-2 rounded-xl font-bold bg-[var(--primary)] text-[var(--primary-foreground)] shadow-md hover:bg-[var(--accent)] hover:text-[var(--primary)] border border-[var(--primary)]/30 transition-all"
                 disabled={saving}
               >
-                {saving ? 'Saving...' : 'Save'}
+                {saving ? "Saving..." : "Save"}
               </button>
               <button
                 type="button"
-                onClick={() => router.push('/user_notes')}
+                onClick={() => router.push("/user_notes")}
                 className="px-6 py-2 rounded-xl font-semibold bg-transparent border border-[var(--border)] text-[var(--primary)] hover:bg-[var(--surface-variant)] transition-all"
                 disabled={saving}
               >

--- a/frontend/src/app/user_notes/page.tsx
+++ b/frontend/src/app/user_notes/page.tsx
@@ -5,10 +5,12 @@ import { useUserNotes } from "../lib/useUserNotes";
 import NoteList from "../components/notes/NoteList";
 import { PlusCircle, Notebook, Users } from "lucide-react";
 import { useAuth } from "../components/auth/AuthProvider";
+import { useUsers } from "../lib/useUsers";
 
 export default function UserNotesPage() {
   const { notes, isLoading } = useUserNotes();
   const { user } = useAuth();
+  const { users } = useUsers();
 
   return (
     <AuthGuard>
@@ -31,27 +33,41 @@ export default function UserNotesPage() {
             </div>
 
             {isLoading ? (
-              <div className="text-center text-lg text-[var(--muted-foreground)]">Loading your notes...</div>
+              <div className="text-center text-lg text-[var(--muted-foreground)]">
+                Loading your notes...
+              </div>
             ) : (
               <div className="w-full flex flex-col md:flex-row gap-8">
                 {/* MY NOTES */}
                 <div className="flex-1 bg-white/70 rounded-2xl border-0 border-[var(--primary)] shadow-md p-5">
                   <div className="flex items-center gap-2 mb-4">
                     <Notebook className="w-6 h-6 text-[var(--primary)]" />
-                    <h2 className="text-xl font-bold text-[var(--primary)] font-serif">My Notes</h2>
+                    <h2 className="text-xl font-bold text-[var(--primary)] font-serif">
+                      My Notes
+                    </h2>
                   </div>
-                  <NoteList notes={notes.filter((n) => n.user_id === user?.id)} />
+                  <NoteList
+                    notes={notes.filter((n) => n.user_id === user?.id)}
+                    users={users}
+                    currentUserId={user?.id}
+                  />
                 </div>
                 {/* SHARED WITH ME */}
                 <div className="flex-1 bg-white/70 rounded-2xl border-0 border-[var(--primary)] shadow-md p-5">
                   <div className="flex items-center gap-2 mb-4">
                     <Users className="w-6 h-6 text-[var(--primary)]" />
-                    <h2 className="text-xl font-bold text-[var(--primary)] font-serif">Shared With Me</h2>
+                    <h2 className="text-xl font-bold text-[var(--primary)] font-serif">
+                      Shared With Me
+                    </h2>
                   </div>
                   <NoteList
                     notes={notes.filter(
-                      (n) => n.user_id !== user?.id && n.shared_with_user_ids?.includes(user?.id)
+                      (n) =>
+                        n.user_id !== user?.id &&
+                        n.shared_with_user_ids?.includes(user?.id),
                     )}
+                    users={users}
+                    currentUserId={user?.id}
                   />
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- allow shared users to edit notes on backend
- add user share selector and show note owners in lists
- support picking multiple recipients when creating or editing notes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_68924c3871608322ba6edbb7dfc050f8