### PR TITLE
fix: add session poll option timezone migration

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -17,11 +17,24 @@ async def init_db():
         await conn.run_sync(_migrate)
 
 
+def _migrate_sessionpolloption(conn, inspector, text):
+    """Ensure SessionPollOption has a timezone column."""
+    if "sessionpolloption" in inspector.get_table_names():
+        columns = [c["name"] for c in inspector.get_columns("sessionpolloption")]
+        if "timezone" not in columns:
+            conn.execute(
+                text(
+                    "ALTER TABLE sessionpolloption ADD COLUMN timezone TEXT DEFAULT 'UTC'"
+                )
+            )
+
+
 def _migrate(conn):
     """Simple migration to add new columns without dropping data."""
     from sqlalchemy import inspect, text
 
     inspector = inspect(conn)
+    _migrate_sessionpolloption(conn, inspector, text)
     columns = [c["name"] for c in inspector.get_columns("agent")]
     if "task" not in columns:
         conn.execute(text("ALTER TABLE agent ADD COLUMN task TEXT"))

--- a/backend/tests/test_sessionpolloption_migration.py
+++ b/backend/tests/test_sessionpolloption_migration.py
@@ -1,0 +1,21 @@
+import pytest
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy import inspect, text
+from app.database import _migrate_sessionpolloption
+
+
+@pytest.mark.anyio
+async def test_sessionpolloption_timezone_migration():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    async with engine.begin() as conn:
+        await conn.exec_driver_sql(
+            "CREATE TABLE sessionpolloption (id INTEGER PRIMARY KEY AUTOINCREMENT, poll_id INTEGER NOT NULL, proposed_time DATETIME NOT NULL)"
+        )
+        await conn.run_sync(lambda c: _migrate_sessionpolloption(c, inspect(c), text))
+        columns = await conn.run_sync(
+            lambda c: [
+                col["name"] for col in inspect(c).get_columns("sessionpolloption")
+            ]
+        )
+        assert "timezone" in columns
+    await engine.dispose()


### PR DESCRIPTION
## Summary
- add database migration to ensure session poll options include timezone column
- cover session poll option timezone migration in tests

## Testing
- `pytest backend/tests/test_sessionpolloption_migration.py`
- `pytest tests/test_sessionpolloption_migration.py tests/test_session_poll.py` *(fails: AssertionError: {"detail":"Not Found"})*

------
https://chatgpt.com/codex/tasks/task_e_689b9cceebcc8322ab661aebc839ad31