### PR TITLE
feat: cascade page removal

### DIFF
--- a/backend/app/crud/crud_page.py
+++ b/backend/app/crud/crud_page.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
-from sqlalchemy import delete
+from sqlalchemy import delete, or_
 
 from app.models.model_page import (
     Page,
@@ -116,6 +116,22 @@ async def delete_page(session: AsyncSession, page_id: int) -> bool:
             value_list = [str(v) for v in pcv.value]
             if str(page_id) in value_list:
                 pcv.value = [v for v in value_list if v != str(page_id)]
+
+    # Remove page-specific data
+    await session.execute(
+        delete(PageCharacteristicValue).where(
+            PageCharacteristicValue.page_id == page_id
+        )
+    )
+    await session.execute(delete(PageKeyEvent).where(PageKeyEvent.page_id == page_id))
+    await session.execute(
+        delete(PageRelationship).where(
+            or_(
+                PageRelationship.page_id == page_id,
+                PageRelationship.target_page_id == page_id,
+            )
+        )
+    )
 
     await session.delete(page)
     await session.commit()

--- a/backend/tests/test_page.py
+++ b/backend/tests/test_page.py
@@ -1,26 +1,34 @@
 import pytest
+from sqlalchemy.future import select
+from sqlalchemy import or_
+from app.models.model_page import (
+    PageCharacteristicValue,
+    PageKeyEvent,
+    PageRelationship,
+)
 
 SYSTEM_ADMIN = {
     "nickname": "sysadmin",
     "email": "sysadmin3@example.com",
     "password": "secret123",
     "role": "system admin",
-    "image_url": "no image"
+    "image_url": "no image",
 }
 WRITER = {
     "nickname": "writer",
     "email": "writer3@example.com",
     "password": "secret123",
     "role": "writer",
-    "image_url": "no image"
+    "image_url": "no image",
 }
 PLAYER = {
     "nickname": "player",
     "email": "player3@example.com",
     "password": "secret123",
     "role": "player",
-    "image_url": "no image"
+    "image_url": "no image",
 }
+
 
 @pytest.mark.anyio
 async def register_and_login(async_client, user_data):
@@ -40,6 +48,7 @@ async def register_and_login(async_client, user_data):
     assert resp.status_code == 200, resp.text
     return resp.json()["access_token"]
 
+
 @pytest.mark.anyio
 async def test_page_create_update_delete_rbac(async_client):
     sysadmin_token = await register_and_login(async_client, SYSTEM_ADMIN)
@@ -47,57 +56,103 @@ async def test_page_create_update_delete_rbac(async_client):
     player_token = await register_and_login(async_client, PLAYER)
 
     # Create gameworld
-    gw_payload = {"name": "Forgotten Realms", "system":"dnd", "description":"Not much!", "logo":"Logo url"}
-    resp = await async_client.post("/gameworlds/", json=gw_payload, headers={"Authorization": f"Bearer {sysadmin_token}"})
+    gw_payload = {
+        "name": "Forgotten Realms",
+        "system": "dnd",
+        "description": "Not much!",
+        "logo": "Logo url",
+    }
+    resp = await async_client.post(
+        "/gameworlds/",
+        json=gw_payload,
+        headers={"Authorization": f"Bearer {sysadmin_token}"},
+    )
     assert resp.status_code == 200
     gw_id = resp.json()["id"]
 
     # Create concept
     concept_payload = {"gameworld_id": gw_id, "name": "Clan", "description": "Clan"}
-    resp = await async_client.post("/concepts/", json=concept_payload, headers={"Authorization": f"Bearer {sysadmin_token}"})
+    resp = await async_client.post(
+        "/concepts/",
+        json=concept_payload,
+        headers={"Authorization": f"Bearer {sysadmin_token}"},
+    )
     assert resp.status_code == 200
     concept_id = resp.json()["id"]
 
     # Create page (writer can create)
-    page_payload = {"gameworld_id": gw_id, "concept_id": concept_id, "name": "Ventrue", "content": "Blue Bloods"}
-    resp = await async_client.post("/pages/", json=page_payload, headers={"Authorization": f"Bearer {writer_token}"})
+    page_payload = {
+        "gameworld_id": gw_id,
+        "concept_id": concept_id,
+        "name": "Ventrue",
+        "content": "Blue Bloods",
+    }
+    resp = await async_client.post(
+        "/pages/",
+        json=page_payload,
+        headers={"Authorization": f"Bearer {writer_token}"},
+    )
     assert resp.status_code == 200
     page_id = resp.json()["id"]
 
     # Created page should have changelog entry
-    resp = await async_client.get(f"/pages/{page_id}", headers={"Authorization": f"Bearer {player_token}"})
+    resp = await async_client.get(
+        f"/pages/{page_id}", headers={"Authorization": f"Bearer {player_token}"}
+    )
     assert resp.status_code == 200
     assert resp.json()["changelog"][0]["change_type"] == "created"
 
     # Player cannot create
-    resp = await async_client.post("/pages/", json=page_payload, headers={"Authorization": f"Bearer {player_token}"})
+    resp = await async_client.post(
+        "/pages/",
+        json=page_payload,
+        headers={"Authorization": f"Bearer {player_token}"},
+    )
     assert resp.status_code == 403
 
     # Get page (anyone)
-    resp = await async_client.get(f"/pages/{page_id}", headers={"Authorization": f"Bearer {player_token}"})
+    resp = await async_client.get(
+        f"/pages/{page_id}", headers={"Authorization": f"Bearer {player_token}"}
+    )
     assert resp.status_code == 200
     assert resp.json()["name"] == "Ventrue"
 
     # Update page (writer can update)
     update = {"content": "Blue Bloods Updated"}
-    resp = await async_client.patch(f"/pages/{page_id}", json=update, headers={"Authorization": f"Bearer {writer_token}"})
+    resp = await async_client.patch(
+        f"/pages/{page_id}",
+        json=update,
+        headers={"Authorization": f"Bearer {writer_token}"},
+    )
     assert resp.status_code == 200
     assert resp.json()["content"] == "Blue Bloods Updated"
     assert resp.json()["changelog"][-1]["change_type"] == "updated"
 
-     # If allowed_user_ids is set, players can edit if they're in the list, writers can always edit
+    # If allowed_user_ids is set, players can edit if they're in the list, writers can always edit
 
     update2 = {"allowed_user_ids": [999]}
-    resp = await async_client.patch(f"/pages/{page_id}", json=update2, headers={"Authorization": f"Bearer {writer_token}"})
+    resp = await async_client.patch(
+        f"/pages/{page_id}",
+        json=update2,
+        headers={"Authorization": f"Bearer {writer_token}"},
+    )
     assert resp.status_code == 200
 
     # Writer can still edit
-    resp = await async_client.patch(f"/pages/{page_id}", json=update, headers={"Authorization": f"Bearer {writer_token}"})
+    resp = await async_client.patch(
+        f"/pages/{page_id}",
+        json=update,
+        headers={"Authorization": f"Bearer {writer_token}"},
+    )
     assert resp.status_code == 200
     assert resp.json()["content"] == "Blue Bloods Updated"
 
     # Player NOT in allowed_user_ids cannot edit
-    resp = await async_client.patch(f"/pages/{page_id}", json=update, headers={"Authorization": f"Bearer {player_token}"})
+    resp = await async_client.patch(
+        f"/pages/{page_id}",
+        json=update,
+        headers={"Authorization": f"Bearer {player_token}"},
+    )
     assert resp.status_code == 403
 
     # Simulate user 999 as a player
@@ -106,26 +161,37 @@ async def test_page_create_update_delete_rbac(async_client):
         "email": "user999@example.com",
         "password": "secret123",
         "role": "player",
-        "image_url": "no image"
+        "image_url": "no image",
     }
