### PR TITLE
fix(frontend): disable Next.js image optimization

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -10,18 +10,16 @@ const nextConfig: NextConfig = {
     // Disable eslint errors failing the build (for dev ONLY)
     ignoreDuringBuilds: true,
   },
-  // images: {
-  //   /**
-  //    * Uploaded assets are stored on a shared volume. When running inside
-  //    * Docker the Next.js image optimizer fails to access these files and
-  //    * returns a 400 error. Disabling optimisation avoids the extra API layer
-  //    * and serves files directly from the `public` folder which works with the
-  //    * shared volume.
-  //    */
-  //   unoptimized: true,
-  // },
+  images: {
+    /**
+     * Uploaded assets are stored on a shared volume. When running inside
+     * Docker the Next.js image optimizer fails to access these files and
+     * returns a 400 error. Disabling optimisation avoids the extra API layer
+     * and serves files directly from the `public` folder which works with the
+     * shared volume.
+     */
+    unoptimized: true,
+  },
 };
 
 export default nextConfig;
-
-


### PR DESCRIPTION
## Summary
- disable Next.js image optimizer to serve uploaded assets directly from shared volume

## Testing
- `npm run lint` *(fails: Unexpected any, no-unused-vars, etc.)*
- `npm test` *(fails: Missing script "test")*
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_689897c9339083229ec85d8ea87d6905