### PR TITLE
fix: block voting on finalized session polls

### DIFF
--- a/backend/app/api/api_session.py
+++ b/backend/app/api/api_session.py
@@ -159,6 +159,8 @@ async def vote_poll_endpoint(
     poll = await get_poll(session, session_id)
     if not poll:
         raise HTTPException(status_code=404, detail="Poll not found")
+    if poll.final_option_id is not None:
+        raise HTTPException(status_code=400, detail="Poll already finalized")
     await cast_vote(session, poll, user.id, vote)
     return await poll_to_read(session, poll)
 
@@ -178,6 +180,8 @@ async def remove_vote_poll_endpoint(
     poll = await get_poll(session, session_id)
     if not poll:
         raise HTTPException(status_code=404, detail="Poll not found")
+    if poll.final_option_id is not None:
+        raise HTTPException(status_code=400, detail="Poll already finalized")
     await remove_vote(session, poll, user_id, option_id)
     return await poll_to_read(session, poll)
 

--- a/backend/tests/test_session_poll.py
+++ b/backend/tests/test_session_poll.py
@@ -239,3 +239,73 @@ async def test_remove_vote(async_client):
     assert resp.status_code == 200, resp.text
     poll = resp.json()
     assert poll["options"][0]["votes"] == []
+
+
+@pytest.mark.anyio
+async def test_vote_disallowed_after_finalize(async_client):
+    user = {
+        "nickname": "gm5",
+        "email": "gm5@example.com",
+        "password": "secret123",
+        "role": "world builder",
+        "image_url": "no image",
+    }
+    resp = await async_client.post("/user/", json=user)
+    assert resp.status_code == 200, resp.text
+    login = await async_client.post(
+        "/user/login", data={"username": user["email"], "password": user["password"]}
+    )
+    token = login.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    gw_payload = {"name": "World", "system": "dnd", "description": "", "logo": ""}
+    resp = await async_client.post("/gameworlds/", json=gw_payload, headers=headers)
+    world_id = resp.json()["id"]
+
+    resp = await async_client.post(
+        "/tables/",
+        json={"world_id": world_id, "name": "Party", "member_ids": []},
+        headers=headers,
+    )
+    table_id = resp.json()["id"]
+
+    sess_payload = {
+        "name": "Session",
+        "scheduled_time": None,
+        "summary": "",
+        "location": "",
+        "table_id": table_id,
+        "timezone": "UTC",
+        "attendee_ids": [],
+        "page_ids": [],
+    }
+    resp = await async_client.post(
+        f"/tables/{table_id}/sessions", json=sess_payload, headers=headers
+    )
+    session_id = resp.json()["id"]
+
+    times = [
+        datetime.now(timezone.utc).isoformat(),
+        (datetime.now(timezone.utc) + timedelta(days=1)).isoformat(),
+    ]
+    resp = await async_client.post(
+        f"/tables/{table_id}/sessions/{session_id}/poll",
+        json={"proposed_times": times, "timezone": "UTC"},
+        headers=headers,
+    )
+    poll = resp.json()
+    option_id = poll["options"][0]["id"]
+
+    resp = await async_client.post(
+        f"/tables/{table_id}/sessions/{session_id}/poll/finalize",
+        json={"option_id": option_id},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    resp = await async_client.post(
+        f"/tables/{table_id}/sessions/{session_id}/poll/vote",
+        json={"option_ids": [option_id]},
+        headers=headers,
+    )
+    assert resp.status_code == 400, resp.text

--- a/frontend/src/app/user_table/sessions/[id]/page.tsx
+++ b/frontend/src/app/user_table/sessions/[id]/page.tsx
@@ -138,6 +138,7 @@ export default function UserTableSessionsPage() {
   function renderPoll(s) {
     const poll = polls[s.id];
     if (!poll) return null;
+    const votingClosed = poll.final_option_id !== null;
 
     return (
       <div className="mt-3 bg-yellow-50/90 rounded-xl border-2 border-yellow-200 p-3 shadow-inner">
@@ -147,22 +148,28 @@ export default function UserTableSessionsPage() {
         </div>
         <div className="flex flex-col gap-2 mb-2">
           {poll.options.map((opt) => (
-            <label
+            <div
               key={opt.id}
-              className={`flex items-center gap-3 rounded-xl px-3 py-2 border cursor-pointer 
+              className={`flex items-center gap-3 rounded-xl px-3 py-2 border
               ${
-                selections[s.id]?.includes(opt.id)
-                  ? "border-[var(--primary)] bg-[var(--primary)]/10"
-                  : "border-yellow-100 hover:border-yellow-300"
+                votingClosed
+                  ? poll.final_option_id === opt.id
+                    ? "border-[var(--primary)] bg-[var(--primary)]/10"
+                    : "border-yellow-100"
+                  : selections[s.id]?.includes(opt.id)
+                    ? "border-[var(--primary)] bg-[var(--primary)]/10"
+                    : "border-yellow-100 hover:border-yellow-300"
               }
-              transition`}
+              ${votingClosed ? "" : "cursor-pointer"} transition`}
             >
-              <input
-                type="checkbox"
-                checked={selections[s.id]?.includes(opt.id) || false}
-                onChange={() => toggleOption(s.id, opt.id)}
-                className="w-5 h-5 accent-[var(--primary)] rounded-md border-2"
-              />
+              {!votingClosed && (
+                <input
+                  type="checkbox"
+                  checked={selections[s.id]?.includes(opt.id) || false}
+                  onChange={() => toggleOption(s.id, opt.id)}
+                  className="w-5 h-5 accent-[var(--primary)] rounded-md border-2"
+                />
+              )}
               <span className="font-mono text-xs">
                 {renderTime(opt.proposed_time, opt.timezone)}
               </span>
@@ -187,19 +194,21 @@ export default function UserTableSessionsPage() {
               <span className="text-xs text-yellow-600 ml-2">
                 {opt.votes.length} vote{opt.votes.length === 1 ? "" : "s"}
               </span>
-            </label>
+            </div>
           ))}
         </div>
-        <button
-          className={`mt-2 px-4 py-2 rounded-lg bg-[var(--primary)] text-white font-bold shadow 
-            hover:scale-105 transition 
+        {!votingClosed && (
+          <button
+            className={`mt-2 px-4 py-2 rounded-lg bg-[var(--primary)] text-white font-bold shadow
+            hover:scale-105 transition
             ${loadingVotes[s.id] ? "opacity-60 cursor-not-allowed" : ""}
           `}
-          disabled={loadingVotes[s.id]}
-          onClick={() => submitVote(s.id)}
-        >
-          {loadingVotes[s.id] ? "Saving..." : "Cast My Vote"}
-        </button>
+            disabled={loadingVotes[s.id]}
+            onClick={() => submitVote(s.id)}
+          >
+            {loadingVotes[s.id] ? "Saving..." : "Cast My Vote"}
+          </button>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- prevent voting or removing votes after a session poll is finalized
- hide voting controls on the user session page when a final date is chosen
- add regression test for voting after poll finalization

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'bs4')*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689ba7fb7ca88322b265f72cc4a1428d