-    user999_token = await register_and_login(async_client, user999)    
+    user999_token = await register_and_login(async_client, user999)
 
-
-    resp = await async_client.patch(f"/pages/{page_id}", json=update, headers={"Authorization": f"Bearer {user999_token}"})
+    resp = await async_client.patch(
+        f"/pages/{page_id}",
+        json=update,
+        headers={"Authorization": f"Bearer {user999_token}"},
+    )
     assert resp.status_code == 403
 
     # But the allowed user can (simulate login as user id 999)
     # (Here, you'd register a user with id 999 and test!)
 
     # Delete page (writer can delete)
-    resp = await async_client.delete(f"/pages/{page_id}", headers={"Authorization": f"Bearer {writer_token}"})
+    resp = await async_client.delete(
+        f"/pages/{page_id}", headers={"Authorization": f"Bearer {writer_token}"}
+    )
     assert resp.status_code == 200
     assert resp.json()["ok"] is True
 
     # Player cannot delete
-    resp = await async_client.post("/pages/", json=page_payload, headers={"Authorization": f"Bearer {writer_token}"})
+    resp = await async_client.post(
+        "/pages/",
+        json=page_payload,
+        headers={"Authorization": f"Bearer {writer_token}"},
+    )
     page_id2 = resp.json()["id"]
