### PR TITLE
fix: include page type in uploaded image URL

### DIFF
--- a/frontend/src/pages/api/uploadImage.ts
+++ b/frontend/src/pages/api/uploadImage.ts
@@ -83,8 +83,14 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     // -------------------------------------------------
 
     const urlBase = isTable ? "/uploads/tables" : "/uploads/images";
+
+    // Build the URL path mirroring where the file was stored on disk
+    const urlPath = isTable
+      ? path.join(urlBase, pageName, fileName)
+      : path.join(urlBase, pageType, pageName, fileName);
+
     res.status(200).json({
-      url: path.join(urlBase, pageName, fileName).replace(/\\+/g, "/"),
+      url: urlPath.replace(/\\+/g, "/"),
     });
   });
 }


### PR DESCRIPTION
## Summary
- return URLs that mirror the filesystem path when uploading images, ensuring page and table logos store the correct path

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68989b05433c8322a82ca7404d806d95