### PR TITLE
feat: add session attendance for new table members

### DIFF
--- a/backend/app/crud/crud_table.py
+++ b/backend/app/crud/crud_table.py
@@ -90,6 +90,30 @@ async def update_table(
             if member.user_id not in new_ids:
                 await session.delete(member)
 
+        if added_ids:
+            session_rows = await session.execute(
+                select(Session.id).where(Session.table_id == table_id)
+            )
+            session_ids = list(session_rows.scalars().all())
+            if session_ids:
+                existing_attendance = await session.execute(
+                    select(
+                        SessionAttendance.session_id,
+                        SessionAttendance.user_id,
+                    )
+                    .where(SessionAttendance.session_id.in_(session_ids))
+                    .where(SessionAttendance.user_id.in_(added_ids))
+                )
+                existing_pairs = {(sid, uid) for sid, uid in existing_attendance.all()}
+                for sid in session_ids:
+                    for uid in added_ids:
+                        if (sid, uid) not in existing_pairs:
+                            session.add(
+                                SessionAttendance(
+                                    session_id=sid, user_id=uid, attending=True
+                                )
+                            )
+
     await session.commit()
     await session.refresh(table)
 

--- a/backend/tests/test_table.py
+++ b/backend/tests/test_table.py
@@ -146,6 +146,102 @@ async def test_update_table_members(async_client):
 
 
 @pytest.mark.anyio
+async def test_added_member_gets_existing_sessions(async_client):
+    gm_payload = {
+        "nickname": "gm_add",
+        "email": "gm_add@example.com",
+        "password": "secret123",
+        "role": "world builder",
+        "image_url": "no image",
+    }
+    resp = await async_client.post("/user/", json=gm_payload)
+    gm_id = resp.json()["id"]
+    login = await async_client.post(
+        "/user/login",
+        data={"username": gm_payload["email"], "password": gm_payload["password"]},
+    )
+    token = login.json()["access_token"]
+    gm_headers = {"Authorization": f"Bearer {token}"}
+
+    player_payload = {
+        "nickname": "player_added",
+        "email": "player_added@example.com",
+        "password": "secret123",
+        "role": "world builder",
+        "image_url": "no image",
+    }
+    resp = await async_client.post("/user/", json=player_payload)
+    player_id = resp.json()["id"]
+
+    gw_payload = {"name": "World", "system": "dnd", "description": "", "logo": ""}
+    resp = await async_client.post("/gameworlds/", json=gw_payload, headers=gm_headers)
+    world_id = resp.json()["id"]
+
+    resp = await async_client.post(
+        "/tables/",
+        json={"world_id": world_id, "name": "Party", "member_ids": []},
+        headers=gm_headers,
+    )
+    table_id = resp.json()["id"]
+
+    sess_payload = {
+        "name": "Session",
+        "scheduled_time": datetime.now(timezone.utc).isoformat(),
+        "summary": "",
+        "location": "",
+        "table_id": table_id,
+        "timezone": "UTC",
+        "attendee_ids": [],
+        "page_ids": [],
+    }
+    resp = await async_client.post(
+        f"/tables/{table_id}/sessions", json=sess_payload, headers=gm_headers
+    )
+    session_id = resp.json()["id"]
+
+    poll_payload = {"proposed_times": [datetime.now(timezone.utc).isoformat()]}
+    resp = await async_client.post(
+        f"/tables/{table_id}/sessions/{session_id}/poll",
+        json=poll_payload,
+        headers=gm_headers,
+    )
+    option_id = resp.json()["options"][0]["id"]
+
+    resp = await async_client.patch(
+        f"/tables/{table_id}",
+        json={"member_ids": [gm_id, player_id]},
+        headers=gm_headers,
+    )
+    assert resp.status_code == 200
+
+    login = await async_client.post(
+        "/user/login",
+        data={
+            "username": player_payload["email"],
+            "password": player_payload["password"],
+        },
+    )
+    player_token = login.json()["access_token"]
+    player_headers = {"Authorization": f"Bearer {player_token}"}
+
+    resp = await async_client.get(
+        f"/tables/{table_id}/sessions?joined=true", headers=player_headers
+    )
+    assert resp.status_code == 200
+    sessions = resp.json()
+    assert any(s["id"] == session_id for s in sessions)
+
+    resp = await async_client.post(
+        f"/tables/{table_id}/sessions/{session_id}/poll/vote",
+        json={"option_ids": [option_id]},
+        headers=player_headers,
+    )
+    assert resp.status_code == 200
+    poll = resp.json()
+    assert player_id in poll["options"][0]["votes"]
+
+
+@pytest.mark.anyio
 async def test_list_tables_handles_naive_session_times(async_client):
     user_payload = {
         "nickname": "gm2",


### PR DESCRIPTION
## Summary
- ensure new table members are registered for all existing sessions
- test that added members can join and vote in past sessions

## Testing
- `pytest` *(fails: 38 failed, 19 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6897a8cc658483228c6837f71aae4622