### PR TITLE
fix: record total embedded page count after page generation

### DIFF
--- a/backend/app/crud/crud_agent_writer.py
+++ b/backend/app/crud/crud_agent_writer.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Optional
 
 from langchain_openai import ChatOpenAI
 from langchain_core.prompts import ChatPromptTemplate
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
@@ -423,12 +424,16 @@ async def generate_pages_worker(
             await asyncio.gather(
                 *(crud_vectordb.add_page(session, pid, emb.id) for pid in affected_ids)
             )
+            result = await session.execute(
+                select(func.count(Page.id)).where(Page.gameworld_id == emb.world_id)
+            )
+            total_pages = result.scalar_one()
             await crud_world_embedding.update_embedding(
                 session,
                 emb.id,
                 {
                     "last_index_time": datetime.now(timezone.utc),
-                    "page_count": len(affected_ids),
+                    "page_count": total_pages,
                 },
             )
 

--- a/backend/tests/test_generate_pages_embedding.py
+++ b/backend/tests/test_generate_pages_embedding.py
@@ -120,5 +120,7 @@ async def test_generate_pages_triggers_embedding(
         assert add_page.await_count > 0
         assert delete_page.called
         assert update_emb.await_count > 0
+        args, _ = update_emb.await_args
+        assert args[2]["page_count"] == 2
     job_files = list(Path(settings.world_embedding_job_dir).glob("*.json"))
     assert len(job_files) == 0


### PR DESCRIPTION
## Summary
- ensure world embedding stores total page count after pages are (re)indexed
- test embedding update now checks total page count value

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'langchain_text_splitters')*


------
https://chatgpt.com/codex/tasks/task_e_689b0510a2b883229701dd3bdd6a0b7b