### PR TITLE
feat(frontend): add direction tabs to relationship table

### DIFF
--- a/frontend/src/app/components/see_page/RelationshipTable.tsx
+++ b/frontend/src/app/components/see_page/RelationshipTable.tsx
@@ -1,5 +1,6 @@
 "use client";
 import Link from "next/link";
+import { useState } from "react";
 
 interface Relationship {
   id: number;
@@ -31,41 +32,92 @@ export default function RelationshipTable({
   onDelete?: (id: number) => void;
 }) {
   const getPage = (id: number) => pages.find((p) => p.id === id);
+  const [activeTab, setActiveTab] = useState<"outgoing" | "incoming">(
+    "outgoing",
+  );
+  const filtered = relationships.filter((r) => r.direction === activeTab);
+
   return (
-    <table className="w-full text-sm mt-4 border">
-      <thead className="bg-[var(--surface)]">
-        <tr>
-          <th className="px-2 py-1 text-left">Target</th>
-          <th className="px-2 py-1 text-left">Type</th>
-          <th className="px-2 py-1 text-left">Description</th>
-          <th className="px-2 py-1 text-left">Source</th>
-          {onEdit && <th></th>}
-        </tr>
-      </thead>
-      <tbody>
-        {relationships.map((rel) => {
-          const target = getPage(rel.target_page_id);
-          const source = rel.source_page_id ? getPage(rel.source_page_id) : null;
-          return (
-            <tr key={rel.id} className="even:bg-[var(--surface)]/50">
-              <td className="px-2 py-1">
-                {target ? <Link href={`/pages/${target.id}`}>{target.name}</Link> : rel.target_page_id}
-              </td>
-              <td className="px-2 py-1">{rel.relationship_type}</td>
-              <td className="px-2 py-1">{rel.description}</td>
-              <td className="px-2 py-1">
-                {source ? <Link href={`/pages/${source.id}`}>{source.name}</Link> : "-"}
-              </td>
-              {onEdit && (
-                <td className="px-2 py-1 space-x-1">
-                  <button onClick={() => onEdit(rel)} className="text-xs text-blue-500">Edit</button>
-                  <button onClick={() => onDelete?.(rel.id)} className="text-xs text-red-500">Delete</button>
+    <div className="mt-4">
+      <div className="flex space-x-2 border-b">
+        <button
+          className={`px-2 py-1 ${
+            activeTab === "outgoing" ? "border-b-2 border-[var(--primary)]" : ""
+          }`}
+          onClick={() => setActiveTab("outgoing")}
+        >
+          From this page
+        </button>
+        <button
+          className={`px-2 py-1 ${
+            activeTab === "incoming" ? "border-b-2 border-[var(--primary)]" : ""
+          }`}
+          onClick={() => setActiveTab("incoming")}
+        >
+          To this page
+        </button>
+      </div>
+      <table className="w-full text-sm border">
+        <thead className="bg-[var(--surface)]">
+          <tr>
+            <th className="px-2 py-1 text-left">
+              {activeTab === "incoming" ? "Source" : "Target"}
+            </th>
+            <th className="px-2 py-1 text-left">Type</th>
+            <th className="px-2 py-1 text-left">Description</th>
+            {activeTab === "outgoing" && (
+              <th className="px-2 py-1 text-left">Source</th>
+            )}
+            {onEdit && <th></th>}
+          </tr>
+        </thead>
+        <tbody>
+          {filtered.map((rel) => {
+            const target = getPage(rel.target_page_id);
+            const source = rel.source_page_id
+              ? getPage(rel.source_page_id)
+              : null;
+            return (
+              <tr key={rel.id} className="even:bg-[var(--surface)]/50">
+                <td className="px-2 py-1">
+                  {target ? (
+                    <Link href={`/pages/${target.id}`}>{target.name}</Link>
+                  ) : (
+                    rel.target_page_id
+                  )}
                 </td>
-              )}
-            </tr>
-          );
-        })}
-      </tbody>
-    </table>
+                <td className="px-2 py-1">{rel.relationship_type}</td>
+                <td className="px-2 py-1">{rel.description}</td>
+                {activeTab === "outgoing" && (
+                  <td className="px-2 py-1">
+                    {source ? (
+                      <Link href={`/pages/${source.id}`}>{source.name}</Link>
+                    ) : (
+                      "-"
+                    )}
+                  </td>
+                )}
+                {onEdit && (
+                  <td className="px-2 py-1 space-x-1">
+                    <button
+                      onClick={() => onEdit(rel)}
+                      className="text-xs text-blue-500"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      onClick={() => onDelete?.(rel.id)}
+                      className="text-xs text-red-500"
+                    >
+                      Delete
+                    </button>
+                  </td>
+                )}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- add directional tabs to filter relationships from or to the current page

## Testing
- `npm run lint` *(fails: Unexpected any and other existing errors)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898e8f000a48322ae43eba1ed430509