### PR TITLE
Expose updated pages in writer job results

### DIFF
--- a/backend/app/task_queue.py
+++ b/backend/app/task_queue.py
@@ -519,7 +519,7 @@ def task_generate_pages_job(
                 session, agent, page, pages, merge_groups
             )
             result_pages = result.get("pages", [])
-            auto_updated = []
+            updated_pages = result.get("updated", [])
             embedding_jobs = result.get("embedding_jobs", [])
 
         end_time = datetime.now(timezone.utc).isoformat()
@@ -531,7 +531,7 @@ def task_generate_pages_job(
                     "page_id": page_id,
                     "job_type": "generate_pages",
                     "pages": result_pages,
-                    "auto_updated": auto_updated,
+                    "updated": updated_pages,
                     "embedding_jobs": embedding_jobs,
                     "start_time": start_time,
                     "end_time": end_time,
@@ -547,7 +547,7 @@ def task_generate_pages_job(
             json.dump(
                 {
                     "pages": result_pages,
-                    "auto_updated": auto_updated,
+                    "updated": updated_pages,
                     "embedding_jobs": embedding_jobs,
                 },
                 gf,

--- a/backend/tests/test_task_generate_pages_job.py
+++ b/backend/tests/test_task_generate_pages_job.py
@@ -1,0 +1,45 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from contextlib import asynccontextmanager
+
+import pytest
+
+from app import task_queue
+
+
+def test_task_generate_pages_job_writes_updated(tmp_path, monkeypatch):
+    monkeypatch.setattr(task_queue.settings, "writer_job_dir", str(tmp_path))
+
+    @asynccontextmanager
+    async def dummy_session():
+        yield None
+
+    async def dummy_get_agent(_session, _agent_id):
+        return SimpleNamespace(id=1, world_id=1)
+
+    async def dummy_get_page(_session, _page_id):
+        return SimpleNamespace(id=1, gameworld_id=1)
+
+    async def dummy_generate_pages(_s, _a, _p, _pages, _merge):
+        return {"pages": [{"id": 1}], "updated": [{"id": 2}]}
+
+    monkeypatch.setattr(task_queue, "async_session_maker", dummy_session)
+    monkeypatch.setattr(task_queue, "get_agent", dummy_get_agent)
+    monkeypatch.setattr(task_queue, "get_page", dummy_get_page)
+    monkeypatch.setattr(
+        task_queue.crud_agent_writer, "generate_pages", dummy_generate_pages
+    )
+
+    task_queue.task_generate_pages_job(1, 1, [], "job1")
+
+    job_dir = Path(tmp_path) / "job1"
+    with open(job_dir / "job.json") as f:
+        job_data = json.load(f)
+    with open(job_dir / "generated.json") as f:
+        gen_data = json.load(f)
+
+    assert job_data["pages"] == [{"id": 1}]
+    assert job_data["updated"] == [{"id": 2}]
+    assert gen_data["pages"] == [{"id": 1}]
+    assert gen_data["updated"] == [{"id": 2}]

--- a/frontend/src/app/agent_writer/[agentID]/review/[jobID]/page.tsx
+++ b/frontend/src/app/agent_writer/[agentID]/review/[jobID]/page.tsx
@@ -70,8 +70,7 @@ export default function ReviewPage() {
         setEmbeddingJobs(data.embedding_jobs || []);
         if (data.status === "done") {
           const newList = data.generated?.pages || data.pages || [];
-          const updList =
-            data.generated?.auto_updated || data.auto_updated || [];
+          const updList = data.generated?.updated || data.updated || [];
 
           const newFull = await Promise.all(
             newList.map(async (p: any) => {


### PR DESCRIPTION
## Summary
- include list of updated pages in writer job results
- display updated pages separately in review UI
- add test ensuring writer job saves created and updated page IDs

## Testing
- `npx prettier -w src/app/agent_writer/[agentID]/review/[jobID]/page.tsx`
- `npm run lint` *(fails: '@typescript-eslint/no-explicit-any' and other lint errors)*
- `npm test` *(fails: Missing script "test")*
- `pytest` *(fails: ModuleNotFoundError: No module named 'chromadb')*


------
https://chatgpt.com/codex/tasks/task_e_689882f9c454832287cdc9002234b9ac