### PR TITLE
feat: handle session poll timezones

### DIFF
--- a/backend/alembic/versions/20241001_01_add_poll_option_timezone.py
+++ b/backend/alembic/versions/20241001_01_add_poll_option_timezone.py
@@ -1,0 +1,27 @@
+"""Add timezone to session poll option
+
+Revision ID: 20241001_01
+Revises: 20240930_01
+Create Date: 2024-10-01
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20241001_01"
+down_revision = "20240930_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "sessionpolloption",
+        sa.Column("timezone", sa.String(), nullable=False, server_default="UTC"),
+    )
+    op.alter_column("sessionpolloption", "timezone", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column("sessionpolloption", "timezone")

--- a/backend/app/crud/crud_session_poll.py
+++ b/backend/app/crud/crud_session_poll.py
@@ -27,7 +27,11 @@ async def create_poll(
     await session.refresh(poll)
 
     for dt in poll_in.proposed_times:
-        session.add(SessionPollOption(poll_id=poll.id, proposed_time=dt))
+        session.add(
+            SessionPollOption(
+                poll_id=poll.id, proposed_time=dt, timezone=poll_in.timezone
+            )
+        )
     await session.commit()
     await session.refresh(poll)
     sess = await session.get(Session, session_id)
@@ -95,6 +99,7 @@ async def finalize_poll(
     sess = await session.get(Session, poll.session_id)
     if option and sess:
         sess.scheduled_time = option.proposed_time
+        sess.timezone = option.timezone
     await session.commit()
     await session.refresh(poll)
     return poll
@@ -115,7 +120,10 @@ async def poll_to_read(session: AsyncSession, poll: SessionPoll) -> SessionPollR
         votes = list(vote_result.scalars().all())
         options_read.append(
             SessionPollOptionRead(
-                id=option.id, proposed_time=option.proposed_time, votes=votes
+                id=option.id,
+                proposed_time=option.proposed_time,
+                timezone=option.timezone,
+                votes=votes,
             )
         )
     return SessionPollRead(

--- a/backend/app/models/model_session.py
+++ b/backend/app/models/model_session.py
@@ -63,6 +63,7 @@ class SessionPollOption(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     poll_id: int = Field(foreign_key="sessionpoll.id")
     proposed_time: datetime
+    timezone: str = Field(default="UTC")
 
     poll: "SessionPoll" = Relationship(
         back_populates="options",

--- a/backend/app/schemas/schema_session_poll.py
+++ b/backend/app/schemas/schema_session_poll.py
@@ -5,6 +5,7 @@ from sqlmodel import SQLModel
 
 class SessionPollCreate(SQLModel):
     proposed_times: List[datetime]
+    timezone: str
 
 
 class SessionPollVoteCreate(SQLModel):
@@ -18,6 +19,7 @@ class SessionPollSelect(SQLModel):
 class SessionPollOptionRead(SQLModel):
     id: int
     proposed_time: datetime
+    timezone: str
     votes: List[int] = []
 
 

--- a/backend/tests/test_session_poll.py
+++ b/backend/tests/test_session_poll.py
@@ -56,7 +56,7 @@ async def test_session_poll_sets_session_date(async_client):
     ]
     resp = await async_client.post(
         f"/tables/{table_id}/sessions/{session_id}/poll",
-        json={"proposed_times": times},
+        json={"proposed_times": times, "timezone": "UTC"},
         headers=headers,
     )
     assert resp.status_code == 200, resp.text
@@ -75,6 +75,7 @@ async def test_session_poll_sets_session_date(async_client):
     sessions = resp.json()
     session_info = next(s for s in sessions if s["id"] == session_id)
     assert session_info["scheduled_time"] == times[0]
+    assert session_info["timezone"] == "UTC"
 
 
 @pytest.mark.anyio
@@ -128,7 +129,7 @@ async def test_session_poll_multi_vote(async_client):
     ]
     resp = await async_client.post(
         f"/tables/{table_id}/sessions/{session_id}/poll",
-        json={"proposed_times": times},
+        json={"proposed_times": times, "timezone": "UTC"},
         headers=headers,
     )
     poll = resp.json()
@@ -219,7 +220,7 @@ async def test_remove_vote(async_client):
     times = [datetime.now(timezone.utc).isoformat()]
     resp = await async_client.post(
         f"/tables/{table_id}/sessions/{session_id}/poll",
-        json={"proposed_times": times},
+        json={"proposed_times": times, "timezone": "UTC"},
         headers=gm_headers,
     )
     option_id = resp.json()["options"][0]["id"]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -42,6 +42,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "date-fns-tz": "^3.1.3",
         "formidable": "^3.5.4",
         "framer-motion": "^12.15.0",
         "html-react-parser": "^5.2.5",
@@ -5666,6 +5667,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+      "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "date-fns": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/debug": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,6 +43,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "date-fns-tz": "^3.1.3",
     "formidable": "^3.5.4",
     "framer-motion": "^12.15.0",
     "html-react-parser": "^5.2.5",

--- a/frontend/src/app/lib/sessionAPI.ts
+++ b/frontend/src/app/lib/sessionAPI.ts
@@ -51,6 +51,7 @@ export async function createSessionPoll(
   tableId: number,
   sessionId: number,
   proposedTimes: string[],
+  timezone: string,
   token: string,
 ) {
   const res = await fetch(
@@ -61,7 +62,7 @@ export async function createSessionPoll(
         Authorization: `Bearer ${token}`,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ proposed_times: proposedTimes }),
+      body: JSON.stringify({ proposed_times: proposedTimes, timezone }),
     },
   );
   if (!res.ok) throw await res.json();

--- a/frontend/src/app/tables/[id]/sessions/page.tsx
+++ b/frontend/src/app/tables/[id]/sessions/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useState, useEffect } from "react";
 import { useParams } from "next/navigation";
 import DashboardLayout from "@/app/components/DashboardLayout";
@@ -17,6 +18,7 @@ import { M3FloatingInput } from "@/app/components/template/M3FloatingInput";
 import PageRefSelectorMD3 from "@/app/components/create_page/PageRefSelectorMD3";
 import { getPages } from "@/app/lib/pagesAPI";
 import { useUsers } from "@/app/lib/useUsers";
+import { formatInTimeZone, zonedTimeToUtc } from "date-fns-tz";
 import {
   CalendarDays,
   Trash2,
@@ -251,9 +253,25 @@ function PollModal({
 export default function TableSessionsPage() {
   const params = useParams();
   const tableId = Number(params?.id);
-  const { token } = useAuth();
+  const { token, user } = useAuth();
+  const userTz =
+    user?.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
   const { sessions, mutate } = useSessions(tableId);
   const { t } = useTranslation();
+
+  function renderTime(timeStr: string, tz: string) {
+    const utc = zonedTimeToUtc(timeStr, tz);
+    const original = formatInTimeZone(utc, tz, "yyyy-MM-dd HH:mm");
+    const userTime = formatInTimeZone(utc, userTz, "yyyy-MM-dd HH:mm");
+    return (
+      <span className="font-mono text-xs">
+        {original} ({tz}){" "}
+        <span className="ml-2">
+          {userTime} ({userTz})
+        </span>
+      </span>
+    );
+  }
 
   const [deleteId, setDeleteId] = useState<number | null>(null);
   const [deleting, setDeleting] = useState(false);
@@ -334,7 +352,7 @@ export default function TableSessionsPage() {
       token,
     );
     if (usePoll && proposed.length) {
-      await createSessionPoll(tableId, sess.id, proposed, token);
+      await createSessionPoll(tableId, sess.id, proposed, userTz, token);
       await refreshPoll(sess.id);
     }
     resetModal();
@@ -402,7 +420,7 @@ export default function TableSessionsPage() {
   }
   async function savePollModal() {
     if (!pollSession) return;
-    await createSessionPoll(tableId, pollSession, pollProposed, token);
+    await createSessionPoll(tableId, pollSession, pollProposed, userTz, token);
     await refreshPoll(pollSession);
     setPollSession(null);
     setPollProposed([]);
@@ -413,15 +431,24 @@ export default function TableSessionsPage() {
   // --- Sessions ---
   const now = new Date();
   const upcoming = sessions.filter(
-    (s: any) => !s.scheduled_time || new Date(s.scheduled_time) >= now,
+    (s: any) =>
+      !s.scheduled_time || zonedTimeToUtc(s.scheduled_time, s.timezone) >= now,
   );
   const past = sessions
-    .filter((s: any) => s.scheduled_time && new Date(s.scheduled_time) < now)
-    .sort((a, b) => new Date(b.scheduled_time) - new Date(a.scheduled_time));
+    .filter(
+      (s: any) =>
+        s.scheduled_time && zonedTimeToUtc(s.scheduled_time, s.timezone) < now,
+    )
+    .sort(
+      (a, b) =>
+        zonedTimeToUtc(b.scheduled_time, b.timezone).getTime() -
+        zonedTimeToUtc(a.scheduled_time, a.timezone).getTime(),
+    );
 
   // --- Card components ---
   function SessionCard({ s, pollData }: { s: any; pollData?: any }) {
-    const isPast = s.scheduled_time && new Date(s.scheduled_time) < now;
+    const isPast =
+      s.scheduled_time && zonedTimeToUtc(s.scheduled_time, s.timezone) < now;
     return (
       <div
         className={`
@@ -451,7 +478,7 @@ export default function TableSessionsPage() {
             <div className="text-xs text-[var(--foreground)]/80 flex items-center gap-1">
               <CalendarDays className="w-4 h-4" />
               {s.scheduled_time ? (
-                new Date(s.scheduled_time).toLocaleString()
+                renderTime(s.scheduled_time, s.timezone)
               ) : pollData ? (
                 <span className="font-semibold text-yellow-600">Voting!</span>
               ) : (
@@ -524,7 +551,7 @@ export default function TableSessionsPage() {
                   `}
                 >
                   <span className="font-bold text-xs">
-                    {new Date(opt.proposed_time).toLocaleString()}
+                    {renderTime(opt.proposed_time, opt.timezone)}
                   </span>
                   <div className="flex flex-wrap gap-2 mt-1">
                     {opt.votes.map((uid: number) => {

--- a/frontend/src/app/user_table/sessions/[id]/page.tsx
+++ b/frontend/src/app/user_table/sessions/[id]/page.tsx
@@ -7,12 +7,15 @@ import { getSessionPoll, voteSessionPoll } from "@/app/lib/sessionAPI";
 import { useAuth } from "@/app/components/auth/AuthProvider";
 import { useUsers } from "@/app/lib/useUsers";
 // import icons (Heroicons/Lucide etc)
-import { Sparkles, MapPin, CalendarClock, BookOpen, User } from "lucide-react";
+import { Sparkles, MapPin, CalendarClock, BookOpen } from "lucide-react";
+import { formatInTimeZone, zonedTimeToUtc } from "date-fns-tz";
 
 export default function UserTableSessionsPage() {
   const params = useParams();
   const tableId = Number(params?.id);
   const { token, user } = useAuth();
+  const userTz =
+    user?.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
   const { sessions } = useSessions(tableId, true);
   const { users } = useUsers();
   const [polls, setPolls] = useState({});
@@ -87,16 +90,31 @@ export default function UserTableSessionsPage() {
     await refreshPoll(sessionId);
     setLoadingVotes((prev) => ({ ...prev, [sessionId]: false }));
   }
-
   const now = new Date();
   const upcomingSessions = sessions.filter(
-    (s) => !s.scheduled_time || new Date(s.scheduled_time) >= now,
+    (s) =>
+      !s.scheduled_time || zonedTimeToUtc(s.scheduled_time, s.timezone) >= now,
   );
   const previousSessions = sessions.filter(
-    (s) => s.scheduled_time && new Date(s.scheduled_time) < now,
+    (s) =>
+      s.scheduled_time && zonedTimeToUtc(s.scheduled_time, s.timezone) < now,
   );
 
   // --- UI HELPERS ---
+
+  function renderTime(timeStr: string, tz: string) {
+    const utc = zonedTimeToUtc(timeStr, tz);
+    const original = formatInTimeZone(utc, tz, "yyyy-MM-dd HH:mm");
+    const userTime = formatInTimeZone(utc, userTz, "yyyy-MM-dd HH:mm");
+    return (
+      <span className="font-mono text-xs">
+        {original} ({tz}){" "}
+        <span className="ml-2">
+          {userTime} ({userTz})
+        </span>
+      </span>
+    );
+  }
 
   function renderPoll(s) {
     const poll = polls[s.id];
@@ -127,7 +145,7 @@ export default function UserTableSessionsPage() {
                 className="w-5 h-5 accent-[var(--primary)] rounded-md border-2"
               />
               <span className="font-mono text-xs">
-                {new Date(opt.proposed_time).toLocaleString()}
+                {renderTime(opt.proposed_time, opt.timezone)}
               </span>
               <div className="flex flex-wrap gap-2">
                 {opt.votes.map((uid) => {
@@ -191,7 +209,7 @@ export default function UserTableSessionsPage() {
               )}
               <CalendarClock size={16} className="ml-3 text-[var(--primary)]" />
               {s.scheduled_time ? (
-                new Date(s.scheduled_time).toLocaleString()
+                renderTime(s.scheduled_time, s.timezone)
               ) : (
                 <span className="italic opacity-50">Not scheduled</span>
               )}
@@ -219,7 +237,7 @@ export default function UserTableSessionsPage() {
             Game Sessions
           </h1>
           <div className="text-md text-[var(--foreground)]/70 ml-2">
-            Track your table's adventures, vote on the next gathering, and
+            Track your table&apos;s adventures, vote on the next gathering, and
             relive the tales of previous quests!
           </div>
         </div>


### PR DESCRIPTION
## Summary
- store timezone with session poll options and propagate it to sessions
- display original and user-adjusted times on session and poll cards
- expose timezone when creating polls via API

## Testing
- `pytest` *(fails: No module named 'requests')*
- `npx eslint src/app/lib/sessionAPI.ts src/app/tables/[id]/sessions/page.tsx src/app/user_table/sessions/[id]/page.tsx`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689b868724d48322a56fe55ca60e5b48