-    resp = await async_client.delete(f"/pages/{page_id2}", headers={"Authorization": f"Bearer {player_token}"})
+    resp = await async_client.delete(
+        f"/pages/{page_id2}", headers={"Authorization": f"Bearer {player_token}"}
+    )
     assert resp.status_code == 403
 
 
@@ -135,13 +201,26 @@ async def test_safe_delete_removes_page_refs(async_client):
     writer_token = await register_and_login(async_client, WRITER)
 
     # Create world and concept
-    gw_payload = {"name": "SafeWorld", "system": "sys", "description": "d", "logo": "logo"}
-    resp = await async_client.post("/gameworlds/", json=gw_payload, headers={"Authorization": f"Bearer {sysadmin_token}"})
+    gw_payload = {
+        "name": "SafeWorld",
+        "system": "sys",
+        "description": "d",
+        "logo": "logo",
+    }
+    resp = await async_client.post(
+        "/gameworlds/",
+        json=gw_payload,
+        headers={"Authorization": f"Bearer {sysadmin_token}"},
+    )
     assert resp.status_code == 200
     gw_id = resp.json()["id"]
 
     concept_payload = {"gameworld_id": gw_id, "name": "Clan", "description": "c"}
-    resp = await async_client.post("/concepts/", json=concept_payload, headers={"Authorization": f"Bearer {sysadmin_token}"})
+    resp = await async_client.post(
+        "/concepts/",
+        json=concept_payload,
+        headers={"Authorization": f"Bearer {sysadmin_token}"},
+    )
     assert resp.status_code == 200
     concept_id = resp.json()["id"]
 
@@ -153,7 +232,11 @@ async def test_safe_delete_removes_page_refs(async_client):
         "ref_concept_id": concept_id,
         "is_list": True,
     }
-    resp = await async_client.post("/characteristics/", json=char_payload, headers={"Authorization": f"Bearer {sysadmin_token}"})
+    resp = await async_client.post(
+        "/characteristics/",
+        json=char_payload,
+        headers={"Authorization": f"Bearer {sysadmin_token}"},
+    )
     assert resp.status_code == 200
     char_id = resp.json()["id"]
 
@@ -166,7 +249,9 @@ async def test_safe_delete_removes_page_refs(async_client):
 
     # Create two pages
     page1 = {"gameworld_id": gw_id, "concept_id": concept_id, "name": "P1"}
-    resp = await async_client.post("/pages/", json=page1, headers={"Authorization": f"Bearer {writer_token}"})
+    resp = await async_client.post(
+        "/pages/", json=page1, headers={"Authorization": f"Bearer {writer_token}"}
+    )
     assert resp.status_code == 200
     p1_id = resp.json()["id"]
 
@@ -176,45 +261,195 @@ async def test_safe_delete_removes_page_refs(async_client):
         "name": "P2",
         "values": [{"characteristic_id": char_id, "value": [str(p1_id)]}],
     }
