### PR TITLE
feat(frontend): add virtual table sidebar link

### DIFF
--- a/frontend/src/app/components/template/Sidebar.tsx
+++ b/frontend/src/app/components/template/Sidebar.tsx
@@ -11,7 +11,6 @@ import NotificationsIcon from "@mui/icons-material/NotificationsRounded";
 import EditIcon from "@mui/icons-material/EditRounded";
 import {
   BookOpenText,
-  FileText,
   PenLine,
   Sparkles,
   ScrollText,
@@ -21,6 +20,7 @@ import {
   Settings,
   StickyNote,
   Users,
+  Dices,
 } from "lucide-react";
 import { getNews, markNewsSeen } from "../../lib/newsAPI";
 
@@ -39,6 +39,14 @@ const MENU_GROUPS = [
         label: "Notes",
         icon: <StickyNote className="w-5 h-5" />,
         href: "/user_notes",
+      },
+      {
+        key: "virtual_table",
+        label: "Virtual Table",
+        icon: <Dices className="w-5 h-5" />,
+        href: "https://foundry.shrecknet.club/",
+        target: "_blank",
+        rel: "noopener noreferrer",
       },
     ],
   },
@@ -339,6 +347,8 @@ export default function Sidebar({
                     <Link
                       key={item.key}
                       href={item.href}
+                      target={item.target}
+                      rel={item.rel}
                       className={`
                         flex items-center gap-3 px-4 py-3 rounded-2xl font-semibold
                         text-base group transition


### PR DESCRIPTION
## Summary
- add Virtual Table link under Game Sessions that opens Foundry in a new tab
- extend sidebar links to support new-tab targets

## Testing
- `npm run lint` *(fails: unexpected any, unused vars, etc.)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689c5af9ccf48322b62f2603731cdc7c