### PR TITLE
fix(frontend): improve dark theme session card contrast

### DIFF
--- a/frontend/src/app/tables/[id]/sessions/page.tsx
+++ b/frontend/src/app/tables/[id]/sessions/page.tsx
@@ -424,7 +424,7 @@ export default function TableSessionsPage() {
     return (
       <div
         className={`
-          group rounded-2xl border border-[var(--border)] bg-white shadow-lg px-5 py-4 mb-3 min-w-[320px] max-w-md
+          group rounded-2xl border border-[var(--border)] bg-[var(--surface)] shadow-lg px-5 py-4 mb-3 min-w-[320px] max-w-md
           transition relative flex flex-col gap-2 hover:shadow-2xl
           ${isPast ? "opacity-70" : "opacity-100"}
         `}
@@ -435,20 +435,28 @@ export default function TableSessionsPage() {
               <ScrollText className="w-5 h-5" /> {s.name}
               <span
                 className={`ml-2 px-2 py-0.5 rounded-full text-xs font-bold
-                ${isPast ? "bg-gray-200 text-gray-500" : pollData ? "bg-yellow-100 text-yellow-700" : "bg-green-100 text-green-700"}
+                ${
+                  isPast
+                    ? "bg-[var(--surface-variant)] text-[var(--foreground)]/70"
+                    : pollData
+                      ? "bg-yellow-100 text-yellow-700"
+                      : "bg-green-100 text-green-700"
+                }
               `}
               >
                 {isPast ? "Completed" : pollData ? "Vote" : "Scheduled"}
               </span>
             </div>
-            <div className="text-xs text-gray-600 flex items-center gap-1">
+            <div className="text-xs text-[var(--foreground)]/80 flex items-center gap-1">
               <CalendarDays className="w-4 h-4" />
               {s.scheduled_time ? (
                 new Date(s.scheduled_time).toLocaleString()
               ) : pollData ? (
                 <span className="font-semibold text-yellow-600">Voting!</span>
               ) : (
-                <span className="font-semibold text-gray-500">Unscheduled</span>
+                <span className="font-semibold text-[var(--foreground)]/70">
+                  Unscheduled
+                </span>
               )}
             </div>
           </div>
@@ -476,12 +484,14 @@ export default function TableSessionsPage() {
             </span>
           )}
           {s.summary && (
-            <span className="text-xs text-gray-500 italic">{s.summary}</span>
+            <span className="text-xs text-[var(--foreground)]/70 italic">
+              {s.summary}
+            </span>
           )}
         </div>
         <div className="flex flex-wrap gap-2 items-center mt-2">
           {s.page_ids?.length > 0 && (
-            <span className="flex items-center gap-2 text-xs text-gray-600">
+            <span className="flex items-center gap-2 text-xs text-[var(--foreground)]/80">
               <Book className="w-4 h-4" />
               Linked:{" "}
               {s.page_ids.map((pid: number) => {

--- a/frontend/src/app/user_table/sessions/[id]/page.tsx
+++ b/frontend/src/app/user_table/sessions/[id]/page.tsx
@@ -31,7 +31,9 @@ export default function UserTableSessionsPage() {
           sel[s.id] = p.options
             .filter((o) => o.votes.includes(user.id))
             .map((o) => o.id);
-        } catch {/* no poll */}
+        } catch {
+          /* no poll */
+        }
       }
       setPolls(res);
       setSelections(sel);
@@ -80,7 +82,7 @@ export default function UserTableSessionsPage() {
       tableId,
       sessionId,
       selections[sessionId] || [],
-      token
+      token,
     );
     await refreshPoll(sessionId);
     setLoadingVotes((prev) => ({ ...prev, [sessionId]: false }));
@@ -88,10 +90,10 @@ export default function UserTableSessionsPage() {
 
   const now = new Date();
   const upcomingSessions = sessions.filter(
-    (s) => !s.scheduled_time || new Date(s.scheduled_time) >= now
+    (s) => !s.scheduled_time || new Date(s.scheduled_time) >= now,
   );
   const previousSessions = sessions.filter(
-    (s) => s.scheduled_time && new Date(s.scheduled_time) < now
+    (s) => s.scheduled_time && new Date(s.scheduled_time) < now,
   );
 
   // --- UI HELPERS ---
@@ -111,9 +113,11 @@ export default function UserTableSessionsPage() {
             <label
               key={opt.id}
               className={`flex items-center gap-3 rounded-xl px-3 py-2 border cursor-pointer 
-              ${selections[s.id]?.includes(opt.id)
+              ${
+                selections[s.id]?.includes(opt.id)
                   ? "border-[var(--primary)] bg-[var(--primary)]/10"
-                  : "border-yellow-100 hover:border-yellow-300"}
+                  : "border-yellow-100 hover:border-yellow-300"
+              }
               transition`}
             >
               <input
@@ -169,17 +173,24 @@ export default function UserTableSessionsPage() {
         <div className="flex items-center gap-4">
           <div className="flex-1">
             <div className="text-xl font-bold text-[var(--primary)] flex items-center gap-2">
-              {isPast ? <BookOpen size={20} className="text-gray-400" /> : <Sparkles size={20} className="text-yellow-400" />}
+              {isPast ? (
+                <BookOpen size={20} className="text-gray-400" />
+              ) : (
+                <Sparkles size={20} className="text-yellow-400" />
+              )}
               {s.name}
             </div>
-            <div className="flex items-center gap-3 text-sm text-gray-700 mt-1">
+            <div className="flex items-center gap-3 text-sm text-[var(--foreground)]/80 mt-1">
               <MapPin size={16} className="text-[var(--primary)]" />
-              {s.location || <span className="italic opacity-50">No location set</span>}
+              {s.location || (
+                <span className="italic opacity-50">No location set</span>
+              )}
               <CalendarClock size={16} className="ml-3 text-[var(--primary)]" />
-              {s.scheduled_time
-                ? new Date(s.scheduled_time).toLocaleString()
-                : <span className="italic opacity-50">Not scheduled</span>
-              }
+              {s.scheduled_time ? (
+                new Date(s.scheduled_time).toLocaleString()
+              ) : (
+                <span className="italic opacity-50">Not scheduled</span>
+              )}
             </div>
             {s.summary && (
               <div className="text-xs text-[var(--primary)]/70 mt-2 px-3 py-1 bg-[var(--surface)]/60 rounded shadow-inner border-l-4 border-[var(--primary)]/20">
@@ -203,8 +214,9 @@ export default function UserTableSessionsPage() {
             <Sparkles size={36} className="text-yellow-300" />
             Game Sessions
           </h1>
-          <div className="text-md text-gray-500 ml-2">
-            Track your table's adventures, vote on the next gathering, and relive the tales of previous quests!
+          <div className="text-md text-[var(--foreground)]/70 ml-2">
+            Track your table's adventures, vote on the next gathering, and
+            relive the tales of previous quests!
           </div>
         </div>
 
@@ -214,7 +226,10 @@ export default function UserTableSessionsPage() {
             Upcoming Sessions
           </h2>
           {upcomingSessions.length === 0 ? (
-            <div className="text-gray-400 italic mb-4">No upcoming sessions scheduled. Ask your Game Master to create one!</div>
+            <div className="text-gray-400 italic mb-4">
+              No upcoming sessions scheduled. Ask your Game Master to create
+              one!
+            </div>
           ) : (
             <ul className="space-y-4">
               {upcomingSessions.map((s) => renderSession(s, false))}
@@ -228,7 +243,9 @@ export default function UserTableSessionsPage() {
             Past Sessions
           </h2>
           {previousSessions.length === 0 ? (
-            <div className="text-gray-400 italic mb-2">No past sessions yet. Your journey begins now!</div>
+            <div className="text-gray-400 italic mb-2">
+              No past sessions yet. Your journey begins now!
+            </div>
           ) : (
             <ul className="space-y-4">
               {previousSessions.map((s) => renderSession(s, true))}


### PR DESCRIPTION
## Summary
- improve session card backgrounds and text to use theme variables for dark mode
- adjust user table session detail colors for better readability

## Testing
- `npx prettier src/app/tables/[id]/sessions/page.tsx src/app/user_table/sessions/[id]/page.tsx --write`
- `npx eslint src/app/tables/[id]/sessions/page.tsx src/app/user_table/sessions/[id]/page.tsx` (errors: @typescript-eslint/no-explicit-any, etc.)
- `npm test` (missing script: test)


------
https://chatgpt.com/codex/tasks/task_e_68924cd10980832293bbcfda238db12f