### PR TITLE
feat(frontend): allow admin password reset and forgot password hint

### DIFF
--- a/frontend/src/app/components/auth/AuthCard.tsx
+++ b/frontend/src/app/components/auth/AuthCard.tsx
@@ -3,7 +3,12 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "./AuthProvider";
-import { getUserCount, loginUser, registerUser, userExists } from "../../lib/usersApi";
+import {
+  getUserCount,
+  loginUser,
+  registerUser,
+  userExists,
+} from "../../lib/usersApi";
 import { useTranslation } from "../../hooks/useTranslation";
 
 // Material 3 Floating Label Field
@@ -44,7 +49,11 @@ enum FormMode {
   FIRST_USER,
 }
 
-export default function AuthCard({ initialError = null }: { initialError?: string | null }) {
+export default function AuthCard({
+  initialError = null,
+}: {
+  initialError?: string | null;
+}) {
   const [formMode, setFormMode] = useState<FormMode>(FormMode.LOGIN);
   const [usersExist, setUsersExist] = useState<boolean | null>(null);
   const [form, setForm] = useState({
@@ -80,13 +89,17 @@ export default function AuthCard({ initialError = null }: { initialError?: strin
     setInfo(null);
     try {
       if (formMode === FormMode.LOGIN) {
-        const { access_token } = await loginUser({ email: form.email, password: form.password });
+        const { access_token } = await loginUser({
+          email: form.email,
+          password: form.password,
+        });
         setToken(access_token);
         const redirectTo = getRedirectAfterLogin() || "/worlds";
         setRedirectAfterLogin(null);
         router.replace(redirectTo);
       } else {
-        const role = formMode === FormMode.FIRST_USER ? "system admin" : "player";
+        const role =
+          formMode === FormMode.FIRST_USER ? "system admin" : "player";
         await registerUser({
           nickname: form.nickname,
           email: form.email,
@@ -94,7 +107,10 @@ export default function AuthCard({ initialError = null }: { initialError?: strin
           role,
           image_url: "/images/default/avatars/logo.png",
         });
-        const { access_token } = await loginUser({ email: form.email, password: form.password });
+        const { access_token } = await loginUser({
+          email: form.email,
+          password: form.password,
+        });
         setToken(access_token);
         setRedirectAfterLogin(null);
         router.replace("/worlds");
@@ -104,7 +120,8 @@ export default function AuthCard({ initialError = null }: { initialError?: strin
         formMode === FormMode.LOGIN &&
         typeof err === "object" &&
         err !== null &&
-        (err as Record<string, unknown>).detail === "Incorrect email or password"
+        (err as Record<string, unknown>).detail ===
+          "Incorrect email or password"
       ) {
         try {
           const exists = await userExists(form.email);
@@ -120,7 +137,7 @@ export default function AuthCard({ initialError = null }: { initialError?: strin
         setError(
           (typeof errObj.detail === "string" && errObj.detail) ||
             (typeof errObj.message === "string" && errObj.message) ||
-            "Unknown error!" + err
+            "Unknown error!" + err,
         );
       } else {
         setError("Unknown error!");
@@ -129,7 +146,6 @@ export default function AuthCard({ initialError = null }: { initialError?: strin
       setLoading(false);
     }
   };
-
 
   if (usersExist === null)
     return <div className="text-white text-center py-8">{t("loading")}</div>;
@@ -173,8 +189,8 @@ export default function AuthCard({ initialError = null }: { initialError?: strin
           {formMode === FormMode.LOGIN
             ? t("sign_in_adventure")
             : formMode === FormMode.REGISTER
-            ? t("create_your_account")
-            : t("welcome_builder")}
+              ? t("create_your_account")
+              : t("welcome_builder")}
         </h3>
         {formMode === FormMode.FIRST_USER && (
           <div className="font-sans text-base text-[var(--accent)] mb-5 text-left">
@@ -195,7 +211,8 @@ export default function AuthCard({ initialError = null }: { initialError?: strin
           </div>
         )}
         <form className="w-full flex flex-col gap-5" onSubmit={handleSubmit}>
-          {(formMode === FormMode.REGISTER || formMode === FormMode.FIRST_USER) && (
+          {(formMode === FormMode.REGISTER ||
+            formMode === FormMode.FIRST_USER) && (
             <M3TextField
               label={t("nickname")}
               name="nickname"
@@ -233,9 +250,14 @@ export default function AuthCard({ initialError = null }: { initialError?: strin
             {loading
               ? t("processing")
               : formMode === FormMode.LOGIN
-              ? t("sign_in")
-              : t("create_account")}
+                ? t("sign_in")
+                : t("create_account")}
           </button>
+          {formMode === FormMode.LOGIN && (
+            <p className="text-sm text-[var(--accent)] text-center mt-2">
+              {t("forgot_password_contact_admin")}
+            </p>
+          )}
         </form>
       </div>
     </div>

--- a/frontend/src/app/components/user_management/User_Modal.tsx
+++ b/frontend/src/app/components/user_management/User_Modal.tsx
@@ -71,7 +71,7 @@ export default function UserModal({
         image_url: form.image_url,
         timezone: form.timezone,
       };
-      if (isProfile && password) updatePayload.password = password;
+      if (password) updatePayload.password = password;
       await updateUser(user.id, updatePayload, token);
       onSave?.();
       onClose();
@@ -185,19 +185,17 @@ export default function UserModal({
             Timezone
           </label>
         </div>
-        {isProfile && (
-          <M3FloatingInput
-            label="New Password"
-            name="password"
-            type="password"
-            value={password}
-            autoComplete="new-password"
-            onChange={(e) => setPassword(e.target.value)}
-            minLength={8}
-            maxLength={100}
-            placeholder=" "
-          />
-        )}
+        <M3FloatingInput
+          label={isProfile ? "New Password" : "New Password (optional)"}
+          name="password"
+          type="password"
+          value={password}
+          autoComplete="new-password"
+          onChange={(e) => setPassword(e.target.value)}
+          minLength={8}
+          maxLength={100}
+          placeholder=" "
+        />
 
         <div className="flex flex-row-reverse gap-3 mt-3">
           <button

--- a/frontend/src/app/locales/en.json
+++ b/frontend/src/app/locales/en.json
@@ -16,6 +16,7 @@
   "processing": "Processing...",
   "sign_in": "Sign In",
   "create_account": "Create Account",
+  "forgot_password_contact_admin": "Forgot your password? Please contact an admin to create a new one.",
   "first_login_error": "Please log in first",
   "welcome_first_login": "Welcome to Shrecknet! First you have to create an account!",
   "visit_worlds": "Visit Worlds",

--- a/frontend/src/app/locales/it.json
+++ b/frontend/src/app/locales/it.json
@@ -16,6 +16,7 @@
   "processing": "Elaborazione...",
   "sign_in": "Accedi",
   "create_account": "Crea Account",
+  "forgot_password_contact_admin": "Hai dimenticato la password? Contatta un amministratore per crearne una nuova.",
   "first_login_error": "Per favore effettua il login prima",
   "welcome_first_login": "Benvenuto su Shrecknet! Prima devi creare un account!",
   "visit_worlds": "Visita Mondi",

--- a/frontend/src/app/locales/pt.json
+++ b/frontend/src/app/locales/pt.json
@@ -16,6 +16,7 @@
   "processing": "Processando...",
   "sign_in": "Entrar",
   "create_account": "Criar Conta",
+  "forgot_password_contact_admin": "Esqueceu sua senha? Fale com o administrador para criar uma nova.",
   "first_login_error": "Por favor faça login primeiro",
   "welcome_first_login": "Bem-vindo ao Shrecknet! Primeiro você precisa criar uma conta!",
   "visit_worlds": "Visitar Mundos",


### PR DESCRIPTION
## Summary
- allow admins to set a user's new password in user management
- show localized hint to contact admin if password is forgotten
- add translations for new password hint in EN/PT/IT

## Testing
- `npx prettier --write src/app/components/user_management/User_Modal.tsx src/app/components/auth/AuthCard.tsx src/app/locales/en.json src/app/locales/pt.json src/app/locales/it.json`
- `npm run lint` *(fails: Unexpected any, unused vars, etc.)*
- `npm test` *(fails: Missing script "test")*
- `pytest` *(fails: ModuleNotFoundError: No module named 'chromadb')*

------
https://chatgpt.com/codex/tasks/task_e_6897a90dda708322bfeebc06694941f8