### PR TITLE
fix: send accurate page specs for generation

### DIFF
--- a/frontend/src/app/agent_writer/[agentID]/[pageID]/page.tsx
+++ b/frontend/src/app/agent_writer/[agentID]/[pageID]/page.tsx
@@ -1,34 +1,45 @@
 // FULLY UPDATED page.tsx WITH MULTI-MERGE SUPPORT
 "use client";
-import { useState, useRef, useEffect } from "react";
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { useState, useRef } from "react";
 import { useParams } from "next/navigation";
 import DashboardLayout from "../../../components/DashboardLayout";
 import AuthGuard from "../../../components/auth/AuthGuard";
 import { useAuth } from "../../../components/auth/AuthProvider";
 import { usePageById } from "../../../lib/usePageById";
 import { useAgentById } from "../../../lib/useAgentById";
-import { analyzePageWithAgent, generatePagesWithAgent } from "../../../lib/agentAPI";
-import { updatePage, createPage, getPagesForConcept, getPage } from "../../../lib/pagesAPI";
+import {
+  analyzePageWithAgent,
+  generatePagesWithAgent,
+} from "../../../lib/agentAPI";
+import {
+  updatePage,
+  createPage,
+  getPagesForConcept,
+  getPage,
+} from "../../../lib/pagesAPI";
 import { usePages } from "../../../lib/usePage";
 import { useConcepts } from "../../../lib/useConcept";
 import { useWorld } from "../../../lib/useWorld";
 import CreatePageForm from "../../../components/create_page/CreatePageForm";
 import SuggestionCard from "../../../components/agents/SuggestionCard";
 import Image from "next/image";
