### PR TITLE
feat: show voter names in session polls

### DIFF
--- a/frontend/src/app/tables/[id]/sessions/page.tsx
+++ b/frontend/src/app/tables/[id]/sessions/page.tsx
@@ -526,32 +526,39 @@ export default function TableSessionsPage() {
                   <span className="font-bold text-xs">
                     {new Date(opt.proposed_time).toLocaleString()}
                   </span>
-                  <div className="flex -space-x-2 mt-1">
+                  <div className="flex flex-wrap gap-2 mt-1">
                     {opt.votes.map((uid: number) => {
                       const u = users.find((usr: any) => usr.id === uid);
                       return (
-                        <div key={uid} className="relative group">
-                          <img
-                            src={u?.image_url || "/images/avatars/default.png"}
-                            alt={u?.nickname || "?"}
-                            className="w-5 h-5 rounded-full border border-white bg-white shadow"
-                            title={u?.nickname}
-                          />
-                          <button
-                            className="absolute -top-1 -right-1 hidden group-hover:block bg-white rounded-full p-0.5"
-                            onClick={async () => {
-                              await removeSessionPollVote(
-                                tableId,
-                                s.id,
-                                uid,
-                                opt.id,
-                                token,
-                              );
-                              refreshPoll(s.id);
-                            }}
-                          >
-                            <X className="w-3 h-3 text-rose-500" />
-                          </button>
+                        <div key={uid} className="flex items-center gap-1">
+                          <div className="relative group">
+                            <img
+                              src={
+                                u?.image_url || "/images/avatars/default.png"
+                              }
+                              alt={u?.nickname || "?"}
+                              className="w-5 h-5 rounded-full border border-white bg-white shadow"
+                              title={u?.nickname}
+                            />
+                            <button
+                              className="absolute -top-1 -right-1 hidden group-hover:block bg-white rounded-full p-0.5"
+                              onClick={async () => {
+                                await removeSessionPollVote(
+                                  tableId,
+                                  s.id,
+                                  uid,
+                                  opt.id,
+                                  token,
+                                );
+                                refreshPoll(s.id);
+                              }}
+                            >
+                              <X className="w-3 h-3 text-rose-500" />
+                            </button>
+                          </div>
+                          <span className="text-xs text-yellow-700">
+                            {u?.nickname}
+                          </span>
                         </div>
                       );
                     })}

--- a/frontend/src/app/user_table/sessions/[id]/page.tsx
+++ b/frontend/src/app/user_table/sessions/[id]/page.tsx
@@ -129,17 +129,21 @@ export default function UserTableSessionsPage() {
               <span className="font-mono text-xs">
                 {new Date(opt.proposed_time).toLocaleString()}
               </span>
-              <div className="flex -space-x-2">
+              <div className="flex flex-wrap gap-2">
                 {opt.votes.map((uid) => {
                   const u = users.find((usr) => usr.id === uid);
                   return (
-                    <img
-                      key={uid}
-                      src={u?.image_url || "/images/avatars/default.png"}
-                      alt={u?.nickname || "?"}
-                      className="w-7 h-7 rounded-full border-2 border-white bg-white shadow"
-                      title={u?.nickname}
-                    />
+                    <div key={uid} className="flex items-center gap-1">
+                      <img
+                        src={u?.image_url || "/images/avatars/default.png"}
+                        alt={u?.nickname || "?"}
+                        className="w-7 h-7 rounded-full border-2 border-white bg-white shadow"
+                        title={u?.nickname}
+                      />
+                      <span className="text-xs text-yellow-700">
+                        {u?.nickname}
+                      </span>
+                    </div>
                   );
                 })}
               </div>


### PR DESCRIPTION
## Summary
- show voter names alongside avatars in user table session polls
- display names next to avatars on table session management poll

## Testing
- `npx prettier --write src/app/user_table/sessions/[id]/page.tsx src/app/tables/[id]/sessions/page.tsx`
- `npm run lint` *(fails: many existing lint errors)*
- `npm test` *(fails: missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897c621de148322bf86f7d9105791c8