-    resp = await async_client.post("/pages/", json=page2, headers={"Authorization": f"Bearer {writer_token}"})
+    resp = await async_client.post(
+        "/pages/", json=page2, headers={"Authorization": f"Bearer {writer_token}"}
+    )
     assert resp.status_code == 200
     p2_id = resp.json()["id"]
 
     # Ensure reference is stored
-    resp = await async_client.get(f"/pages/{p2_id}", headers={"Authorization": f"Bearer {writer_token}"})
+    resp = await async_client.get(
+        f"/pages/{p2_id}", headers={"Authorization": f"Bearer {writer_token}"}
+    )
     assert resp.status_code == 200
     vals = resp.json()["values"]
     assert vals and str(p1_id) in vals[0]["value"]
 
     # Delete first page
-    resp = await async_client.delete(f"/pages/{p1_id}", headers={"Authorization": f"Bearer {writer_token}"})
+    resp = await async_client.delete(
+        f"/pages/{p1_id}", headers={"Authorization": f"Bearer {writer_token}"}
+    )
     assert resp.status_code == 200
 
     # Fetch second page again - reference should be removed
-    resp = await async_client.get(f"/pages/{p2_id}", headers={"Authorization": f"Bearer {writer_token}"})
+    resp = await async_client.get(
+        f"/pages/{p2_id}", headers={"Authorization": f"Bearer {writer_token}"}
+    )
     assert resp.status_code == 200
     vals = resp.json()["values"]
     assert not vals or str(p1_id) not in (vals[0]["value"] or [])
 
 
 @pytest.mark.anyio
-async def test_page_search_endpoint(async_client):
-    token = await register_and_login(async_client, SYSTEM_ADMIN)
+async def test_delete_page_removes_related_data(async_client, session):
+    sysadmin_token = await register_and_login(async_client, SYSTEM_ADMIN)
+    writer_token = await register_and_login(async_client, WRITER)
 
-    gw_payload = {"name": "SearchWorld", "system": "sys", "description": "d", "logo": "logo"}
-    resp = await async_client.post("/gameworlds/", json=gw_payload, headers={"Authorization": f"Bearer {token}"})
+    gw_payload = {
+        "name": "CleanWorld",
+        "system": "sys",
+        "description": "d",
+        "logo": "logo",
+    }
+    resp = await async_client.post(
+        "/gameworlds/",
+        json=gw_payload,
+        headers={"Authorization": f"Bearer {sysadmin_token}"},
+    )
+    assert resp.status_code == 200
     gw_id = resp.json()["id"]
 
     concept_payload = {"gameworld_id": gw_id, "name": "Clan", "description": "c"}