-import { Loader2, PlusCircle, PenLine, Merge, AlertTriangle } from "lucide-react";
+import { Loader2, AlertTriangle } from "lucide-react";
 import { useTranslation } from "@/app/hooks/useTranslation";
 
 const AGENT_PERSONALITIES = {
-  "Lorekeeper Lyra": "“Every story is a new star in the night sky. Let’s light up your world!”",
-  "Archivist Axion": "“Where words end, legends begin. Let us chronicle them together.”",
-  "default": "“I am your humble scribe. Let’s bring new tales to your world!”"
+  "Lorekeeper Lyra":
+    "“Every story is a new star in the night sky. Let’s light up your world!”",
+  "Archivist Axion":
+    "“Where words end, legends begin. Let us chronicle them together.”",
+  default: "“I am your humble scribe. Let’s bring new tales to your world!”",
 };
 
 const STEPS = [
   { label: "Review Lore" },
   { label: "Scribe’s Suggestions" },
   { label: "Choose Legends" },
-  { label: "Finalize Chronicle" }
+  { label: "Finalize Chronicle" },
 ];
 
 function Stepper({ step }) {
@@ -36,17 +47,26 @@ function Stepper({ step }) {
     <div className="flex items-center justify-center gap-4 mb-6">
       {STEPS.map((s, idx) => (
         <div className="flex items-center gap-1" key={s.label}>
-          <div className={`w-8 h-8 flex items-center justify-center rounded-full border-2 transition-all
-            ${step === idx
-              ? "bg-[var(--primary)] text-[var(--primary-foreground)] border-[var(--primary)] scale-110 shadow"
-              : step > idx
-                ? "bg-[var(--accent)]/70 text-white border-[var(--accent)]"
-                : "bg-[var(--muted)] text-gray-400 border-gray-300"
-            } font-bold`}>
+          <div
+            className={`w-8 h-8 flex items-center justify-center rounded-full border-2 transition-all
+            ${
+              step === idx
+                ? "bg-[var(--primary)] text-[var(--primary-foreground)] border-[var(--primary)] scale-110 shadow"
+                : step > idx
+                  ? "bg-[var(--accent)]/70 text-white border-[var(--accent)]"
+                  : "bg-[var(--muted)] text-gray-400 border-gray-300"
+            } font-bold`}
+          >
             {idx + 1}
           </div>
-          <div className={`text-xs font-semibold mt-2 text-center ${step === idx ? "text-[var(--primary)]" : "text-gray-400"}`}>{s.label}</div>
-          {idx < STEPS.length - 1 && <span className="w-6 h-1 bg-gradient-to-r from-[var(--primary)]/40 to-[var(--accent)]/30 rounded"></span>}
+          <div
+            className={`text-xs font-semibold mt-2 text-center ${step === idx ? "text-[var(--primary)]" : "text-gray-400"}`}
+          >
+            {s.label}
+          </div>
+          {idx < STEPS.length - 1 && (
+            <span className="w-6 h-1 bg-gradient-to-r from-[var(--primary)]/40 to-[var(--accent)]/30 rounded"></span>
+          )}
         </div>
       ))}
     </div>
@@ -57,8 +77,13 @@ function AgentBubble({ agent, children, loading = false }) {
   return (
     <div className="flex items-start gap-4 mb-4">
       <div className="relative">
-        <Image src={agent.logo || "/images/default/avatars/logo.png"} alt={agent.name} width={56} height={56}
-          className={`rounded-full object-cover border-2 border-[var(--primary)] shadow-md ${loading ? "animate-pulse" : ""}`} />
+        <Image
+          src={agent.logo || "/images/default/avatars/logo.png"}
+          alt={agent.name}
+          width={56}
+          height={56}
+          className={`rounded-full object-cover border-2 border-[var(--primary)] shadow-md ${loading ? "animate-pulse" : ""}`}
+        />
         {loading && (
           <span className="absolute -bottom-1 -right-1 bg-[var(--primary)] rounded-full w-4 h-4 flex items-center justify-center">
             <Loader2 className="w-3 h-3 text-white animate-spin" />
@@ -83,7 +108,9 @@ export default function PageAnalyze() {
   const { agent } = useAgentById(Number(agentID));
   const { concepts } = useConcepts(agent?.world_id);
   const { world } = useWorld(agent?.world_id);
-  const { pages: allPages } = usePages(agent?.world_id ? { gameworld_id: agent.world_id } : {});
+  const { pages: allPages } = usePages(
+    agent?.world_id ? { gameworld_id: agent.world_id } : {},
+  );
 
   const [step, setStep] = useState(0);
   const [loading, setLoading] = useState(false);
@@ -94,44 +121,54 @@ export default function PageAnalyze() {
 
   const scrollToCard = (idx) => {
     const ref = suggestionRefs.current[idx];
-    if (ref && ref.scrollIntoView) ref.scrollIntoView({ behavior: "smooth", block: "start" });
+    if (ref && ref.scrollIntoView)
+      ref.scrollIntoView({ behavior: "smooth", block: "start" });
   };
 
-  const getPersonality = () => AGENT_PERSONALITIES[agent?.name] || AGENT_PERSONALITIES.default;
+  const getPersonality = () =>
+    AGENT_PERSONALITIES[agent?.name] || AGENT_PERSONALITIES.default;
 
   async function handleAnalyze() {
     if (!agentID || !pageID || !token) return;
     setLoading(true);
     try {
-      const data = await analyzePageWithAgent(Number(agentID), Number(pageID), token);
+      const data = await analyzePageWithAgent(
+        Number(agentID),
+        Number(pageID),
+        token,
+      );
       let suggs = data.suggestions || [];
-      suggs = await Promise.all(suggs.map(async (s) => {
-        if (s.exists) {
-          const pages = await getPagesForConcept(s.concept_id, token);
-          const existing = pages.find((p) => p.name.toLowerCase() === s.name.toLowerCase());
-          if (existing) {
-            s.target_page_id = existing.id;
-            s.mode = "update";
-            s.concept_id = existing.concept_id;
-            const c = concepts?.find((c) => c.id === existing.concept_id);
-            if (c) s.concept = c.name;
+      suggs = await Promise.all(
+        suggs.map(async (s) => {
+          if (s.exists) {
+            const pages = await getPagesForConcept(s.concept_id, token);
+            const existing = pages.find(
+              (p) => p.name.toLowerCase() === s.name.toLowerCase(),
+            );
+            if (existing) {
+              s.target_page_id = existing.id;
+              s.mode = "update";
+              s.concept_id = existing.concept_id;
+              const c = concepts?.find((c) => c.id === existing.concept_id);
+              if (c) s.concept = c.name;
+            }
           }
-        }
-        return s;
-      }));
+          return s;
+        }),
+      );
       suggs.sort((a, b) => (a.exists === b.exists ? 0 : a.exists ? -1 : 1));
       setSelectedSuggestions(suggs);
       setStep(2);
     } catch (err) {
       console.error(err);
-      alert(t('fail_analyze_page'));
+      alert(t("fail_analyze_page"));
     }
     setLoading(false);
   }
 
   function buildMergeGroups(suggestions) {
     const graph = new Map();
-  
+
     suggestions.forEach((s) => {
       if (!graph.has(s.name)) graph.set(s.name, new Set());
       (s.merge_targets || []).forEach((target) => {
@@ -140,10 +177,10 @@ export default function PageAnalyze() {
         graph.get(target).add(s.name);
       });
     });
-  
+
     const visited = new Set();
     const groups = [];
-  
+
     for (const name of graph.keys()) {
       if (visited.has(name)) continue;
       const queue = [name];
@@ -157,37 +194,72 @@ export default function PageAnalyze() {
       }
       groups.push(Array.from(group));
     }
-  
-    const independent = suggestions.filter(s => !graph.has(s.name)).map(s => [s.name]);
+
+    const independent = suggestions
+      .filter((s) => !graph.has(s.name))
+      .map((s) => [s.name]);
     return [...groups, ...independent];
   }
-  
+
   async function handleGenerate({ bulkAcceptUpdates = false } = {}) {
     if (!agentID || !pageID || !token) return;
     setLoading(true);
     try {
       const mergeGroups = buildMergeGroups(selectedSuggestions);
-  
-      const fullGroups = mergeGroups.map(names => {
-        const group = selectedSuggestions.filter(s => names.includes(s.name));
-        const base = group.find(s => s.merge_targets?.length > 0) || group[0];
-        const mergedItems = group.filter(s => s !== base);
+
+      const fullGroups = mergeGroups.map((names) => {
+        const group = selectedSuggestions.filter((s) => names.includes(s.name));
+        const base = group.find((s) => s.merge_targets?.length > 0) || group[0];
+        const mergedItems = group.filter((s) => s !== base);
         return { base, mergedItems, group };
       });
-  
-      const allToGenerate = fullGroups.flatMap(({ group }) =>
-        group.map(({ name, concept_id }) => ({ name, concept_id }))
+
+      const pageSpecs = fullGroups.map(({ group }) => {
+        const base =
+          group.find(
+            (g) => Array.isArray(g.merge_targets) && g.merge_targets.length > 0,
+          ) || group[0];
+        const sourceIds = Array.from(
+          new Set(
+            group.flatMap((g) =>
+              (g.source_pages || []).map((sp: any) => sp.id),
+            ),
+          ),
+        );
+        const spec: any = {
+          name: base.name,
+          concept_id: base.concept_id,
+          source_page_ids: sourceIds,
+        };
+        const mode = base.mode || (base.exists ? "update" : "create");
+        spec.mode = mode;
+        if (mode === "update" && base.target_page_id) {
+          spec.target_page_id = base.target_page_id;
+        }
+        return spec;
+      });
+
+      const generatedAll = await generatePagesWithAgent(
+        Number(agentID),
+        Number(pageID),
+        pageSpecs,
+        token,
+        mergeGroups,
       );
-  
-      const generatedAll = await generatePagesWithAgent(Number(agentID), Number(pageID), allToGenerate, token);
-      const generatedPagesMap = new Map((generatedAll.pages || []).map(p => [p.name, p]));
-  
+      const generatedPagesMap = new Map(
+        (generatedAll.pages || []).map((p) => [p.name, p]),
+      );
+
       const mergedResult = [];
-  
-      for (const { base, mergedItems, group } of fullGroups) {
+
+      for (const { base, mergedItems } of fullGroups) {
         const generatedBase = generatedPagesMap.get(base.name);
-        const mergedContents = [generatedBase?.autogenerated_content || base.autogenerated_content || ""];
-  
+        const mergedContents = [
+          generatedBase?.autogenerated_content ||
+            base.autogenerated_content ||
+            "",
+        ];
+
         for (const item of mergedItems) {
           const generated = generatedPagesMap.get(item.name);
           if (generated?.autogenerated_content) {
@@ -196,38 +268,47 @@ export default function PageAnalyze() {
             mergedContents.push(item.autogenerated_content);
           }
         }
-  
-        const combinedAutogen = mergedContents.filter(Boolean).join("\n\n---\n\n");
-  
+
+        const combinedAutogen = mergedContents
+          .filter(Boolean)
+          .join("\n\n---\n\n");
+
         if ((base.exists || base.mode === "update") && bulkAcceptUpdates) {
           const backendPage = base.target_page_id
             ? await getPage(base.target_page_id, token)
-            : (await getPagesForConcept(base.concept_id, token)).find((p) => p.name.toLowerCase() === base.name.toLowerCase());
-  
+            : (await getPagesForConcept(base.concept_id, token)).find(
+                (p) => p.name.toLowerCase() === base.name.toLowerCase(),
+              );
+
           const previousAutogen = backendPage?.autogenerated_content || "";
           const extraHeader = `<h2>Notes from ${page?.name || "Analysis"}</h2>`;
           const fullAutogen = `${previousAutogen ? previousAutogen + "\n\n---\n\n" : ""}${extraHeader}\n${combinedAutogen}`;
-  
-          await updatePage(backendPage.id, {
-            name: backendPage.name,            
-            logo: backendPage.logo || undefined,
-            autogenerated_content: fullAutogen,
-            updated_by_agent_id: Number(agentID),                                                   
-            allow_crosslinks: backendPage.allowCrosslinks,
-            ignore_crosslink: backendPage.ignoreCrosslink,
-            allow_crossworld: backendPage.allowCrossworld,
-            
-          }, token);
+
+          await updatePage(
+            backendPage.id,
+            {
+              name: backendPage.name,
+              logo: backendPage.logo || undefined,
+              autogenerated_content: fullAutogen,
+              updated_by_agent_id: Number(agentID),
+              allow_crosslinks: backendPage.allowCrosslinks,
+              ignore_crosslink: backendPage.ignoreCrosslink,
+              allow_crossworld: backendPage.allowCrossworld,
+            },
+            token,
+          );
         } else {
           if (base.exists || base.mode === "update") {
             const backendPage = base.target_page_id
               ? await getPage(base.target_page_id, token)
-              : (await getPagesForConcept(base.concept_id, token)).find((p) => p.name.toLowerCase() === base.name.toLowerCase());
-  
+              : (await getPagesForConcept(base.concept_id, token)).find(
+                  (p) => p.name.toLowerCase() === base.name.toLowerCase(),
+                );
+
             const previousAutogen = backendPage?.autogenerated_content || "";
             const extraHeader = `<h2>Notes from ${page?.name || "Analysis"}</h2>`;
             const fullAutogen = `${previousAutogen ? previousAutogen + "\n\n---\n\n" : ""}${extraHeader}\n${combinedAutogen}`;
-  
+
             mergedResult.push({
               ...backendPage,
               autogenerated_content: fullAutogen,
@@ -243,66 +324,78 @@ export default function PageAnalyze() {
           }
         }
       }
-  
+
       setGeneratedPages(mergedResult);
       setActiveGen(0);
       setStep(3);
     } catch (err) {
       console.error(err);
-      alert(t('fail_generate_pages'));
+      alert(t("fail_generate_pages"));
     }
     setLoading(false);
   }
-  
 
-  
-  const [subStep, setSubStep] = useState<'a' | 'b' | 'c'>('a');
+  const [subStep, setSubStep] = useState<"a" | "b" | "c">("a");
   const [bulkAcceptUpdates, setBulkAcceptUpdates] = useState(false);
-  
+
   function advanceSubStep() {
-    if (subStep === 'a') setSubStep('b');
-    else if (subStep === 'b') setSubStep('c');
+    if (subStep === "a") setSubStep("b");
+    else if (subStep === "b") setSubStep("c");
     else setStep(3);
   }
-  
+
   function goBackSubStep() {
-    if (subStep === 'c') setSubStep('b');
-    else if (subStep === 'b') setSubStep('a');
+    if (subStep === "c") setSubStep("b");
+    else if (subStep === "b") setSubStep("a");
     else setStep(0);
   }
-  
+
   return (
     <AuthGuard>
       <DashboardLayout>
-      <div className="min-h-screen w-full bg-[var(--background)] text-[var(--foreground)] px-2 sm:px-6 py-10 flex justify-center">
-      <div className="">
-
+        <div className="min-h-screen w-full bg-[var(--background)] text-[var(--foreground)] px-2 sm:px-6 py-10 flex justify-center">
+          <div className="">
             {agent && (
               <div className="flex flex-col items-center gap-2 mb-3">
                 <div className="flex items-center gap-4">
-                  <Image src={agent.logo || "/images/default/avatars/logo.png"} alt={agent.name} width={64} height={64} className="rounded-full border-2 border-[var(--primary)] shadow-lg" />
+                  <Image
+                    src={agent.logo || "/images/default/avatars/logo.png"}
+                    alt={agent.name}
+                    width={64}
+                    height={64}
+                    className="rounded-full border-2 border-[var(--primary)] shadow-lg"
+                  />
                   <div>
-                    <h1 className="text-2xl font-extrabold text-[var(--primary)]">{agent.name}, Scribe of {world?.name}</h1>
-                    <div className="italic text-md text-[var(--accent)]">{getPersonality()}</div>
+                    <h1 className="text-2xl font-extrabold text-[var(--primary)]">
+                      {agent.name}, Scribe of {world?.name}
+                    </h1>
+                    <div className="italic text-md text-[var(--accent)]">
+                      {getPersonality()}
+                    </div>
                   </div>
                 </div>
-                <div className="w-full mt-6"><Stepper step={step} /></div>
+                <div className="w-full mt-6">
+                  <Stepper step={step} />
+                </div>
               </div>
             )}
 
             {step === 0 && (
               <>
                 <AgentBubble agent={agent}>
-                  <b>{t('step1_review_tome')}</b>
+                  <b>{t("step1_review_tome")}</b>
                   <br />
                   {user?.nickname
-                    ? `${user.nickname}, ${t('lets_read_page')}`
-                    : `“${t('lets_read_page')}”`}
+                    ? `${user.nickname}, ${t("lets_read_page")}`
+                    : `“${t("lets_read_page")}”`}
                 </AgentBubble>
                 {page && (
                   <div className="bg-[var(--card)] p-6 rounded-xl border border-[var(--border)] shadow max-w-3xl mx-auto">
                     <h2 className="text-lg font-bold mb-2">{page.name}</h2>
-                    <div className="prose prose-invert max-w-none" dangerouslySetInnerHTML={{ __html: page.content }} />
+                    <div
+                      className="prose prose-invert max-w-none"
+                      dangerouslySetInnerHTML={{ __html: page.content }}
+                    />
                   </div>
                 )}
                 <div className="flex justify-end mt-6">
@@ -310,259 +403,317 @@ export default function PageAnalyze() {
                     onClick={handleAnalyze}
                     disabled={loading}
                     className="px-4 py-2 rounded-xl bg-[var(--primary)] text-[var(--primary-foreground)] font-bold shadow hover:bg-[var(--accent)] transition disabled:opacity-50"
-                  >{loading ? <><Loader2 className="w-4 h-4 animate-spin" /> {t('reading')}</> : t('ready_scribe')}</button>
+                  >
+                    {loading ? (
+                      <>
+                        <Loader2 className="w-4 h-4 animate-spin" />{" "}
+                        {t("reading")}
+                      </>
+                    ) : (
+                      t("ready_scribe")
+                    )}
+                  </button>
                 </div>
               </>
             )}
 
-{/* // STEP 2A/2B/2C FLOW LOGIC AND UI */}
+            {/* // STEP 2A/2B/2C FLOW LOGIC AND UI */}
 
+            {step === 2 && (
+              <>
+                {/* Agent Bubble for Substeps */}
+                <div className="w-full max-w-screen-2xl mx-auto px-4 mb-4">
+                  <AgentBubble agent={agent}>
+                    {subStep === "a" && (
+                      <>
+                        <b>{t("step2a_remove")}</b>
+                        <br />
+                        {user?.nickname
+                          ? `${user.nickname}, ${t("step2a_desc")}`
+                          : t("step2a_desc")}
+                        <p className="mt-2 text-sm italic text-[var(--muted-foreground)]">
+                          {t("step2a_hint")}
+                        </p>
+                      </>
+                    )}
+                    {subStep === "b" && (
+                      <>
+                        <b>{t("step2b_merge")}</b>
+                        <br />
+                        {user?.nickname
+                          ? `${user.nickname}, ${t("step2b_desc")}`
+                          : t("step2b_desc")}
+                        <p className="mt-2 text-sm italic text-[var(--muted-foreground)]">
+                          {t("step2b_hint")}
+                        </p>
+                      </>
+                    )}
+                    {subStep === "c" && (
+                      <>
+                        <b>{t("step2c_finalize")}</b>
+                        <br />
+                        {user?.nickname
+                          ? `${user.nickname}, ${t("step2c_desc")}`
+                          : t("step2c_desc")}
+                        <p className="mt-2 text-sm italic text-[var(--muted-foreground)]">
+                          {t("step2c_hint")}
+                        </p>
+                      </>
+                    )}
+                  </AgentBubble>
+                </div>
 
+                {/* Main Grid Layout */}
+                <div className="min-h-screen w-full bg-[var(--background)] text-[var(--foreground)] px-4 flex justify-center">
+                  <div className="w-full max-w-screen-2xl grid grid-cols-1 xl:grid-cols-[1fr_18rem] gap-6 items-start">
+                    {/* Suggestion Cards */}
+                    <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
+                      {selectedSuggestions.map((sugg, idx) => (
+                        <div
+                          key={idx}
+                          ref={(el) => (suggestionRefs.current[idx] = el)}
+                        >
+                          <SuggestionCard
+                            index={idx}
+                            suggestion={sugg}
+                            suggestions={selectedSuggestions}
+                            concepts={concepts}
+                            pages={allPages}
+                            token={token}
+                            subStep={subStep}
+                            onUpdate={(i, data) => {
+                              const copy = [...selectedSuggestions];
+                              copy[i] = { ...copy[i], ...data };
+                              setSelectedSuggestions(copy);
+                            }}
+                            onRemove={(i) => {
+                              const copy = [...selectedSuggestions];
+                              copy.splice(i, 1);
+                              setSelectedSuggestions(copy);
+                            }}
+                          />
+                        </div>
+                      ))}
+                    </div>
 
-{step === 2 && (
-  <>
-    {/* Agent Bubble for Substeps */}
-    <div className="w-full max-w-screen-2xl mx-auto px-4 mb-4">
-      <AgentBubble agent={agent}>
-        {subStep === 'a' && (
-          <> 
-            <b>{t('step2a_remove')}</b>
-            <br />
-            {user?.nickname
-              ? `${user.nickname}, ${t('step2a_desc')}`
-              : t('step2a_desc')}
-            <p className="mt-2 text-sm italic text-[var(--muted-foreground)]">
-              {t('step2a_hint')}
-            </p>
-          </>
-        )}
-        {subStep === 'b' && (
-          <> 
-            <b>{t('step2b_merge')}</b>
-            <br />
-            {user?.nickname
-              ? `${user.nickname}, ${t('step2b_desc')}`
-              : t('step2b_desc')}
-            <p className="mt-2 text-sm italic text-[var(--muted-foreground)]">
-              {t('step2b_hint')}
-            </p>
-          </>
-        )}
-        {subStep === 'c' && (
-          <> 
-            <b>{t('step2c_finalize')}</b>
-            <br />
-            {user?.nickname
-              ? `${user.nickname}, ${t('step2c_desc')}`
-              : t('step2c_desc')}
-            <p className="mt-2 text-sm italic text-[var(--muted-foreground)]">
-              {t('step2c_hint')}
-            </p>
-          </>
-        )}
-      </AgentBubble>
-    </div>
+                    {/* Summary Panel */}
+                    <div className="sticky top-10 bg-[var(--surface)] border border-[var(--border)] rounded-lg p-4">
+                      <h2 className="text-xl font-bold mb-3 text-[var(--primary)] border-b border-[var(--primary)] pb-1">
+                        📋 {t("summary")}
+                      </h2>
+                      <p className="text-sm mb-4 text-[var(--muted-foreground)]">
+                        {selectedSuggestions.length} {t("suggestions_label")}
+                      </p>
+                      <p className="mb-4">{t("track_progress")}</p>
+                      <div className="grid grid-cols-2 gap-2 text-sm">
+                        {selectedSuggestions.map((s, idx) => {
+                          const isMerged = selectedSuggestions.some(
+                            (other, j) =>
+                              j !== idx &&
+                              Array.isArray(other.merge_targets) &&
+                              other.merge_targets.includes(s.name),
+                          );
+                          const type = isMerged
+                            ? "Merged"
+                            : s.mode === "update" || s.exists
+                              ? "Update"
+                              : "Create";
+                          const color =
+                            type === "Update"
+                              ? "text-blue-500"
+                              : type === "Create"
+                                ? "text-green-500"
+                                : "text-gray-500";
+                          return (
+                            <div
+                              key={idx}
+                              onClick={() => scrollToCard(idx)}
+                              className="cursor-pointer px-3 py-2 rounded border border-[var(--border)] bg-[var(--surface-variant)] hover:bg-[var(--surface)] transition"
+                            >
+                              <div className={`font-semibold ${color}`}>
+                                {s.name}
+                              </div>
+                              <div className="text-xs text-[var(--muted-foreground)]">
+                                {type} in {s.concept || "(No Concept)"}
+                              </div>
+                              {!s.concept && (
+                                <div className="text-red-500 text-xs flex items-center gap-1 mt-1">
+                                  <AlertTriangle className="w-3 h-3" />{" "}
+                                  {t("missing_concept")}
+                                </div>
+                              )}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  </div>
+                </div>
 
-    {/* Main Grid Layout */}
-    <div className="min-h-screen w-full bg-[var(--background)] text-[var(--foreground)] px-4 flex justify-center">
-      <div className="w-full max-w-screen-2xl grid grid-cols-1 xl:grid-cols-[1fr_18rem] gap-6 items-start">
+                {/* Step Controls */}
+                <div className="flex justify-between mt-8 w-full max-w-screen-2xl mx-auto px-4">
+                  <button
+                    onClick={goBackSubStep}
+                    className="px-4 py-2 rounded-xl border border-[var(--primary)] text-[var(--primary)] font-bold shadow hover:bg-[var(--accent)]/30 transition"
+                  >
+                    {t("back")}
+                  </button>
 
-        {/* Suggestion Cards */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
-          {selectedSuggestions.map((sugg, idx) => (
-            <div key={idx} ref={(el) => (suggestionRefs.current[idx] = el)}>
-              <SuggestionCard
-                index={idx}
-                suggestion={sugg}
-                suggestions={selectedSuggestions}
-                concepts={concepts}
-                pages={allPages} 
-                token={token}
-                subStep={subStep}
-                onUpdate={(i, data) => {
-                  const copy = [...selectedSuggestions];
-                  copy[i] = { ...copy[i], ...data };
-                  setSelectedSuggestions(copy);
-                }}
-                onRemove={(i) => {
-                  const copy = [...selectedSuggestions];
-                  copy.splice(i, 1);
-                  setSelectedSuggestions(copy);
-                }}
-              />
-            </div>
-          ))}
-        </div>
-
-        {/* Summary Panel */}
-        <div className="sticky top-10 bg-[var(--surface)] border border-[var(--border)] rounded-lg p-4">
-          <h2 className="text-xl font-bold mb-3 text-[var(--primary)] border-b border-[var(--primary)] pb-1">📋 {t('summary')}</h2>
-          <p className="text-sm mb-4 text-[var(--muted-foreground)]">{selectedSuggestions.length} {t('suggestions_label')}</p>
-          <p className="mb-4">{t('track_progress')}</p>
-          <div className="grid grid-cols-2 gap-2 text-sm">
-            {selectedSuggestions.map((s, idx) => {
-              const isMerged = selectedSuggestions.some((other, j) =>
-                j !== idx && Array.isArray(other.merge_targets) && other.merge_targets.includes(s.name)
-              );
-              const type = isMerged ? "Merged" : s.mode === "update" || s.exists ? "Update" : "Create";
-              const color = type === "Update" ? "text-blue-500" : type === "Create" ? "text-green-500" : "text-gray-500";
-              return (
-                <div
-                  key={idx}
-                  onClick={() => scrollToCard(idx)}
-                  className="cursor-pointer px-3 py-2 rounded border border-[var(--border)] bg-[var(--surface-variant)] hover:bg-[var(--surface)] transition"
-                >
-                  <div className={`font-semibold ${color}`}>{s.name}</div>
-                  <div className="text-xs text-[var(--muted-foreground)]">{type} in {s.concept || "(No Concept)"}</div>
-                  {!s.concept && (
-                    <div className="text-red-500 text-xs flex items-center gap-1 mt-1">
-                      <AlertTriangle className="w-3 h-3" /> {t('missing_concept')}
+                  {step === 2 && subStep === "c" && (
+                    <div className="max-w-screen-2xl mx-auto px-4 mb-4">
+                      <label className="flex items-center gap-2 text-sm font-medium text-[var(--foreground)]">
+                        <input
+                          type="checkbox"
+                          checked={bulkAcceptUpdates}
+                          onChange={(e) =>
+                            setBulkAcceptUpdates(e.target.checked)
+                          }
+                          className="accent-[var(--primary)]"
+                        />
+                        {t("auto_apply_updates")}
+                      </label>
+                      <p className="text-xs text-[var(--muted-foreground)] ml-6 mt-1">
+                        {t("auto_apply_updates_desc")}
+                      </p>
                     </div>
                   )}
+                  {subStep !== "c" ? (
+                    <button
+                      onClick={advanceSubStep}
+                      className="px-4 py-2 rounded-xl bg-[var(--primary)] text-white font-bold shadow hover:bg-[var(--accent)] transition"
+                    >
+                      {t("continue_to_step")} {subStep === "a" ? "2B" : "2C"}
+                    </button>
+                  ) : (
+                    <button
+                      onClick={() => handleGenerate({ bulkAcceptUpdates })}
+                      disabled={loading}
+                      className="px-4 py-2 rounded-xl bg-[var(--primary)] text-white font-bold shadow hover:bg-[var(--accent)] transition disabled:opacity-50"
+                    >
+                      {loading ? (
+                        <>
+                          <Loader2 className="w-4 h-4 animate-spin" />{" "}
+                          {t("processing")}
+                        </>
+                      ) : (
+                        t("inscribe_legends")
+                      )}
+                    </button>
+                  )}
                 </div>
-              );
-            })}
-          </div>
-        </div>
-      </div>
-    </div>
-    
-    {/* Step Controls */}
-    <div className="flex justify-between mt-8 w-full max-w-screen-2xl mx-auto px-4">
-      
-      <button
-        onClick={goBackSubStep}
-        className="px-4 py-2 rounded-xl border border-[var(--primary)] text-[var(--primary)] font-bold shadow hover:bg-[var(--accent)]/30 transition"
-      >
-        {t('back')}
-      </button>
+              </>
+            )}
 
-      {step === 2 && subStep === 'c' && (
-      <div className="max-w-screen-2xl mx-auto px-4 mb-4">
-        <label className="flex items-center gap-2 text-sm font-medium text-[var(--foreground)]">
-          <input
-            type="checkbox"
-            checked={bulkAcceptUpdates}
-            onChange={(e) => setBulkAcceptUpdates(e.target.checked)}
-            className="accent-[var(--primary)]"
-          />
-          {t('auto_apply_updates')} 
-        </label>
-        <p className="text-xs text-[var(--muted-foreground)] ml-6 mt-1">
-          {t('auto_apply_updates_desc')}
-        </p>
-      </div>
-    )}
-      {subStep !== 'c' ? (
-        <button
-          onClick={advanceSubStep}
-          className="px-4 py-2 rounded-xl bg-[var(--primary)] text-white font-bold shadow hover:bg-[var(--accent)] transition"
-        >
-          {t('continue_to_step')} {subStep === 'a' ? '2B' : '2C'}
-        </button>
-      ) : (
-        <button
-          onClick={() => handleGenerate({ bulkAcceptUpdates })}
-          disabled={loading}
-          className="px-4 py-2 rounded-xl bg-[var(--primary)] text-white font-bold shadow hover:bg-[var(--accent)] transition disabled:opacity-50"
-        >
-          {loading ? <><Loader2 className="w-4 h-4 animate-spin" /> {t('processing')}</> : t('inscribe_legends')}
-        </button>
-      )}
-    </div>
-  </>
-)}
+            {step === 3 && generatedPages.length > 0 && (
+              <>
+                <AgentBubble agent={agent}>
+                  <b>{t("final_step_review")}</b>
+                  <br />
+                  {t("final_step_desc")}
+                </AgentBubble>
 
-{step === 3 && generatedPages.length > 0 && (
-  <>
-    <AgentBubble agent={agent}>
-      <b>{t('final_step_review')}</b><br />
-      {t('final_step_desc')}
-    </AgentBubble>
+                <div className="w-full max-w-screen-2xl mx-auto px-4">
+                  <div className="overflow-x-auto">
+                    <div className="flex flex-wrap gap-2 border-b border-[var(--border)] pb-2 mb-6">
+                      {generatedPages.map((p, idx) => (
+                        <button
+                          key={idx}
+                          onClick={() => setActiveGen(idx)}
+                          className={`px-4 py-2 rounded-t-lg text-sm font-bold border-b-2 transition-all ${
+                            activeGen === idx
+                              ? "border-[var(--primary)] text-[var(--primary)] bg-[var(--card)]"
+                              : "border-transparent text-[var(--muted-foreground)] hover:text-[var(--primary)]"
+                          }`}
+                        >
+                          {p.name}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
 
-    <div className="w-full max-w-screen-2xl mx-auto px-4">
-      <div className="overflow-x-auto">
-        <div className="flex flex-wrap gap-2 border-b border-[var(--border)] pb-2 mb-6">
-          {generatedPages.map((p, idx) => (
-            <button
-              key={idx}
-              onClick={() => setActiveGen(idx)}
-              className={`px-4 py-2 rounded-t-lg text-sm font-bold border-b-2 transition-all ${
-                activeGen === idx
-                  ? "border-[var(--primary)] text-[var(--primary)] bg-[var(--card)]"
-                  : "border-transparent text-[var(--muted-foreground)] hover:text-[var(--primary)]"
-              }`}
-            >
-              {p.name}
-            </button>
-          ))}
-        </div>
-      </div>
+                  {generatedPages.map(
+                    (p, idx) =>
+                      activeGen === idx && (
+                        <div
+                          key={idx}
+                          className="border border-[var(--border)] rounded-xl p-6 bg-[var(--card)] shadow-sm mb-12"
+                        >
+                          {/* Concept Header */}
+                          <div className="flex items-center gap-4 mb-4">
+                            {concepts?.find((c) => c.id === p.concept_id)
+                              ?.logo && (
+                              <img
+                                src={
+                                  concepts.find((c) => c.id === p.concept_id)
+                                    .logo
+                                }
+                                alt="concept logo"
+                                className="w-10 h-10 rounded-full border border-[var(--border)]"
+                              />
+                            )}
+                            <h3 className="text-xl font-bold text-[var(--primary)]">
+                              {concepts?.find((c) => c.id === p.concept_id)
+                                ?.name || t("unknown_concept")}
+                            </h3>
+                          </div>
 
-      {generatedPages.map((p, idx) => (
-        activeGen === idx && (
-          <div
-            key={idx}
-            className="border border-[var(--border)] rounded-xl p-6 bg-[var(--card)] shadow-sm mb-12"
-          >
-            {/* Concept Header */}
-            <div className="flex items-center gap-4 mb-4">
-              {concepts?.find(c => c.id === p.concept_id)?.logo && (
-                <img
-                  src={concepts.find(c => c.id === p.concept_id).logo}
-                  alt="concept logo"
-                  className="w-10 h-10 rounded-full border border-[var(--border)]"
-                />
-              )}
-              <h3 className="text-xl font-bold text-[var(--primary)]">
-                {concepts?.find(c => c.id === p.concept_id)?.name || t('unknown_concept')}
-              </h3>
-            </div>
+                          {/* Autogenerated Content */}
+                          <div className="prose prose-invert max-w-none mb-6 border-l-4 border-yellow-400 pl-4">
+                            <div
+                              dangerouslySetInnerHTML={{
+                                __html: p.autogenerated_content,
+                              }}
+                            />
+                          </div>
 
-            {/* Autogenerated Content */}
-            <div className="prose prose-invert max-w-none mb-6 border-l-4 border-yellow-400 pl-4">
-              <div dangerouslySetInnerHTML={{ __html: p.autogenerated_content }} />
-            </div>
-
-            {/* Create/Edit Page Form */}
-            <CreatePageForm
-              selectedWorld={world}
-              selectedConcept={concepts?.find((c) => c.id === p.concept_id)}
-              token={token}
-              initialValues={p}
-              mode={p?.id ? "edit" : "create"}
-              onSubmit={async (payload) => {
-                if (!token) return;
-                if (p?.id) {
-                  await updatePage(
-                    p.id,
-                    {
-                      ...payload,
-                      autogenerated_content: p.autogenerated_content,
-                      updated_by_agent_id: Number(agentID),
-                    },
-                    token
-                  );
-                } else {
-                  const created = await createPage(payload, token);
-                  await updatePage(
-                    created.id,
-                    {
-                      autogenerated_content: p.autogenerated_content,
-                      updated_by_agent_id: Number(agentID),
-                    },
-                    token
-                  );
-                }
-                setGeneratedPages((g) => g.filter((_, i) => i !== idx));
-              }}
-            />
-          </div>
-        )
-      ))}
-    </div>
-  </>
-)}
+                          {/* Create/Edit Page Form */}
+                          <CreatePageForm
+                            selectedWorld={world}
+                            selectedConcept={concepts?.find(
+                              (c) => c.id === p.concept_id,
+                            )}
+                            token={token}
+                            initialValues={p}
+                            mode={p?.id ? "edit" : "create"}
+                            onSubmit={async (payload) => {
+                              if (!token) return;
+                              if (p?.id) {
+                                await updatePage(
+                                  p.id,
+                                  {
+                                    ...payload,
+                                    autogenerated_content:
+                                      p.autogenerated_content,
+                                    updated_by_agent_id: Number(agentID),
+                                  },
+                                  token,
+                                );
+                              } else {
+                                const created = await createPage(
+                                  payload,
+                                  token,
+                                );
+                                await updatePage(
+                                  created.id,
+                                  {
+                                    autogenerated_content:
+                                      p.autogenerated_content,
+                                    updated_by_agent_id: Number(agentID),
+                                  },
+                                  token,
+                                );
+                              }
+                              setGeneratedPages((g) =>
+                                g.filter((_, i) => i !== idx),
+                              );
+                            }}
+                          />
+                        </div>
+                      ),
+                  )}
+                </div>
+              </>
+            )}
           </div>
         </div>
       </DashboardLayout>

--- a/frontend/src/app/agent_writer/[agentID]/suggestions/[jobID]/page.tsx
+++ b/frontend/src/app/agent_writer/[agentID]/suggestions/[jobID]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useParams, useRouter } from "next/navigation";
 import DashboardLayout from "@/app/components/DashboardLayout";
 import AuthGuard from "@/app/components/auth/AuthGuard";
@@ -6,7 +7,11 @@ import { useAuth } from "@/app/components/auth/AuthProvider";
 import { useEffect, useRef, useState } from "react";
 import Image from "next/image";
 import SuggestionCard from "@/app/components/agents/SuggestionCard";
-import { getWriterJob, startGenerateJob, updateWriterJob } from "@/app/lib/agentAPI";
+import {
+  getWriterJob,
+  startGenerateJob,
+  updateWriterJob,
+} from "@/app/lib/agentAPI";
 import { useAgentById } from "@/app/lib/useAgentById";
 import { useConcepts } from "@/app/lib/useConcept";
 import { useWorld } from "@/app/lib/useWorld";
@@ -31,14 +36,20 @@ function Stepper({ step }: { step: number }) {
               step === idx
                 ? "bg-[var(--primary)] text-[var(--primary-foreground)] border-[var(--primary)] scale-110 shadow"
                 : step > idx
-                ? "bg-[var(--accent)]/70 text-white border-[var(--accent)]"
-                : "bg-[var(--muted)] text-gray-400 border-gray-300"
+                  ? "bg-[var(--accent)]/70 text-white border-[var(--accent)]"
+                  : "bg-[var(--muted)] text-gray-400 border-gray-300"
             } font-bold`}
           >
             {idx + 1}
           </div>
-          <div className={`text-xs font-semibold mt-2 text-center ${step === idx ? "text-[var(--primary)]" : "text-gray-400"}`}>{s.label}</div>
-          {idx < STEPS.length - 1 && <span className="w-6 h-1 bg-gradient-to-r from-[var(--primary)]/40 to-[var(--accent)]/30 rounded"></span>}
+          <div
+            className={`text-xs font-semibold mt-2 text-center ${step === idx ? "text-[var(--primary)]" : "text-gray-400"}`}
+          >
+            {s.label}
+          </div>
+          {idx < STEPS.length - 1 && (
+            <span className="w-6 h-1 bg-gradient-to-r from-[var(--primary)]/40 to-[var(--accent)]/30 rounded"></span>
+          )}
         </div>
       ))}
     </div>
@@ -81,13 +92,15 @@ export default function SuggestionsPage() {
 
   const [job, setJob] = useState<any>(null);
   const [selectedSuggestions, setSelectedSuggestions] = useState<any[]>([]);
-  const [subStep, setSubStep] = useState<'a' | 'b' | 'c'>('a');
+  const [subStep, setSubStep] = useState<"a" | "b" | "c">("a");
   const [loading, setLoading] = useState(false);
 
   const { agent } = useAgentById(Number(agentID));
   const { concepts } = useConcepts(agent?.world_id);
   const { world } = useWorld(agent?.world_id);
-  const { pages: allPages } = usePages(agent?.world_id ? { gameworld_id: agent.world_id } : {});
+  const { pages: allPages } = usePages(
+    agent?.world_id ? { gameworld_id: agent.world_id } : {},
+  );
 
   const suggestionRefs = useRef<HTMLDivElement[]>([]);
 
@@ -97,7 +110,7 @@ export default function SuggestionsPage() {
       .then((data) => {
         setJob(data);
         const mapped = (data.suggestions || []).map((s: any) =>
-          s.exists && !s.mode ? { ...s, mode: "update" } : s
+          s.exists && !s.mode ? { ...s, mode: "update" } : s,
         );
         setSelectedSuggestions(mapped);
       })
@@ -106,7 +119,8 @@ export default function SuggestionsPage() {
 
   const scrollToCard = (idx: number) => {
     const ref = suggestionRefs.current[idx];
-    if (ref && ref.scrollIntoView) ref.scrollIntoView({ behavior: "smooth", block: "start" });
+    if (ref && ref.scrollIntoView)
+      ref.scrollIntoView({ behavior: "smooth", block: "start" });
   };
 
   function buildMergeGroups(suggestions: any[]) {
@@ -134,18 +148,20 @@ export default function SuggestionsPage() {
       }
       groups.push(Array.from(group));
     }
-    const independent = suggestions.filter((s) => !graph.has(s.name)).map((s) => [s.name]);
+    const independent = suggestions
+      .filter((s) => !graph.has(s.name))
+      .map((s) => [s.name]);
     return [...groups, ...independent];
   }
 
   const advanceSubStep = () => {
-    if (subStep === 'a') setSubStep('b');
-    else if (subStep === 'b') setSubStep('c');
+    if (subStep === "a") setSubStep("b");
+    else if (subStep === "b") setSubStep("c");
   };
 
   const goBackSubStep = () => {
-    if (subStep === 'c') setSubStep('b');
-    else if (subStep === 'b') setSubStep('a');
+    if (subStep === "c") setSubStep("b");
+    else if (subStep === "b") setSubStep("a");
   };
 
   const handleBulkDelete = () => {
@@ -172,8 +188,9 @@ export default function SuggestionsPage() {
           });
         });
         const base =
-          group.find((g) => Array.isArray(g.merge_targets) && g.merge_targets.length > 0) ||
-          group[0];
+          group.find(
+            (g) => Array.isArray(g.merge_targets) && g.merge_targets.length > 0,
+          ) || group[0];
         base.source_pages = Object.values(sourcesMap);
       }
 
@@ -182,27 +199,45 @@ export default function SuggestionsPage() {
           .map((n) => prepared.find((ss) => ss.name === n))
           .filter(Boolean) as any[];
         const base =
-          group.find((g) => Array.isArray(g.merge_targets) && g.merge_targets.length > 0) ||
-          group[0];
+          group.find(
+            (g) => Array.isArray(g.merge_targets) && g.merge_targets.length > 0,
+          ) || group[0];
         const ids = Array.from(
           new Set(
-            group.flatMap((g) => (g.source_pages || []).map((sp: any) => sp.id))
-          )
+            group.flatMap((g) =>
+              (g.source_pages || []).map((sp: any) => sp.id),
+            ),
+          ),
         );
-        return { name: base.name, concept_id: base.concept_id, source_page_ids: ids };
+        const spec: any = {
+          name: base.name,
+          concept_id: base.concept_id,
+          source_page_ids: ids,
+        };
+        const mode = base.mode || (base.exists ? "update" : "create");
+        spec.mode = mode;
+        if (mode === "update" && base.target_page_id) {
+          spec.target_page_id = base.target_page_id;
+        }
+        return spec;
       });
-      const basePageId = job.page_id || (Array.isArray(job.page_ids) ? job.page_ids[0] : 0);
-      const res = await startGenerateJob(
+      const basePageId =
+        job.page_id || (Array.isArray(job.page_ids) ? job.page_ids[0] : 0);
+      await startGenerateJob(
         Number(agentID),
         basePageId,
         allPages as any[],
         token || "",
         prepared,
         mergeGroups,
-        jobID as string
+        jobID as string,
       );
       if (jobID)
-        await updateWriterJob(jobID as string, { action_needed: "done" }, token || "");
+        await updateWriterJob(
+          jobID as string,
+          { action_needed: "done" },
+          token || "",
+        );
       // router.push(`/agent_writer/${agentID}/review/${res.job_id}`);
       router.push(`/agent_writer?agent=${agentID}`);
     } catch (err) {
@@ -212,16 +247,17 @@ export default function SuggestionsPage() {
     setLoading(false);
   }
 
-  if (!job) return (
-    <AuthGuard>
-      <DashboardLayout>Loading...</DashboardLayout>
-    </AuthGuard>
-  );
+  if (!job)
+    return (
+      <AuthGuard>
+        <DashboardLayout>Loading...</DashboardLayout>
+      </AuthGuard>
+    );
 
   const step = 2;
 
   const sortedSuggestions = [...selectedSuggestions].sort((a, b) =>
-    a.name.localeCompare(b.name)
+    a.name.localeCompare(b.name),
   );
 
   const handleDragMerge = (fromIdx: number, toIdx: number) => {
@@ -245,51 +281,61 @@ export default function SuggestionsPage() {
             {agent && (
               <div className="flex flex-col items-center gap-2 mb-3">
                 <div className="flex items-center gap-4">
-                  <Image src={agent.logo || "/images/default/avatars/logo.png"} alt={agent.name} width={64} height={64} className="rounded-full border-2 border-[var(--primary)] shadow-lg" />
+                  <Image
+                    src={agent.logo || "/images/default/avatars/logo.png"}
+                    alt={agent.name}
+                    width={64}
+                    height={64}
+                    className="rounded-full border-2 border-[var(--primary)] shadow-lg"
+                  />
                   <div>
-                    <h1 className="text-2xl font-extrabold text-[var(--primary)]">{agent.name}, Scribe of {world?.name}</h1>
+                    <h1 className="text-2xl font-extrabold text-[var(--primary)]">
+                      {agent.name}, Scribe of {world?.name}
+                    </h1>
                   </div>
                 </div>
-                <div className="w-full mt-6"><Stepper step={step} /></div>
+                <div className="w-full mt-6">
+                  <Stepper step={step} />
+                </div>
               </div>
             )}
 
             {/* Substep bubble */}
             <div className="w-full max-w-screen-2xl mx-auto px-4 mb-4">
               <AgentBubble agent={agent}>
-                {subStep === 'a' && (
+                {subStep === "a" && (
                   <>
-                    <b>{t('step2a_remove')}</b>
+                    <b>{t("step2a_remove")}</b>
                     <br />
                     {user?.nickname
-                      ? `${user.nickname}, ${t('step2a_desc')}`
-                      : t('step2a_desc')}
+                      ? `${user.nickname}, ${t("step2a_desc")}`
+                      : t("step2a_desc")}
                     <p className="mt-2 text-sm italic text-[var(--muted-foreground)]">
-                      {t('step2a_hint')}
+                      {t("step2a_hint")}
                     </p>
                   </>
                 )}
-                {subStep === 'b' && (
+                {subStep === "b" && (
                   <>
-                    <b>{t('step2b_merge')}</b>
+                    <b>{t("step2b_merge")}</b>
                     <br />
                     {user?.nickname
-                      ? `${user.nickname}, ${t('step2b_desc')}`
-                      : t('step2b_desc')}
+                      ? `${user.nickname}, ${t("step2b_desc")}`
+                      : t("step2b_desc")}
                     <p className="mt-2 text-sm italic text-[var(--muted-foreground)]">
-                      {t('step2b_hint')}
+                      {t("step2b_hint")}
                     </p>
                   </>
                 )}
-                {subStep === 'c' && (
+                {subStep === "c" && (
                   <>
-                    <b>{t('step2c_finalize')}</b>
+                    <b>{t("step2c_finalize")}</b>
                     <br />
                     {user?.nickname
-                      ? `${user.nickname}, ${t('step2c_desc')}`
-                      : t('step2c_desc')}
+                      ? `${user.nickname}, ${t("step2c_desc")}`
+                      : t("step2c_desc")}
                     <p className="mt-2 text-sm italic text-[var(--muted-foreground)]">
-                      {t('step2c_hint')}
+                      {t("step2c_hint")}
                     </p>
                   </>
                 )}
@@ -301,46 +347,69 @@ export default function SuggestionsPage() {
                 {sortedSuggestions.map((sugg, idx) => {
                   const origIndex = selectedSuggestions.indexOf(sugg);
                   return (
-                  <div key={idx} ref={(el) => (suggestionRefs.current[idx] = el!)}>
-                    <SuggestionCard
-                      index={origIndex}
-                      suggestion={sugg}
-                      suggestions={sortedSuggestions}
-                      concepts={concepts}
-                      pages={allPages}
-                      token={token}
-                      subStep={subStep}
-                      onDragMerge={handleDragMerge}
-                      onUpdate={(i: number, data: any) => {
-                        const copy = [...selectedSuggestions];
-                        copy[i] = { ...copy[i], ...data };
-                        setSelectedSuggestions(copy);
-                      }}
-                    />
-                  </div>
-                )})}
+                    <div
+                      key={idx}
+                      ref={(el) => (suggestionRefs.current[idx] = el!)}
+                    >
+                      <SuggestionCard
+                        index={origIndex}
+                        suggestion={sugg}
+                        suggestions={sortedSuggestions}
+                        concepts={concepts}
+                        pages={allPages}
+                        token={token}
+                        subStep={subStep}
+                        onDragMerge={handleDragMerge}
+                        onUpdate={(i: number, data: any) => {
+                          const copy = [...selectedSuggestions];
+                          copy[i] = { ...copy[i], ...data };
+                          setSelectedSuggestions(copy);
+                        }}
+                      />
+                    </div>
+                  );
+                })}
               </div>
 
               <div className="sticky top-10 bg-[var(--surface)] border border-[var(--border)] rounded-lg p-4">
-                <h2 className="text-xl font-bold mb-3 text-[var(--primary)] border-b border-[var(--primary)] pb-1">📋 {t('summary')}</h2>
-                <p className="text-sm mb-4 text-[var(--muted-foreground)]">{selectedSuggestions.length} {t('suggestions_label')}</p>
-                <p className="mb-4">{t('track_progress')}</p>
+                <h2 className="text-xl font-bold mb-3 text-[var(--primary)] border-b border-[var(--primary)] pb-1">
+                  📋 {t("summary")}
+                </h2>
+                <p className="text-sm mb-4 text-[var(--muted-foreground)]">
+                  {selectedSuggestions.length} {t("suggestions_label")}
+                </p>
+                <p className="mb-4">{t("track_progress")}</p>
                 <div className="grid grid-cols-2 gap-2 text-sm">
                   {sortedSuggestions.map((s, idx) => {
                     const targetedByOther = selectedSuggestions.some(
                       (other) =>
                         other !== s &&
                         Array.isArray(other.merge_targets) &&
-                        other.merge_targets.includes(s.name)
+                        other.merge_targets.includes(s.name),
                     );
-                    const firstIndex = selectedSuggestions.findIndex((ss) => ss.name === s.name);
+                    const firstIndex = selectedSuggestions.findIndex(
+                      (ss) => ss.name === s.name,
+                    );
                     const isMerged =
                       targetedByOther ||
                       (firstIndex !== selectedSuggestions.indexOf(s) &&
-                        Array.isArray(selectedSuggestions[firstIndex]?.merge_targets) &&
-                        selectedSuggestions[firstIndex].merge_targets.includes(s.name));
-                    const type = isMerged ? "Merged" : s.mode === "update" || s.exists ? "Update" : "Create";
-                    const color = type === "Update" ? "text-blue-500" : type === "Create" ? "text-green-500" : "text-gray-500";
+                        Array.isArray(
+                          selectedSuggestions[firstIndex]?.merge_targets,
+                        ) &&
+                        selectedSuggestions[firstIndex].merge_targets.includes(
+                          s.name,
+                        ));
+                    const type = isMerged
+                      ? "Merged"
+                      : s.mode === "update" || s.exists
+                        ? "Update"
+                        : "Create";
+                    const color =
+                      type === "Update"
+                        ? "text-blue-500"
+                        : type === "Create"
+                          ? "text-green-500"
+                          : "text-gray-500";
                     return (
                       <div
                         key={idx}
@@ -348,10 +417,13 @@ export default function SuggestionsPage() {
                         className="cursor-pointer px-3 py-2 rounded border border-[var(--border)] bg-[var(--surface-variant)] hover:bg-[var(--surface)] transition"
                       >
                         <div className={`font-semibold ${color}`}>{s.name}</div>
-                        <div className="text-xs text-[var(--muted-foreground)]">{type} in {s.concept || "(No Concept)"}</div>
+                        <div className="text-xs text-[var(--muted-foreground)]">
+                          {type} in {s.concept || "(No Concept)"}
+                        </div>
                         {!s.concept && (
                           <div className="text-red-500 text-xs flex items-center gap-1 mt-1">
-                            <AlertTriangle className="w-3 h-3" /> {t('missing_concept')}
+                            <AlertTriangle className="w-3 h-3" />{" "}
+                            {t("missing_concept")}
                           </div>
                         )}
                       </div>
@@ -366,25 +438,25 @@ export default function SuggestionsPage() {
                 onClick={goBackSubStep}
                 className="px-4 py-2 rounded-xl border border-[var(--primary)] text-[var(--primary)] font-bold shadow hover:bg-[var(--accent)]/30 transition"
               >
-                {t('back')}
+                {t("back")}
               </button>
 
-              {subStep === 'a' && selectedSuggestions.some((s) => s._delete) && (
-                <button
-                  onClick={handleBulkDelete}
-                  className="px-4 py-2 rounded-xl bg-red-600 text-white font-bold shadow hover:bg-red-700 transition"
-                >
-                  {t('delete_selected')}
-                </button>
-              )}
+              {subStep === "a" &&
+                selectedSuggestions.some((s) => s._delete) && (
+                  <button
+                    onClick={handleBulkDelete}
+                    className="px-4 py-2 rounded-xl bg-red-600 text-white font-bold shadow hover:bg-red-700 transition"
+                  >
+                    {t("delete_selected")}
+                  </button>
+                )}
 
-
-              {subStep !== 'c' ? (
+              {subStep !== "c" ? (
                 <button
                   onClick={advanceSubStep}
                   className="px-4 py-2 rounded-xl bg-[var(--primary)] text-white font-bold shadow hover:bg-[var(--accent)] transition"
                 >
-                  {t('continue_to_step')} {subStep === 'a' ? '2B' : '2C'}
+                  {t("continue_to_step")} {subStep === "a" ? "2B" : "2C"}
                 </button>
               ) : (
                 <button
@@ -394,10 +466,11 @@ export default function SuggestionsPage() {
                 >
                   {loading ? (
                     <>
-                      <Loader2 className="w-4 h-4 animate-spin" /> {t('processing')}
+                      <Loader2 className="w-4 h-4 animate-spin" />{" "}
+                      {t("processing")}
                     </>
                   ) : (
-                    t('inscribe_legends')
+                    t("inscribe_legends")
                   )}
                 </button>
               )}

--- a/frontend/src/app/lib/agentAPI.ts
+++ b/frontend/src/app/lib/agentAPI.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { API_URL } from "./config";
 
 export type SourceLink = { title: string; url: string };
@@ -10,7 +11,7 @@ export type ChatMessage = {
 
 export async function getAgents(
   token: string,
-  params: { world_id?: number } = {}
+  params: { world_id?: number } = {},
 ) {
   const query = new URLSearchParams();
   if (params.world_id !== undefined)
@@ -33,7 +34,10 @@ export async function getAgent(id: number, token: string) {
 export async function createAgent(data: unknown, token: string) {
   const res = await fetch(`${API_URL}/agents/`, {
     method: "POST",
-    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
     body: JSON.stringify(data),
   });
   if (!res.ok) throw await res.json();
@@ -43,7 +47,10 @@ export async function createAgent(data: unknown, token: string) {
 export async function updateAgent(id: number, data: unknown, token: string) {
   const res = await fetch(`${API_URL}/agents/${id}`, {
     method: "PATCH",
-    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
     body: JSON.stringify(data),
   });
   if (!res.ok) throw await res.json();
@@ -62,7 +69,7 @@ export async function deleteAgent(id: number, token: string) {
 export async function chatWithConversationalAgent(
   agentId: number,
   messages: ChatMessage[],
-  token: string
+  token: string,
 ) {
   const res = await fetch(`${API_URL}/agents/${agentId}/chat`, {
     method: "POST",
@@ -82,7 +89,7 @@ export async function chatWithConversationalAgent(
 export async function chatTest(
   agentId: number,
   messages: ChatMessage[],
-  token: string
+  token: string,
 ) {
   const res = await fetch(`${API_URL}/agents/${agentId}/chat_test`, {
     method: "POST",
@@ -101,9 +108,12 @@ export async function getChatHistory(
   token: string,
   limit = 20,
 ) {
-  const res = await fetch(`${API_URL}/agents/${agentId}/history?limit=${limit}`, {
-    headers: token ? { Authorization: `Bearer ${token}` } : {},
-  });
+  const res = await fetch(
+    `${API_URL}/agents/${agentId}/history?limit=${limit}`,
+    {
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    },
+  );
   if (!res.ok) throw await res.text();
   const data = await res.json();
   return data.messages || [];
@@ -121,12 +131,12 @@ export async function clearChatHistory(agentId: number, token: string) {
 export async function analyzePageWithAgent(
   agentId: number,
   pageId: number,
-  token: string
+  token: string,
 ) {
   const { job_id } = await startAnalyzeJob(agentId, [pageId], token);
   let attempts = 0;
   while (attempts < 30) {
-    await new Promise(r => setTimeout(r, 2000));
+    await new Promise((r) => setTimeout(r, 2000));
     const job = await getWriterJob(job_id, token);
     if (job.status === "done") {
       return { suggestions: job.suggestions || job.analysis || [] };
@@ -139,16 +149,22 @@ export async function generatePagesWithAgent(
   agentId: number,
   pageId: number,
   pages: unknown[],
-  token: string
+  token: string,
+  mergeGroups?: string[][],
 ) {
-  const res = await fetch(`${API_URL}/agents/${agentId}/pages/${pageId}/generate`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  const body: any = { pages };
+  if (mergeGroups) body.merge_groups = mergeGroups;
+  const res = await fetch(
+    `${API_URL}/agents/${agentId}/pages/${pageId}/generate`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify(body),
     },
-    body: JSON.stringify({ pages }),
-  });
+  );
   if (!res.ok) throw await res.text();
   return await res.json();
 }
@@ -156,7 +172,7 @@ export async function generatePagesWithAgent(
 export async function startAnalyzeJob(
   agentId: number,
   pageIds: number[],
-  token: string
+  token: string,
 ) {
   const res = await fetch(`${API_URL}/agents/${agentId}/analyze_job`, {
     method: "POST",
@@ -177,20 +193,23 @@ export async function startGenerateJob(
   token: string,
   suggestions?: any[],
   mergeGroups?: string[][],
-  requestId?: string
+  requestId?: string,
 ) {
   const body: any = { pages };
   if (suggestions) body.suggestions = suggestions;
   if (mergeGroups) body.merge_groups = mergeGroups;
   if (requestId) body.request_id = requestId;
-  const res = await fetch(`${API_URL}/agents/${agentId}/pages/${pageId}/generate_job`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  const res = await fetch(
+    `${API_URL}/agents/${agentId}/pages/${pageId}/generate_job`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify(body),
     },
-    body: JSON.stringify(body),
-  });
+  );
   if (!res.ok) throw await res.text();
   return await res.json();
 }
@@ -219,7 +238,7 @@ export async function startNovelJob(
     previous_page_id?: number | null;
     helper_agents?: number[];
   },
-  token: string
+  token: string,
 ) {
   const res = await fetch(`${API_URL}/agents/${agentId}/novel_job`, {
     method: "POST",
@@ -249,11 +268,7 @@ export async function listNovelistJobs(token: string) {
   return await res.json();
 }
 
-export async function updateWriterJob(
-  jobId: string,
-  data: any,
-  token: string
-) {
+export async function updateWriterJob(jobId: string, data: any, token: string) {
   const res = await fetch(`${API_URL}/agents/writer_jobs/${jobId}`, {
     method: "PATCH",
     headers: {
@@ -269,7 +284,7 @@ export async function updateWriterJob(
 export async function updateNovelistJob(
   jobId: string,
   data: any,
-  token: string
+  token: string,
 ) {
   const res = await fetch(`${API_URL}/agents/novelist_jobs/${jobId}`, {
     method: "PATCH",
@@ -282,4 +297,3 @@ export async function updateNovelistJob(
   if (!res.ok) throw await res.text();
   return await res.json();
 }
-


### PR DESCRIPTION
## Summary
- include merge group support in `generatePagesWithAgent`
- build page specs with update mode and target IDs
- send correct specs when starting generation jobs

## Testing
- `npx eslint src/app/lib/agentAPI.ts src/app/agent_writer/[agentID]/[pageID]/page.tsx src/app/agent_writer/[agentID]/suggestions/[jobID]/page.tsx`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897be2be8488322abca072e9d75d300