### PR TITLE
fix(frontend): align date-fns-tz usage with v3 API

### DIFF
--- a/frontend/src/app/tables/[id]/sessions/page.tsx
+++ b/frontend/src/app/tables/[id]/sessions/page.tsx
@@ -18,7 +18,7 @@ import { M3FloatingInput } from "@/app/components/template/M3FloatingInput";
 import PageRefSelectorMD3 from "@/app/components/create_page/PageRefSelectorMD3";
 import { getPages } from "@/app/lib/pagesAPI";
 import { useUsers } from "@/app/lib/useUsers";
-import { formatInTimeZone, zonedTimeToUtc } from "date-fns-tz";
+import { formatInTimeZone, fromZonedTime } from "date-fns-tz";
 import {
   CalendarDays,
   Trash2,
@@ -260,7 +260,7 @@ export default function TableSessionsPage() {
   const { t } = useTranslation();
 
   function renderTime(timeStr: string, tz: string) {
-    const utc = zonedTimeToUtc(timeStr, tz);
+    const utc = fromZonedTime(timeStr, tz);
     const original = formatInTimeZone(utc, tz, "yyyy-MM-dd HH:mm");
     const userTime = formatInTimeZone(utc, userTz, "yyyy-MM-dd HH:mm");
     return (
@@ -432,23 +432,23 @@ export default function TableSessionsPage() {
   const now = new Date();
   const upcoming = sessions.filter(
     (s: any) =>
-      !s.scheduled_time || zonedTimeToUtc(s.scheduled_time, s.timezone) >= now,
+      !s.scheduled_time || fromZonedTime(s.scheduled_time, s.timezone) >= now,
   );
   const past = sessions
     .filter(
       (s: any) =>
-        s.scheduled_time && zonedTimeToUtc(s.scheduled_time, s.timezone) < now,
+        s.scheduled_time && fromZonedTime(s.scheduled_time, s.timezone) < now,
     )
     .sort(
       (a, b) =>
-        zonedTimeToUtc(b.scheduled_time, b.timezone).getTime() -
-        zonedTimeToUtc(a.scheduled_time, a.timezone).getTime(),
+        fromZonedTime(b.scheduled_time, b.timezone).getTime() -
+        fromZonedTime(a.scheduled_time, a.timezone).getTime(),
     );
 
   // --- Card components ---
   function SessionCard({ s, pollData }: { s: any; pollData?: any }) {
     const isPast =
-      s.scheduled_time && zonedTimeToUtc(s.scheduled_time, s.timezone) < now;
+      s.scheduled_time && fromZonedTime(s.scheduled_time, s.timezone) < now;
     return (
       <div
         className={`

--- a/frontend/src/app/user_table/sessions/[id]/page.tsx
+++ b/frontend/src/app/user_table/sessions/[id]/page.tsx
@@ -8,7 +8,7 @@ import { useAuth } from "@/app/components/auth/AuthProvider";
 import { useUsers } from "@/app/lib/useUsers";
 // import icons (Heroicons/Lucide etc)
 import { Sparkles, MapPin, CalendarClock, BookOpen } from "lucide-react";
-import { formatInTimeZone, zonedTimeToUtc } from "date-fns-tz";
+import { formatInTimeZone, fromZonedTime } from "date-fns-tz";
 
 export default function UserTableSessionsPage() {
   const params = useParams();
@@ -93,17 +93,17 @@ export default function UserTableSessionsPage() {
   const now = new Date();
   const upcomingSessions = sessions.filter(
     (s) =>
-      !s.scheduled_time || zonedTimeToUtc(s.scheduled_time, s.timezone) >= now,
+      !s.scheduled_time || fromZonedTime(s.scheduled_time, s.timezone) >= now,
   );
   const previousSessions = sessions.filter(
     (s) =>
-      s.scheduled_time && zonedTimeToUtc(s.scheduled_time, s.timezone) < now,
+      s.scheduled_time && fromZonedTime(s.scheduled_time, s.timezone) < now,
   );
 
   // --- UI HELPERS ---
 
   function renderTime(timeStr: string, tz: string) {
-    const utc = zonedTimeToUtc(timeStr, tz);
+    const utc = fromZonedTime(timeStr, tz);
     const original = formatInTimeZone(utc, tz, "yyyy-MM-dd HH:mm");
     const userTime = formatInTimeZone(utc, userTz, "yyyy-MM-dd HH:mm");
     return (


### PR DESCRIPTION
## Summary
- replace `zonedTimeToUtc` with `fromZonedTime` in session pages
- keep time comparisons and formatting functional after date-fns-tz upgrade

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b8b5f439083228758a2c1a83b3572