-    resp = await async_client.post("/concepts/", json=concept_payload, headers={"Authorization": f"Bearer {token}"})
+    resp = await async_client.post(
+        "/concepts/",
+        json=concept_payload,
+        headers={"Authorization": f"Bearer {sysadmin_token}"},
+    )
+    assert resp.status_code == 200
+    concept_id = resp.json()["id"]
+
+    char_payload = {
+        "gameworld_id": gw_id,
+        "name": "desc",
+        "type": "string",
+        "is_list": True,
+    }
+    resp = await async_client.post(
+        "/characteristics/",
+        json=char_payload,
+        headers={"Authorization": f"Bearer {sysadmin_token}"},
+    )
+    assert resp.status_code == 200
+    char_id = resp.json()["id"]
+
+    resp = await async_client.post(
+        "/characteristics/link/",
+        params={"concept_id": concept_id, "characteristic_id": char_id, "order": 0},
+        headers={"Authorization": f"Bearer {sysadmin_token}"},
+    )
+    assert resp.status_code == 200
+
+    page1 = {
+        "gameworld_id": gw_id,
+        "concept_id": concept_id,
+        "name": "P1",
+        "values": [{"characteristic_id": char_id, "value": ["v"]}],
+    }
+    resp = await async_client.post(
+        "/pages/", json=page1, headers={"Authorization": f"Bearer {writer_token}"}
+    )
+    assert resp.status_code == 200
+    p1_id = resp.json()["id"]
+
+    page2 = {"gameworld_id": gw_id, "concept_id": concept_id, "name": "P2"}
+    resp = await async_client.post(
+        "/pages/", json=page2, headers={"Authorization": f"Bearer {writer_token}"}
+    )
+    assert resp.status_code == 200
+    p2_id = resp.json()["id"]
+
+    event_payload = {
+        "page_id": p1_id,
+        "event_type": "founding",
+        "author_type": "user",
+        "author_id": 1,
+    }
+    resp = await async_client.post(
+        f"/pages/{p1_id}/events/",
+        json=event_payload,
+        headers={"Authorization": f"Bearer {writer_token}"},
+    )
+    assert resp.status_code == 200
+
+    rel_payload = {
+        "page_id": p1_id,
+        "target_page_id": p2_id,
+        "relationship_type": "ally",
+        "author_type": "user",
+        "author_id": 1,
+    }
+    resp = await async_client.post(
+        f"/pages/{p1_id}/relationships/",
+        json=rel_payload,
+        headers={"Authorization": f"Bearer {writer_token}"},
+    )
+    assert resp.status_code == 200
+
+    resp = await async_client.delete(
+        f"/pages/{p1_id}", headers={"Authorization": f"Bearer {writer_token}"}
+    )
+    assert resp.status_code == 200
+
+    result = await session.execute(
+        select(PageCharacteristicValue).where(PageCharacteristicValue.page_id == p1_id)
+    )
+    assert result.scalars().all() == []
+
+    result = await session.execute(
+        select(PageKeyEvent).where(PageKeyEvent.page_id == p1_id)
+    )
+    assert result.scalars().all() == []
+
+    result = await session.execute(
+        select(PageRelationship).where(
+            or_(
+                PageRelationship.page_id == p1_id,
+                PageRelationship.target_page_id == p1_id,
+            )
+        )
+    )
+    assert result.scalars().all() == []
+
+    resp = await async_client.get(
+        f"/pages/{p2_id}", headers={"Authorization": f"Bearer {writer_token}"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["relationship_map"] == []
+
+
+@pytest.mark.anyio
+async def test_page_search_endpoint(async_client):
+    token = await register_and_login(async_client, SYSTEM_ADMIN)
+
+    gw_payload = {
+        "name": "SearchWorld",
+        "system": "sys",
+        "description": "d",
+        "logo": "logo",
+    }
+    resp = await async_client.post(
+        "/gameworlds/", json=gw_payload, headers={"Authorization": f"Bearer {token}"}
+    )
+    gw_id = resp.json()["id"]
+
+    concept_payload = {"gameworld_id": gw_id, "name": "Clan", "description": "c"}
+    resp = await async_client.post(
+        "/concepts/", json=concept_payload, headers={"Authorization": f"Bearer {token}"}
+    )
     concept_id = resp.json()["id"]
 
     for name in ["Alpha", "Beta"]:
         page_payload = {"gameworld_id": gw_id, "concept_id": concept_id, "name": name}
-        resp = await async_client.post("/pages/", json=page_payload, headers={"Authorization": f"Bearer {token}"})
+        resp = await async_client.post(
+            "/pages/", json=page_payload, headers={"Authorization": f"Bearer {token}"}
+        )
         assert resp.status_code == 200
 
-    resp = await async_client.get("/pages/search", params={"query": "Al"}, headers={"Authorization": f"Bearer {token}"})
+    resp = await async_client.get(
+        "/pages/search",
+        params={"query": "Al"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
     assert resp.status_code == 200
     results = resp.json()
     assert any(p["name"] == "Alpha" for p in results)


### PR DESCRIPTION
## Summary
- remove associated page characteristic values, key events, and relationships when deleting a page
- test page deletion cleans up related data

## Testing
- `pytest` *(fails: AssertionError Not Found, KeyError id, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6898826f875c832297904c20767318ee