### PR TITLE
feat(frontend): add original timezone tooltip

### DIFF
--- a/frontend/src/app/user_table/sessions/[id]/page.tsx
+++ b/frontend/src/app/user_table/sessions/[id]/page.tsx
@@ -7,8 +7,19 @@ import { getSessionPoll, voteSessionPoll } from "@/app/lib/sessionAPI";
 import { useAuth } from "@/app/components/auth/AuthProvider";
 import { useUsers } from "@/app/lib/useUsers";
 // import icons (Heroicons/Lucide etc)
-import { Sparkles, MapPin, CalendarClock, BookOpen } from "lucide-react";
+import {
+  Sparkles,
+  MapPin,
+  CalendarClock,
+  BookOpen,
+  HelpCircle,
+} from "lucide-react";
 import { formatInTimeZone, fromZonedTime } from "date-fns-tz";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/tiptap-ui-primitive/tooltip";
 
 export default function UserTableSessionsPage() {
   const params = useParams();
@@ -107,11 +118,19 @@ export default function UserTableSessionsPage() {
     const original = formatInTimeZone(utc, tz, "yyyy-MM-dd HH:mm");
     const userTime = formatInTimeZone(utc, userTz, "yyyy-MM-dd HH:mm");
     return (
-      <span className="font-mono text-xs">
-        {original} ({tz}){" "}
-        <span className="ml-2">
-          {userTime} ({userTz})
-        </span>
+      <span className="font-mono text-xs flex items-center gap-1">
+        {userTime} ({userTz})
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <HelpCircle
+              size={14}
+              className="text-[var(--primary)] cursor-help"
+            />
+          </TooltipTrigger>
+          <TooltipContent>
+            Original timezone: {original} ({tz})
+          </TooltipContent>
+        </Tooltip>
       </span>
     );
   }


### PR DESCRIPTION
## Summary
- show session times in user's timezone
- display original timezone in tooltip

## Testing
- `npx prettier --write src/app/user_table/sessions/[id]/page.tsx`
- `npx eslint src/app/user_table/sessions/[id]/page.tsx` *(warning: Using `<img>` could result in slower LCP and higher bandwidth...)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ba479edd88322a63707362c08bb9d