### PR TITLE
fix: allow merge groups in page generation

### DIFF
--- a/backend/app/crud/crud_agent_writer.py
+++ b/backend/app/crud/crud_agent_writer.py
@@ -442,9 +442,24 @@ async def generate_pages(
     agent: Agent,
     page: Page,
     page_specs: List[dict],
+    merge_groups: Optional[List[List[str]]] = None,
 ) -> dict:
-    """Orchestrate generation or update of pages from specs."""
+    """Orchestrate generation or update of pages from specs.
+
+    Parameters
+    ----------
+    session: AsyncSession
+        Database session.
+    agent: Agent
+        Agent performing the generation.
+    page: Page
+        Target page for generation.
+    page_specs: List[dict]
+        Specifications for pages to create or update.
+    merge_groups: Optional[List[List[str]]]
+        Groups of page names to treat as aliases during generation.
+    """
 
     if page.gameworld_id != agent.world_id:
         raise ValueError("Agent and page belong to different worlds")
-    return await generate_pages_worker(session, agent, page, page_specs)
+    return await generate_pages_worker(session, agent, page, page_specs, merge_groups)

--- a/backend/tests/test_generate_pages_merge_groups.py
+++ b/backend/tests/test_generate_pages_merge_groups.py
@@ -1,0 +1,41 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from app.crud.crud_agent_writer import generate_pages
+from app.models.model_agent import Agent
+from app.models.model_gameworld import GameWorld
+from app.models.model_page import Page
+from app.models.model_concept import Concept
+
+
+@pytest.mark.anyio
+async def test_generate_pages_passes_merge_groups(session):
+    gw = GameWorld(name="W", system="s", description="d", created_by=1)
+    session.add(gw)
+    await session.commit()
+    await session.refresh(gw)
+
+    concept = Concept(gameworld_id=gw.id, name="C")
+    session.add(concept)
+    await session.commit()
+    await session.refresh(concept)
+
+    agent = Agent(name="A", world_id=gw.id)
+    session.add(agent)
+    await session.commit()
+    await session.refresh(agent)
+
+    page = Page(name="P", gameworld_id=gw.id, concept_id=concept.id)
+    session.add(page)
+    await session.commit()
+    await session.refresh(page)
+
+    page_specs = [{"name": "P", "concept_id": concept.id}]
+    merge_groups = [["P", "Alias"]]
+
+    with patch(
+        "app.crud.crud_agent_writer.generate_pages_worker", new_callable=AsyncMock
+    ) as worker:
+        worker.return_value = {"pages": [], "updated": []}
+        await generate_pages(session, agent, page, page_specs, merge_groups)
+        worker.assert_awaited_once_with(session, agent, page, page_specs, merge_groups)


### PR DESCRIPTION
## Summary
- forward merge group data when generating or updating pages
- cover merge group support with tests

## Testing
- `cd backend && pytest` *(fails: AssertionError: {"detail":"Not Found"})*

------
https://chatgpt.com/codex/tasks/task_e_68976d3146548322ab653547a36b8910