### PR TITLE
fix: avoid duplicate cross-page relationships

### DIFF
--- a/backend/app/crud/crud_page.py
+++ b/backend/app/crud/crud_page.py
@@ -263,11 +263,11 @@ async def create_relationship(
 ) -> PageRelationship:
     """Create a relationship and its inverse if needed.
 
-    This function guards against duplicate relationships being created by first
-    checking if the relationship already exists. When adding the inverse
-    relationship, it selects at most one existing record to avoid
-    ``MultipleResultsFound`` errors if duplicates are already present in the
-    database.
+    This function guards against duplicate relationships by first checking if
+    the relationship already exists. When adding the inverse relationship, it
+    ensures that no other relationship of the same type exists between the two
+    pages, regardless of direction, to avoid ``MultipleResultsFound`` errors if
+    duplicates are already present in the database.
     """
 
     # Check for an existing relationship to avoid duplicates
@@ -297,13 +297,12 @@ async def create_relationship(
             PageRelationship.page_id == rel.target_page_id,
             PageRelationship.target_page_id == rel.page_id,
             PageRelationship.relationship_type == rel.relationship_type,
-            PageRelationship.direction == inverse_dir,
             PageRelationship.source_page_id == rel.source_page_id,
         )
         .limit(1)
     )
-    existing_inverse = result.scalar_one_or_none()
-    if not existing_inverse:
+    existing_between = result.scalar_one_or_none()
+    if not existing_between:
         inverse = PageRelationship(
             page_id=rel.target_page_id,
             target_page_id=rel.page_id,

--- a/backend/tests/test_page_relationship.py
+++ b/backend/tests/test_page_relationship.py
@@ -213,3 +213,92 @@ async def test_add_relationship_handles_existing_inverse_duplicates(
         and r["direction"] == "outgoing"
     )
     assert count == 1
+
+
+@pytest.mark.anyio
+async def test_add_relationship_skips_if_target_has_any(async_client, session):
+    sys_token = await register_and_login(async_client, SYSTEM_ADMIN)
+    writer_token = await register_and_login(async_client, WRITER)
+
+    gw = {"name": "RelWorld4", "system": "sys", "description": "d", "logo": "l"}
+    resp = await async_client.post(
+        "/gameworlds/",
+        json=gw,
+        headers={"Authorization": f"Bearer {sys_token}"},
+    )
+    assert resp.status_code == 200
+    gw_id = resp.json()["id"]
+
+    concept = {"gameworld_id": gw_id, "name": "Clan", "description": "c"}
+    resp = await async_client.post(
+        "/concepts/",
+        json=concept,
+        headers={"Authorization": f"Bearer {sys_token}"},
+    )
+    assert resp.status_code == 200
+    concept_id = resp.json()["id"]
+
+    p1 = {"gameworld_id": gw_id, "concept_id": concept_id, "name": "A"}
+    resp = await async_client.post(
+        "/pages/",
+        json=p1,
+        headers={"Authorization": f"Bearer {writer_token}"},
+    )
+    assert resp.status_code == 200
+    p1_id = resp.json()["id"]
+
+    p2 = {"gameworld_id": gw_id, "concept_id": concept_id, "name": "B"}
+    resp = await async_client.post(
+        "/pages/",
+        json=p2,
+        headers={"Authorization": f"Bearer {writer_token}"},
+    )
+    assert resp.status_code == 200
+    p2_id = resp.json()["id"]
+
+    existing = PageRelationship(
+        page_id=p2_id,
+        target_page_id=p1_id,
+        relationship_type="friend",
+        direction="outgoing",
+        author_type="user",
+        author_id=1,
+    )
+    session.add(existing)
+    await session.commit()
+
+    rel_payload = {
+        "page_id": p1_id,
+        "target_page_id": p2_id,
+        "relationship_type": "friend",
+        "author_type": "user",
+        "author_id": 1,
+    }
+    resp = await async_client.post(
+        f"/pages/{p1_id}/relationships/",
+        json=rel_payload,
+        headers={"Authorization": f"Bearer {writer_token}"},
+    )
+    assert resp.status_code == 200
+
+    resp = await async_client.get(
+        f"/pages/{p2_id}",
+        headers={"Authorization": f"Bearer {writer_token}"},
+    )
+    rels = resp.json()["relationship_map"]
+    outgoing = sum(
+        1
+        for r in rels
+        if r["page_id"] == p2_id
+        and r["target_page_id"] == p1_id
+        and r["direction"] == "outgoing"
+    )
+    incoming = sum(
+        1
+        for r in rels
+        if r["page_id"] == p2_id
+        and r["target_page_id"] == p1_id
+        and r["direction"] == "incoming"
+    )
+    assert outgoing == 1
+    assert incoming == 0


### PR DESCRIPTION
## Summary
- prevent creation of inverse relationship when one already exists between pages in either direction
- add regression test ensuring existing target relationship blocks duplicate inverse creation

## Testing
- `pytest` *(fails: ImportError: cannot import name 'Graph' from 'langgraph.graph')*

------
https://chatgpt.com/codex/tasks/task_e_68988c575dcc8322888d994dd59a4ac7